### PR TITLE
Instance & map editing: flags, light, scripts, scenery, critter, map ops + undo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ cmake-build-debug/
 
 .DS_Store
 
+.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,20 @@ if (mimeData->hasFormat(ui::mime::GECK_OBJECT)) { ... }
 2. Use modern `connect()` syntax with lambdas or method pointers
 3. Emit signals with `Q_EMIT` for clarity
 
+## Git & PR Workflow
+
+On feature branches, follow this workflow:
+
+1. **Clean commit messages.** Describe the change in plain language. Do not include internal
+   identifiers such as `WP-9`, `F11`, or other plan/task codes in commit messages or PR titles.
+2. **Open a PR** for the branch once the work is ready for review.
+3. **Wait for CI to finish.** Use `gh pr checks <num> --watch` (or poll `gh run list`) until all
+   workflow runs complete.
+4. **Read and address review feedback.** After the build finishes, read any code-review comments
+   (Copilot, human reviewers) and SonarCloud/SonarQube warnings on the PR, then fix the valid ones
+   and push the updates. Keep any explanatory comments you add relevant and brief — do not
+   overcomment.
+
 ## Development Setup
 
 ### Essential Setup
@@ -243,5 +257,5 @@ if (mimeData->hasFormat(ui::mime::GECK_OBJECT)) { ... }
 
 ---
 
-*Last updated: 2026-03-10*
+*Last updated: 2026-06-10*
 *This file should be updated whenever significant architectural decisions or fixes are made.*

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,16 +1,220 @@
 # Improvement Backlog
 
-- Refactor build system to split `src/CMakeLists.txt` into composable libraries (core logic, UI, widgets/pro, vault). Publish include dirs per target and remove `../../` include patterns. Downshift `cmake_minimum_required` to 3.24-ish and extract third-party FetchContent setup into `cmake/dependencies.cmake` so both CI and IDE users get consistent toolchains.
+## Test-suite audit & refactor plan
 
-- Replace global singletons (`ResourceManager`, `Settings`, `EventBus`) with injectable services. Introduce a lightweight `ResourceContext` that loaders/widgets receive explicitly and a dedicated VFS service. This reduces coupling, simplifies tests, and enables headless or mocked runs.
+Audit of `tests/` (22 source files, ~117 `TEST_CASE`s across `general_tests`,
+`performance_tests`, `qt_tests`). The format round-trip coverage (PRO all-types,
+MAP all-object-types + engine-framing regressions) is genuinely strong; the gaps
+are in (a) the other binary formats, (b) editor/coordinate invariants, and (c)
+duplicated scaffolding plus a fragile fixture-path setup. Items are ordered by
+value/effort.
 
-- Break up `src/ui/dialogs/ProEditorDialog.cpp` (4k+ lines) into per-tab widgets and presenter-style controllers. Move shared data mapping into reusable helpers so UI code becomes maintainable and testable.
+### P0 — Shared test-support header (highest leverage, unblocks everything below)
 
-- Tame the macOS-specific `scripts/post-build-test.sh`: guard execution by platform, disable `GECK_AUTO_TEST` by default, and surface a CLI flag so Linux/CI builds don't fail. Consider replacing hard-coded paths with configurable environment variables.
+Create `tests/support/` with a small, header-only support library linked into all
+three executables. The two round-trip suites already re-derive the same helpers;
+new format tests would copy them a third and fourth time.
 
-- Reorganize the catch-all `util/` directory. Group UI-specific helpers under `ui/`, resource utilities under `resources/`, and platform helpers separately to improve discoverability and reduce accidental dependencies.
+- **`tests/support/Fixtures.h`** — one function `geck::test::dataDir()` /
+  `dataPath(name)` that resolves fixtures from a compile-time
+  `GECK_TEST_DATA_DIR` (see P1). Replaces the bare `"data/test.gam"` string
+  literal repeated in `test_reading_gam.cpp`, `test_reading_msg.cpp`,
+  `test_reading_pro_drug.cpp`, `test_pro_roundtrip.cpp`, and the `"data/…"` calls
+  inside `test_reader_performance.cpp`.
+- **`tests/support/TempFile.h`** — RAII `TempFile{stem, ".pro"}` that picks a
+  unique path under `temp_directory_path()`, removes any stale copy on
+  construction, and unlinks on destruction. This collapses the near-identical
+  `makeTempProPath()` (test_pro_roundtrip.cpp:24) and `tempMapPath()`
+  (test_map_roundtrip.cpp:44) plus the hand-written `std::error_code ec;
+  std::filesystem::remove(...)` cleanup that appears at the end of **every**
+  round-trip `TEST_CASE` (10+ copies). Also folds in `readAllBytes()`
+  (test_pro_roundtrip.cpp:15) for byte-for-byte comparisons.
+- **`tests/support/ProStubProvider.h`** — promote `StubProvider` from
+  test_map_roundtrip.cpp (the in-memory `pid -> Pro` map with `addItem` /
+  `addScenery` / `set` / `load`) and the free `pidOf(OBJECT_TYPE, index)` helper.
+  These are exactly the provider callbacks `MapReader`/`MapWriter` take, so any
+  future MAP or object-query test needs them. Keep `StubProvider` returning raw
+  subtype-only `Pro`s (the only thing (de)serialization dereferences).
+- **`tests/support/MapObjectBuilder.h`** — promote `fillBase()` / `checkBase()`
+  (test_map_roundtrip.cpp:54/76) and the local `add(proPid, seed)` lambda into a
+  reusable builder/asserter over the 22-field base block. This is the single
+  biggest duplicated block and is needed verbatim by the MAP fixture test (P2)
+  and any editor/selection test that fabricates objects.
+- **`tests/support/ProBuilder.h`** — the `roundTrip(Pro, path)` helper
+  (test_pro_roundtrip.cpp:183) plus thin constructors that set a PID with the
+  correct type nibble (`(type<<24)|index`), currently re-spelled in every PRO
+  `TEST_CASE`.
 
-- Add coverage-focused tests for loaders and resource caching once dependency injection is in place, ensuring core logic is verifiable without spinning up the Qt event loop.
+Wire it up in `tests/CMakeLists.txt` as
+`add_library(test_support INTERFACE)` with
+`target_include_directories(test_support INTERFACE ${CMAKE_SOURCE_DIR}/tests)`,
+and link it into `general_tests`, `performance_tests`, `qt_tests`. Migrate the two
+existing round-trip suites onto it in the same change to prove the API.
+
+### P1 — Make fixture loading robust (fixes the ctest-only gotcha)
+
+**Problem:** `general_tests` / `performance_tests` load fixtures via bare relative
+paths (`reader.openFile("data/test.gam")`). These only resolve because
+`catch_discover_tests` runs each test with its working directory defaulting to
+`$<TARGET_FILE_DIR>` (the build dir, where the post-build `copy_directory` rule
+drops `data/`). Running the executable directly from any other cwd
+(`./build/general_tests`, a debugger, an IDE) silently fails to find fixtures.
+Only `qt_tests` does this correctly, via the `GECK_TEST_DATA_DIR` compile
+definition (tests/CMakeLists.txt:60-62).
+
+**Fix:**
+1. Add `target_compile_definitions(general_tests PRIVATE
+   GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data")` (and the same for
+   `performance_tests`). Point fixtures at the source tree so no copy step is
+   needed for *reading*.
+2. Route all fixture access through `test::dataPath()` (P0). Delete the bare
+   `"data/…"` literals.
+3. Once fixtures resolve by absolute path, the per-target
+   `copy_directory tests/data` POST_BUILD commands (tests/CMakeLists.txt:108-118)
+   become dead weight — drop them (keep only what `qt_tests` still needs for the
+   `resources/` copy).
+4. Add a `set_tests_properties(... PROPERTIES WORKING_DIRECTORY ...)` is then
+   unnecessary; document in `AGENTS.md` that fixtures are absolute and tests are
+   cwd-independent.
+
+### P2 — Highest-value missing tests (format round-trips & editor invariants)
+
+Format fidelity is the project's core promise; these are the untested formats and
+the load-bearing editor math.
+
+**Formats / readers / writers (priority order):**
+
+1. **FRM round-trip + correctness** — `FrmReader` is exercised only for *timing*
+   in `test_reader_performance.cpp` (in-memory buffer, no assertions on decoded
+   frames). No correctness test exists, and there is **no `FrmWriter`** — confirm
+   whether FRM is read-only; if so, add a read-correctness test against a small
+   real `.frm` fixture (frame count, dimensions, per-direction offsets, pixel-0
+   sanity). `new tests/general/test_reading_frm.cpp`.
+2. **DAT reader correctness in `general_tests`** — `DatReader` is only touched by
+   `test_dat_archive.cpp` in the **qt** suite (because it pulls the resource
+   stack), exercising the vfspp path. Add a pure-`vault` test for the raw
+   `DatReader` (entry table parse, compressed vs stored entries, file extraction
+   bytes) using the existing `tests/data/f2_res.dat` fixture. Belongs in
+   `general_tests` (no Qt needed). `new tests/general/test_reading_dat.cpp`.
+3. **LST reader** — `LstReader` (used everywhere for proto/script list lookups)
+   has zero coverage. Add a trivial fixture test: line parsing, comment/whitespace
+   trimming, 1-based vs 0-based indexing, CRLF handling.
+   `new tests/general/test_reading_lst.cpp`.
+4. **PAL reader** — `PalReader` untested. Small, deterministic: 256-entry palette,
+   6-bit→8-bit channel scaling, the cycling/animation indices. Pairs well with a
+   `ColorUtils` test. `new tests/general/test_reading_pal.cpp`.
+5. **MAP read from a real fixture** — the MAP round-trip is fully synthetic (no
+   `.map` on disk). Add one small real `.map` fixture and assert header +
+   representative objects/tiles parse, to catch reader assumptions the synthetic
+   path can't (real elevation flags, real script sections, tile blocks).
+   Reuses the P0 `StubProvider`. Extend `test_map_roundtrip.cpp` or
+   `new tests/general/test_reading_map.cpp`.
+6. **MSG / GAM negative + edge cases** — current tests assert a few happy-path
+   lookups. Add: missing message id, the documented unclosed-`}` recovery
+   (test_reading_msg.cpp has a `FIXME` for messages #1382/#32020 — turn it into a
+   real expectation or an xfail), empty file, duplicate ids.
+
+**Editor / selection / util invariants (priority order):**
+
+7. **`Coordinates.h` round-trips & clamping** — `HexPosition` (0–39999),
+   `TileIndex` (0–9999), and the world/screen/hex conversions are the project's
+   most safety-critical math (the CLAUDE.md "never validate hex against
+   TILES_PER_ELEVATION" rule lives or dies here). Test `isValid()` boundaries,
+   `operator+/-` clamping at the 39999/9999 edges, and world→hex→world stability.
+   `new tests/general/test_coordinates.cpp`.
+8. **`HexagonGrid` invariants** — only 2 `TEST_CASE`s today. Add:
+   `positionForCoordinates`↔`coordinatesForPosition` round-trip over the whole
+   grid, `containsPosition` boundary, `tileIndexForPosition` mapping
+   (200×200 hex ↔ 100×100 tile), and `rectangleBorderPositions` for a known rect.
+9. **`UndoStack`** — pure, deterministic, zero deps, currently untested. Test
+   push/undo/redo ordering, redo-stack invalidation on new push, the
+   `_maxCommands` eviction (oldest dropped), `lastUndo/RedoLabel`, and the
+   reject-on-missing-undo/redo guard (UndoStack.h:26). High value because every
+   instance-edit feature in this very PLAN routes through it.
+10. **`object_query` (ObjectQueries.h)** — `blocksMovement` /
+    `isWallBlocker` / `isShootThroughWallBlocker` read PRO flags and gate
+    movement/rendering. Testable with the P0 `StubProvider` supplying flag bits;
+    no Qt needed (but needs `GameResources`, so likely a `qt_tests` resident).
+11. **`SpatialIndex` / `TileSpatialIndex`** — query-correctness (point/area/radius
+    membership, no duplicates across cells, update/remove consistency). Pure
+    geometry over SFML rects; belongs in `general_tests`.
+
+### P3 — Structure & categorization cleanup
+
+The 3-executable split (general = pure C++ logic, performance = Catch2 benchmarks,
+qt = needs `gecko::app` + `Qt6::Test`) is sound and the boundary is mostly clean.
+Issues:
+
+- **Naming is inconsistent.** Two conventions coexist: `test_reading_<fmt>.cpp`
+  (gam/msg/pro_drug) vs `test_<fmt>_roundtrip.cpp` (pro/map) vs
+  `test_<subject>.cpp` (everything else). Pick one. Recommend
+  `test_<subject>.cpp` for unit/logic and reserve `_roundtrip` as a meaningful
+  suffix; rename `test_reading_gam/msg/pro_drug` → `test_gam/test_msg/test_pro`
+  (and fold `test_reading_pro_drug` into the PRO suite, since `test_pro_roundtrip`
+  already owns the drug fixture). This also de-confuses "reading" tests that
+  actually only read vs the round-trip ones.
+- **`test_reading_pro_drug.cpp` is redundant.** Its single happy-path drug parse
+  is a strict subset of `test_pro_roundtrip.cpp`'s Level-1 case (same fixture).
+  Merge and delete.
+- **No tag-based categorization.** Catch2 tags exist (`[map]`, `[pro]`,
+  `[selection_state]`, …) but `ctest` can't filter by them (AGENTS/CLAUDE both
+  note "no ctest label registration"). Low priority, but `catch_discover_tests`
+  supports `TEST_PREFIX`/`PROPERTIES LABELS` — consider emitting one ctest label
+  per top-level area so `ctest -L format` works.
+- **`test_selection_system.cpp` is a 1631-line, 24-`TEST_CASE` monolith** (a third
+  of all test LOC). It mixes `SelectionState`, tile/hex coordinate conversions,
+  selection-mode enums, and "original" position-conversion cases. Split into
+  `test_selection_state.cpp`, `test_tile_hex_conversion.cpp` (overlaps
+  `test_tile_utils.cpp` — consolidate), and fold the coordinate cases into the new
+  `test_coordinates.cpp` (P2#7). Several of its coordinate `SECTION`s duplicate
+  `test_tile_utils.cpp` and `test_selection_system.cpp` itself.
+- **Misplacement check:** `test_data_path_resolution.cpp` and
+  `test_game_data_path_resolver.cpp` are near-siblings split across qt/general by
+  whether they touch `DataFileSystem`. That's defensible, but verify the general
+  one doesn't transitively need Qt; if it links cleanly it's correctly placed.
+
+### P4 — Other duplication to retire (after P0 lands)
+
+- The **writer-then-reader block** `{ Writer w; w.openFile(p); REQUIRE(w.write(x)); }`
+  immediately followed by `Reader r; auto back = r.openFile(p);` appears in every
+  round-trip case in both PRO and MAP suites. The P0 `roundTrip()` /
+  `MapRoundTrip()` helpers cover PRO and inline MAP; add a `mapRoundTrip(MapFile,
+  StubProvider&)` to fully retire it.
+- The **`pidOf` / type-nibble PID construction**
+  (`(static_cast<uint32_t>(type) << 24) | index`) is hand-inlined in ~8 places
+  across both suites with slightly different casts — centralize in P0.
+- **Per-test temp-path + `std::error_code ec; remove(...)` cleanup** — fully
+  removed by `TempFile` RAII (P0).
+
+### Suggested sequencing
+
+1. **P0 + P1 together** (shared support header + robust fixtures; migrate the two
+   existing round-trip suites onto them as the proof). Net LOC should *drop*.
+2. **P2 formats** (FRM, DAT-in-general, LST, PAL, real-MAP fixture) — each is a
+   small file that reuses P0.
+3. **P2 invariants** (Coordinates, HexagonGrid, UndoStack first — pure & zero-dep;
+   then object_query, SpatialIndex).
+4. **P3 restructure** (renames, split the selection monolith, merge the redundant
+   drug test) — purely mechanical once P0 helpers exist.
+
+## Architecture backlog (remaining)
+
+- **Replace the `Settings` singleton with an injected service.** `ResourceManager` and
+  `EventBus` are already gone (resource access is the injected `GameResources` facade), but
+  `Settings::getInstance()` remains a global. Introduce a dedicated VFS service alongside it
+  so loaders/widgets receive dependencies explicitly — simplifies tests and enables
+  headless/mocked runs.
+- **Reorganize the catch-all `src/util/` directory** (still ~40 mixed files spanning UI
+  helpers, resource utilities and platform code). Group UI-specific helpers under `ui/`,
+  resource utilities under `resources/`, and platform helpers separately to improve
+  discoverability and reduce accidental dependencies.
+- **Loader/resource-caching tests** — the DI precondition is now met (`gecko_resource` and
+  `gecko_core` are Qt-free, headless-linkable), but no dedicated loader/cache tests exist
+  yet. Tracked under P2 of the test-suite plan above.
+
+*(Done since this backlog was first written: the four-library CMake split with per-target
+includes + `cmake/dependencies.cmake`; the `ProEditorDialog` breakup into `ui/widgets/pro/`
+— now 367 lines; and removal of the macOS `post-build-test.sh`.)*
 
 ## Known tool-mode (EditorMode) UI gaps
 
@@ -36,224 +240,362 @@ UI affordances, not regressions:
 
 ---
 
-## Engine (fallout2-ce) MAP compatibility
+## Done — engine MAP compatibility & instance/map editing
 
-Audited our `.map` read/write against the in-engine mapper (`map.cc`, `object.cc`,
-`proto.cc`, `scripts.cc`, `src/mapper/`). The **format incompatibilities are fixed**
-(`MapReader.cpp`, `MapWriter.cpp`, `Map.h`; regression tests #89/#90 in
-`test_map_roundtrip.cpp`):
+**MAP format compatibility (fixed; regression tests #89/#90 in `test_map_roundtrip.cpp`):**
+object section is always 3 elevations (`objectSaveAll`/`objectLoadAll` framing), tiles keyed
+by true elevation gated on the per-elevation flag bit, and MISC exit-grid trailing data only
+for exit-grid PIDs (ids 16–23). *Intentional non-goal:* we deliberately do not recompute /
+auto-prune the per-elevation enable flags at save time (the engine does in `_map_save_file`) —
+our output is always internally consistent and engine-loadable, and pruning risks silently
+dropping an elevation the user wants. Revisit only if exact byte-parity with engine-saved maps
+becomes a requirement.
 
-- **Object section is always 3 elevations.** The engine's `objectSaveAll` /
-  `objectLoadAll` unconditionally loop `0..ELEVATION_COUNT` (=3). We now read/write
-  exactly three per-elevation count blocks regardless of enabled elevations. (This was
-  the critical bug: single/two-elevation maps — most F2 interiors — desynced on read and
-  would not load back into the engine.)
-- **Tiles keyed by true elevation.** Each elevation's tile block is gated on its flag bit
-  (`Map::elevationIsPresent`, `0x2 << elev`; engine `_map_data_elev_flags = {2,4,8}`,
-  `_square_load` / `_map_save_file`) and stored under its real elevation index.
-- **MISC exit-grid trailing data only for exit-grid PIDs** (MISC ids 16–23, engine
-  `isExitGridPid` = `0x5000010..0x5000017`, via `MapObject::isExitGridMarker()`). Ordinary
-  MISC objects no longer emit 16 stray bytes.
+**Instance & map editing (F10–F17 implemented; 98 tests pass):** object flags
+(`ObjectFlagsDialog`), light (`LightPropertiesDialog`), scenery destination
+(`SceneryDestinationDialog`), door/container locked-jammed (`InstancePropertiesDialog`, routed
+to the correct per-type field — doors `walkthrough`/openFlags, containers `unknown11`/data.flags),
+critter combat + working inventory add/remove/quantity (`CritterPropertiesDialog`), object
+script attach (`ScriptSelectorDialog`), spatial scripts (`SpatialScriptDialog`), and map ops
+(`MapInfoPanel` clear/copy elevation). Instance edits route through a shared `registerInstanceEdit`
+undo command; built-tile packing, SID encoding and script-record construction are centralized
+(`util/BuiltTile.h`, `MapScript` helpers/factories); `MapObject::cloneDeep` supports copy/stamp.
 
-**Intentional non-goal — save-time flag recompute.** The engine recomputes per-elevation
-enable flags at save (`_map_save_file` lines 1389–1424), auto-pruning elevations that are
-all-empty with no savable objects. We deliberately **do not** do this: our output is always
-internally consistent and engine-loadable (tile blocks match `header.flags`, object blocks
-are always three), and auto-pruning risks silently dropping an elevation the user intends to
-keep. Revisit only if exact byte-parity with engine-saved maps becomes a requirement.
+## Known limitations & follow-ups
+
+1. **Undo is partial.** Single-object instance edits (flags, light, critter, destination,
+   locked/jammed) are undoable. **Inventory edits, script attach/detach, spatial-script
+   creation, and map-wide ops (clear/copy elevation) are direct model mutations without undo**
+   — they live in panels holding a raw `Map*`, like the pre-existing elevation add/remove.
+   Routing them through `ObjectCommandController` (a generic `cloneDeep`-based vector-swap
+   command for inventory/clear/copy + a script-edit command, via the existing signal-up
+   pattern) is the main follow-up; also add a cascading script-delete on object deletion.
+2. **Exit grids are rectangle-only** — detailed below.
+3. **AI packet / script program are raw values** (engine packet numbers / scripts.lst names),
+   not friendly labels — no invented label tables, per the engine-fidelity rule. Real labels
+   need `data/ai.txt` parsing (AI) or the scripts.lst trailing comment (script "description" —
+   see the SSL-editing section; the `.int` has no description, Q below).
+4. **Newly created scripts get `local_var_count=0` / `offset=-1`** — exactly what the engine's
+   `scriptAdd` writes; locals are allocated at runtime from the `.int`. The editor does not
+   parse `.int` headers, and the local-var *count* lives in `scripts.lst`, not the binary.
+5. **F11 spatial placement is dialog-driven** (enter tile/elevation/radius), not click-to-place
+   with a live hex marker, radius overlay, and a new `EditorMode`. Existing spatial scripts also
+   aren't visualized on the map or editable/deletable through the UI yet.
+6. **F16 per-instance kill-type and custom name are out of scope** — not exposed in the engine
+   mapper and would require new serialized `MapObject` fields.
+7. **Script attach reassigns the object OID** (`unknown0`) to a fresh unique id (matching the
+   engine's `objectSetScript`); existing cross-references to the old OID aren't audited/rewritten.
+8. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
+9. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
+   recompute, multi-hex occupancy overlay, or live light-radius overlay beyond the rebuild.
+
+### Exit-grid shapes (rectangle-only) — limitation #2 in detail
+
+**Current behaviour:** the reachable exit-grid creation path
+(`ExitGridPlacementManager::selectExitGridsInArea`) fills a **rectangular** drag selection — it
+collects every hex whose footprint intersects the rectangle and makes an exit-grid object on
+each, so only axis-aligned rectangular exit-grid regions can be authored.
+
+**Engine reality (investigated):** exit grids are **independent per-hex MISC objects**
+(pid 16–23), each carrying its own exit destination; there is **no rectangle, perimeter, or
+"interior texture" concept** in the format — the player triggers the transition by stepping on
+any exit-grid hex. The fallout2-ce mapper's **"Mark Exit-Grids"** mode toggles a marker on each
+**individually clicked hex** (`mapper.cc`: `markExitGridMode` → `mapper_mark_exit_grid()` on each
+left-click, mapper.cc:1325), and the legacy `reference/F2_Mapper_Dims-master/Mapper` works the
+same way. Because the playable map area is an iso diamond, real exit grids commonly run
+**diagonally** along the screen edges — the "triangular"/diagonal shapes a rectangle fill cannot
+represent.
+
+**Fix:** drop the rectangle-fill assumption and support arbitrary-shape placement. We already
+have per-hex placement (`ExitGridPlacementManager::placeExitGridAtPosition`), but it's gated
+behind `EditorMode::PlaceExitGrid`, which has **no UI trigger** (see the EditorMode gap above) —
+wiring that one button gives engine-equivalent per-hex marking. Optionally add line/freehand
+placement for fast diagonal runs. There is no perimeter/interior distinction to preserve: every
+exit-grid hex is a full, independent exit-grid object.
 
 ---
 
-## Missing in-engine-mapper features (instance & map editing)
+## SSL Script Editing Integration
 
-> **Status (implemented):** F10–F17 below are now implemented and build cleanly
-> (96 base tests + the 2 MAP-compat regression tests pass). Summary:
-> - **F12 flags** — `ObjectFlagsDialog`, undoable via `registerInstanceEdit`.
-> - **F13 light** — `LightPropertiesDialog`, undoable.
-> - **F14 critter** — `CritterPropertiesDialog` (AI packet numeric, team, HP/rad/poison),
->   undoable; inventory Add/Remove/quantity now mutate the model (persist on save).
-> - **F15 scenery destination** — `SceneryDestinationDialog` (stairs/ladder built-tile,
->   elevator type/level), undoable.
-> - **F16 interaction** — `InstancePropertiesDialog` locked/jammed routed to the correct
->   per-type field (doors → `walkthrough`/openFlags, containers → `unknown11`/data.flags),
->   undoable.
-> - **F17 map ops** — `MapInfoPanel` "Map Operations": Clear Elevation Objects, Copy
->   Elevation (tiles + deep-cloned objects via `MapObject::cloneDeep`).
-> - **F10 script attach** — `ScriptSelectorDialog` from scripts.lst; creates a `MapScript`
->   with engine-correct linkage (per-type SID, fresh object OID, program index,
->   `local_var_count=0`/`offset=-1` exactly as `scriptAdd`).
-> - **F11 spatial script** — `SpatialScriptDialog` from `MapInfoPanel` creates a spatial
->   `MapScript` (built-tile + radius).
->
-> **Known limitations (follow-ups):**
-> - **Undo:** instance edits (F12/13/14-critter/15/16) are undoable; **inventory edits,
->   script attach/detach, spatial scripts, and map-wide ops are direct mutations without
->   undo** (matching `MapInfoPanel`'s existing elevation add/remove). Routing these through
->   `ObjectCommandController` is the main follow-up.
-> - **AI packet / script program** are entered as raw engine numbers / scripts.lst names
->   (no invented label tables, per the engine-fidelity rule). Local variables for newly
->   attached scripts are left to the engine at runtime (as the mapper's own `scriptAdd` does).
-> - **F11** is dialog-driven (enter tile/elevation/radius) rather than click-to-place with a
->   live hex marker + new `EditorMode`; that interactive flow is the remaining enhancement.
-> - **F16 deferred extensions** (per-instance kill-type / custom name) remain out of scope —
->   they need new serialized fields and are not in the engine mapper.
+### Goal
+Let users view and edit the Fallout 2 SSL script behind a `scripts.lst` entry from inside Gecko, instead of alt-tabbing to an external toolchain. This connects to our existing model: `scripts.lst` is a flat name list whose line index is the *program index* stored in the map header's `script_id` and in each `MapScript.script_id` (see `MapInfoPanel.cpp:397-403`, `ScriptSelectorDialog`, `SpatialScriptDialog`). Today Gecko only *references* scripts by index/name — it cannot open the source. The `.ssl` source compiles to `.int` bytecode (what the engine actually loads), which lives under `scripts/` alongside `scripts.lst`.
 
-These are the editor capabilities the fallout2-ce in-engine mapper has that Gecko lacks.
-**Key finding: nearly all of the underlying data already round-trips through our `.map`
-format** — `MapObject` already carries `flags`, `light_radius`/`light_intensity`,
-`map_scripts_pid`/`script_id`, the critter block (`ai_packet`, `group_id`, `current_hp`…),
-`inventory`, and the scenery fields (`elevhex`, `map`, `elevtype`, `elevlevel`,
-`walkthrough`), and `MapScript` already carries `spatial_radius`/`script_oid`. So these are
-predominantly **UI-only features with no format change** (the two exceptions are called out
-explicitly under F16). Everything must route edits through `ObjectCommandController` for
-undo/redo.
+### The three external tools
 
-### Shared infrastructure (build first)
+| Tool | Purpose | Lang | License | Cross-platform | Ships binaries |
+|------|---------|------|---------|----------------|----------------|
+| **sslc** (sfall-team) | `.ssl` → `.int` compiler | C | **No LICENSE file** (`license: null` on GitHub; Watcom-derived heritage, bundles `mcpp` preprocessor) | CMake; releases include `compile.exe`, `sslc-linux`, **and a wasm/emscripten/node build** | Yes |
+| **int2ssl** (falltergeist) | `.int` → `.ssl` decompiler | C++ | **GPL-3.0** | CMake (Win/macOS/Linux); release ships `int2ssl.exe` only | Win only prebuilt |
+| **BGforge-MLS** | VS Code ext **+ standalone LSP** server (syntax/completion/hover/diagnostics/go-to-def/dialog preview for SSL) | TypeScript | **Effectively unstated** — `LICENSE.txt` is 0 bytes; npm says "SEE LICENSE IN LICENSE.txt" | npm `@bgforge/mls-server`, needs **Node ≥20**; runs standalone over LSP | npm; also bundles wasm **sslc** as an optional dep, so the server can compile too |
 
-These are reused across most features; building them first avoids eight one-off buttons:
+Key facts that shape the decision:
+- **sslc has no license file.** Redistribution terms are unclear. Bundling its binary into Gecko's installer is a legal grey area; safest to *invoke* a user-provided/separately-fetched binary rather than vendor it into our repo/installers until licensing is clarified upstream.
+- **int2ssl is GPL-3.0.** We can ship/build it as a *separate executable* we shell out to (mere aggregation — no GPL obligation on Gecko itself). We must **not** link it into our binary.
+- **BGforge-MLS's empty LICENSE = all-rights-reserved by default.** Embedding/redistributing it is risky; depending on a user-installed copy (VS Code or npm) is safe; vendoring is not.
+- Decompilation (int2ssl) is **lossy**: comments, original names, and some constructs don't round-trip. Treat `.int`→`.ssl` as best-effort, not authoritative.
 
-1. **Instance section in `SelectionPanel`.** A selection-driven, type-aware collapsible
-   area (alongside the existing object info / "Edit PRO…" / "Edit Exit Grid…" controls)
-   that hosts the per-type editors below. Hub for F10/F12/F13/F14/F15/F16.
-2. **`ObjectFlagsDialog`** — checkbox grid over the engine's user-togglable flags (engine
-   `regModFlagsDialog`, `mp_instance.cc`: Flat, NoBlock, MultiHex, the `Trans*` set,
-   ShootThru `OBJECT_SHOOT_THRU`, LightThru `OBJECT_LIGHT_THRU`, WallTransEnd, item-only
-   NoHighlight), with type-based visibility. Used by F12/F14/F16.
-3. **`ScriptSelectorDialog`** — lists scripts from `scripts.lst`, filtered by the 5 script
-   types (System/Spatial/Timer/Item/Critter). Used by F10/F11/F14.
-4. **`LightPropertiesDialog`** (or inline spinboxes) — distance 0–8, intensity 0–100%.
-   Used by F13 (and any instance editor showing light).
-5. **`ObjectCommandController` edit commands** — a generic before/after instance-property
-   command (mirroring the existing `registerExitGridEdit`/`registerObjectRotation`
-   pattern) so each feature is a thin wrapper, plus a cascading-delete hook so deleting an
-   object also drops its attached `MapScript` (avoids dangling scripts on re-save).
+### Option A — Embed BGforge-MLS LSP into a Qt editor widget
 
-### F10 — Object-instance script attachment · effort M · no format change
-- **What:** attach/detach a script (SID) to a placed object via the UI.
-- **Engine:** `scripts.cc` `scriptAdd` (sid = `(type<<24)|id`), `scriptGetScript`,
-  `scriptGetNewId`; `object.cc` `objectLoadAll` re-links `Object::sid → Script`;
-  `mapper/mp_scrpt.cc` `scr_choose`.
-- **Already have:** `MapObject.map_scripts_pid` (SID) + `script_id`, and the five
-  `Map::MapFile.map_scripts[...]` sections — all read/written today; map scripts are
-  currently read-only in the editor.
-- **UI:** "Attach Script…" in the instance section → `ScriptSelectorDialog` (filtered by
-  object type); creates/updates a `MapScript` entry in the right section, sets its
-  `script_oid` to the object's OID, sets the object's `map_scripts_pid`. "Detach" clears it.
-- **Undo:** `registerScriptAttachment` / `registerScriptDetachment` restoring both the
-  `MapObject` SID and the `MapScript` entry. Wire cascading delete (shared infra #5).
-- **Risks:** SID/OID allocation must not collide; orphaned scripts on object delete.
+A Qt code-editor widget (QScintilla, or `QPlainTextEdit` + **KSyntaxHighlighting**, or a custom widget) acting as an LSP *client* talking to `@bgforge/mls-server` over stdio.
 
-### F11 — Spatial (hex) script placement · effort M · no format change
-- **What:** place a spatial (trigger-zone) script at a hex with a radius.
-- **Engine:** `mapper/mp_scrpt.cc` `map_scr_add_spatial` / `map_scr_remove_spatial` /
-  `map_scr_toggle_hexes`; `Script.sp.built_tile` + `sp.radius` (0–50);
-  `obj_types.h` `builtTileCreate`/`builtTileGetTile`/`builtTileGetElevation`
-  (`BUILT_TILE_ELEVATION_SHIFT = 29`, tile mask `0x3FFFFFF`).
-- **Already have:** `MapScript.spatial_radius` and `script_oid` (the packed tile+elevation)
-  already round-trip; the SPATIAL section exists.
-- **UI:** new `EditorMode::PlaceSpatialScript` (mirror `ExitGridPlacementManager`) + a
-  toolbar action; on hex click, `SpatialScriptDialog` (script pick + radius). Show a marker
-  object at the hex (engine uses an INTERFACE-type marker). **Use hex coordinates
-  (0–39999), not tile coordinates** — pack via the engine's built-tile encoding exactly.
-- **Undo:** placement / deletion / radius-change commands; treat placement + marker as one
-  command.
+- **Effort: L.** We'd write a full LSP client (JSON-RPC framing, lifecycle, `textDocument/*`, diagnostics, completion, hover, semantic tokens), a process supervisor for the Node server, and editor-side rendering of all of it. No mature drop-in LSP client exists for Qt Widgets (Qt Creator's is internal/not reusable).
+- **Pros:** Best in-app UX — same diagnostics/completion as VS Code, fully integrated, no context switch.
+- **Cons / risk: High.** Requires a **Node ≥20 runtime** on the user's machine (heavy new dependency for a C++ desktop app). The MLS license is unstated, so we can't bundle the server. LSP client is a large surface to build and maintain against an upstream we don't control.
+- **Cross-platform:** Node + npm install must work on Win/macOS/Linux; manageable but adds a runtime-detection/onboarding burden.
+- **Verdict:** High value, but premature. Revisit only after a basic editor exists and if MLS licensing gets clarified.
 
-### F12 — Object-instance flag editing · effort M · no format change
-- **What:** toggle per-instance flags (Flat, NoBlock, MultiHex, ShootThru, LightThru,
-  `Trans*`, WallTransEnd, item NoHighlight).
-- **Engine:** `obj_types.h` `enum ObjectFlags` (exact bit values, `0x01..0x80000000`);
-  `mapper/mp_instance.cc` `regModFlagsDialog` / `regModInstFlags` (note the `OBJECT_FLAT`
-  special case triggers a visual `_obj_toggle_flat`).
-- **Already have:** `MapObject.flags` round-trips; our `Pro::ObjectFlags` mirror the engine.
-- **UI:** `ObjectFlagsDialog` (shared infra #2) from an "Edit Flags…" button; type-based
-  visibility matching the engine.
-- **Undo:** `registerObjectFlagsChange` (before/after); toggling Flat must refresh the
-  sprite/outline.
+### Option B — Hand off to external VS Code + sslc/int2ssl round-trip
 
-### F13 — Per-instance light editing · effort M · no format change
-- **What:** edit light distance (0–8 hex) and intensity (0–100%) per object.
-- **Engine:** `object.cc` `objectSetLight` (clamps distance ≤ 8, intensity ≤ 65536);
-  `mp_instance.cc` constants `kInstMaxLightDistance = 8`, `kInstMaxLightPct = 100`,
-  `kInstLightScale = 0x10000`. Display intensity as `intensity * 100 / 0x10000` %.
-- **Already have:** `MapObject.light_radius` (= engine `lightDistance`) and
-  `light_intensity` (raw 0–65536) round-trip; `isLightSource()` helper exists.
-- **UI:** `LightPropertiesDialog` (shared infra #4) from an "Edit Light…" button, shown for
-  light-source objects.
-- **Undo:** `registerLightEdit` (before/after) + light/sprite refresh.
+User installs VS Code + BGforge-MLS. Gecko opens the `.ssl` in VS Code (`code <file>`); on the Gecko side we provide "Compile" (invoke sslc → `.int`, copy into `scripts/`) and "Decompile existing" (int2ssl `.int` → `.ssl`).
 
-### F14 — Critter-instance editing · effort M · no format change
-- **What:** edit AI packet, team/group, HP/rad/poison, and inventory add/remove.
-- **Engine:** `mapper/mp_instance.cc` `protoInstCritterEdit`, `protoInstAddToInven`,
-  `protoInstChooseItemsForInven*`; `combat_ai.cc` `combat_ai_name(packet)`;
-  `item.cc` `itemAdd`/`itemRemove`.
-- **Already have:** all critter fields + the `inventory` vector round-trip;
-  `SelectionPanel` already renders the inventory tree and has the **TODO-stub** handlers
-  `onAddInventoryClicked` / `onRemoveInventoryClicked` (the inventory Add/Remove gap noted
-  in CLAUDE.md).
-- **UI:** critter-only "Combat Properties" group (AI-packet picker via `combat_ai_name`,
-  team, HP/rad/poison spinboxes) + implement the inventory add (item PID picker) / remove /
-  quantity handlers.
-- **Undo:** per-field commands; inventory add/remove/qty as commands (mind lambda-captured
-  `unique_ptr` ownership).
+- **Effort: S–M.** Mostly `QProcess` plumbing + tool-path settings + parsing sslc/int2ssl exit codes and stderr into a Gecko output panel.
+- **Pros:** Best editing experience for free (full MLS in VS Code); we own only the compile/place/decompile glue, which we need regardless.
+- **Cons:** Hard dependency on the user having VS Code + extension; clunky two-app workflow; no live feedback inside Gecko; we don't control when the user saves.
+- **Cross-platform:** `code` CLI exists on all three; sslc ships `sslc-linux`/`compile.exe` (no macOS prebuilt → users build it or we provide a CMake recipe); int2ssl ships Win-only (build from source on macOS/Linux). Tool-path config + "locate binary" UX needed.
+- **Licensing:** Cleanest — everything stays a separate user-installed/shelled-out process; no vendoring.
+- **Verdict:** Good pragmatic baseline; the compile/place/decompile glue is reusable by every other option.
 
-### F15 — Scenery transition-destination editing · effort M · no format change
-- **What:** edit destination Tile/Elevation/Map for stairs and ladders, and Type/Level for
-  elevators.
-- **Engine:** `proto.cc` scenery `objectDataRead`/`objectDataWrite` (stairs:
-  `destinationBuiltTile` + `destinationMap`; ladders: built-tile / map, version-dependent
-  order; elevator: type + level); `mapper/mp_instance.cc` `protoInstSceneryEdit`;
-  built-tile helpers as in F11.
-- **Already have:** `MapObject.elevhex`, `map`, `elevtype`, `elevlevel` round-trip — with
-  the **stairs-vs-ladder field-order difference already handled** in `MapReader`/`MapWriter`.
-- **UI:** `SceneryDestinationDialog` from an "Edit Destination…" button; spinboxes for
-  dest tile (0–39999), dest elevation (0–2), dest map; swap to Type/Level for elevators.
-  Decode/encode `elevhex` with the engine's built-tile packing (validate elevation 0–2 even
-  though 3 bits allow 0–7).
-- **Undo:** `registerDestinationEdit` (before/after `elevhex`/`map` or `elevtype`/`elevlevel`).
+### Option C — Built-in lightweight editor + bundled-ish toolchain (hybrid, recommended core)
 
-### F16 — Door/interaction state · effort M (kill-type/name deferred)
-- **In scope, no format change:** **door walkthrough** (open/closed — `MapObject.walkthrough`
-  already serialized) and **locked/jammed** flags (`OBJECT_LOCKED 0x02000000`,
-  `OBJECT_JAMMED 0x04000000` in `MapObject.flags`). Engine: `mp_instance.cc` instance flag
-  toggles (`'l'` key toggles locked), `proto_instance.h`
-  `objectLock`/`objectUnlock`/`objectJamLock`. This resolves the door-state overlap with
-  F15: **F15 = transition destinations, F16 = interaction state.**
-- **UI:** door/container interaction controls (walkthrough open/closed; locked/jammed
-  checkboxes) in the instance section, disabled for types that don't support them.
-- **Deferred — beyond engine-mapper parity (require decisions / format work):**
-  - **Per-instance critter kill-type override.** *Not* exposed in the engine mapper's
-    instance editor (kill type is proto-level, `proto_types.h` `KILL_TYPE_*`,
-    `KILL_TYPE_COUNT`). Adding it is a **Gecko extension that needs a new serialized
-    `MapObject` field** (with a `-1 = use proto` sentinel and a compatibility story). Defer.
-  - **Custom per-instance display name.** Needs a **format extension** (the vanilla
-    fixed-size object record has no name slot). Defer pending a storage decision.
-  - **Can-use** is proto-level (`PROTO_EXT_FLAG_CAN_USE`), not instance-overridable — out of
-    scope.
+A simple Gecko-native editor: `QPlainTextEdit` (or QScintilla) + **KSyntaxHighlighting** (we may already pull Qt/KDE deps; KSyntaxHighlighting ships an SSL/`*.ssl` syntax definition) — **no LSP**. Plus the Option-B compile/decompile glue. Optionally detect an installed external editor and offer "Open in VS Code" as a power-user escape hatch.
 
-### F17 — Map-wide operations · effort M (Shift-Map interactive part deferred) · no format change
-- **What:** Clear Level, Copy Elevation, Shift/Move Map, and editable map-header fields
-  (darkness, entering position/elevation/orientation).
-- **Engine:** `mapper/map_func.cc` `map_clear_elevation`, `mapper_copy_map_elev`,
-  `mapper_shift_map` (+ `mapper_shift_map_once` / `mapper_shift_map_elev`); header fields in
-  `map.cc`.
-- **Already have:** all `MapHeader` fields round-trip; `MapInfoPanel::onElevationCheckboxChanged`
-  already clears an elevation's tiles/objects (but **without undo** — factor this into a
-  proper command). Tiles/objects are stored per-elevation in `MapFile`.
-- **UI:** a "Map Operations" group in `MapInfoPanel` — Clear Level (confirm dialog),
-  Copy Elevation (N→M), editable Darkness; make the existing checkbox path go through undo.
-  **Shift/Move Map**: implement the simple numeric-offset form first (interactive
-  arrow-key shift deferred). Shift/Copy must rewrite spatial-script built-tiles and destroy
-  objects that move off-map (0..39999).
-- **Undo:** batch bulk deletions/moves into a single command (don't register per object);
-  custom header-change commands via `pushCommand`.
+- **Effort: M.** Editor widget + highlighter wiring + reuse of B's `QProcess` compile/decompile glue + tool-path settings.
+- **Pros:** Zero hard external editor dependency for basic edits; consistent in-app UX; no Node runtime; degrades gracefully (highlighting + compile, no completion). Lays the LSP-client groundwork (the editor widget) so Option A becomes incremental later.
+- **Cons:** No completion/diagnostics-as-you-type (only sslc compile errors, surfaced in an output panel); KSyntaxHighlighting adds a dependency if not already present.
+- **Cross-platform:** KSyntaxHighlighting is portable. sslc/int2ssl binary acquisition is the only friction (same as B) — mitigated by tool-path settings + first-run "locate/download sslc" helper. Avoid vendoring sslc binaries until its license is clarified.
+- **Licensing:** Safe — we ship our own editor + highlighter; sslc/int2ssl are invoked as external processes (int2ssl GPL stays at arm's length).
+- **Verdict:** **Best value-for-effort and the recommended foundation.**
 
-### Suggested sequencing
+### Recommendation & phased path
 
-1. **Shared infra** (SelectionPanel instance section, `ObjectFlagsDialog`,
-   `LightPropertiesDialog`, `ScriptSelectorDialog`, generic instance-edit + cascading-delete
-   commands).
-2. **Core instance editing — highest value:** F12 (flags), F13 (light), F10 (scripts),
-   F14 (critter + finish the inventory TODO stubs).
-3. **Scenery / spatial:** F15 (destinations), F11 (spatial scripts; needs the new EditorMode).
-4. **Lower priority:** F16 door/interaction state (defer kill-type/name), F17 map-wide ops
-   (defer interactive Shift-Map).
+Adopt **C as the core**, structured so **B** falls out for free and **A** remains a future upgrade.
+
+- **Phase 1 — Toolchain glue (S/M).** `QProcess` wrappers for sslc (compile `.ssl`→`.int`, place into `scripts/`) and int2ssl (decompile `.int`→`.ssl`); tool-path Settings + first-run "locate binary" UX; output panel for compiler errors/warnings. Wire into the existing `scripts.lst`/`MapScript` flow: from `ScriptSelectorDialog`/`SpatialScriptDialog`/`MapInfoPanel`, given a program index, resolve `scripts.lst[index]` → `scripts/<name>.int`, and offer "Edit script."
+- **Phase 2 — Built-in editor (M).** `QPlainTextEdit`/QScintilla + KSyntaxHighlighting SSL highlighting. Open the `.ssl` if present, else int2ssl-decompile the `.int` (clearly flagged "decompiled, lossy"); Save → Phase-1 compile → place `.int`. Add "Open in external editor (VS Code)" detection as the escape hatch (this *is* Option B, now a menu item).
+- **Phase 3 — Optional LSP upgrade (L, gated on demand + MLS licensing).** Reuse the Phase-2 widget as an LSP client to `@bgforge/mls-server` for completion/hover/diagnostics, **only if** a Node runtime is acceptable and MLS's license is clarified so we can guide installation. Do not bundle the server.
+
+### Ties to scripts.lst + MapScript model
+
+- The bridge from our data model to a source file is: `header.script_id` / `MapScript.script_id` (program index) → `scripts.lst` line → `scripts/<name>.int` (compiled, what the engine loads) → `scripts/source/<name>.ssl` or `scripts/<name>.ssl` (source). Current code already resolves index→name (`MapInfoPanel.cpp:397-403`); the new layer adds name→file→edit/compile.
+- **Compiling a *new* script must also register it** in `scripts.lst` (append a line) so a fresh program index exists for `MapScript` to reference — mirror the engine's index-is-line-number convention exactly (1-based in the map header; `at(index-1)` in our `Lst`).
+- Keep `.int` placement consistent with VFS/`ResourcePaths::Lst::SCRIPTS` (`scripts/`); a recompiled `.int` must land where the engine and our `repository().load<Lst>` lookups expect it.
+- **Note:** BGforge-MLS itself already parses `scripts.lst`, MAP, and PRO formats — if we ever adopt its server, some of our format awareness overlaps, but our writers remain the source of truth for IDs.
+
+---
+
+# Scripting & Automation Layer (Patterns / Prefabs + Procedural Generation)
+
+> Status: design proposal. Grounded in `src/format/map/Map.h`, `MapObject.h`,
+> `src/editor/HexagonGrid.h` / `Hex.h`, `src/format/map/Tile.h`,
+> `src/ui/editing/ObjectCommandController.h`, and `src/util/UndoStack.h`.
+
+## 1. Goals & two use cases
+
+**(1) User patterns / prefabs.** A reusable piece (tent, building wing, room) is a set
+of *relative* placements: objects at hex offsets plus floor/roof tiles at tile offsets.
+The user picks a pattern and stamps / drag-drops it on the map with a rotation
+(0–5, F2's six hex directions). Patterns are authored once, shared as files, and
+combined to assemble larger structures.
+
+**(2) Procedural generation.** The user selects an area and fills it with a seamless
+ground pattern (desert + scattered rocks; acid lake with a shore border that adapts to
+edges). Endgame: a script that generates a full random map from a high-level definition.
+
+The two cases pull in opposite directions: (1) is *fixed data* a non-programmer authors
+in the editor and replays deterministically; (2) is *open-ended computation* (loops,
+noise, conditionals, neighbour queries) that genuinely needs a language. This asymmetry
+is the central design fact and drives the two-tier recommendation below.
+
+## 2. Embedding option comparison (C++20 / Qt6, 2025)
+
+Weighted on: embedding ease, sandboxing/safety, performance at map scale
+(40,000 hexes / 10,000 tiles per elevation), binding ergonomics for our `Map` /
+`HexagonGrid` / placement API, licensing, and modder learning curve.
+
+| Option | Embed ease | Sandboxing | Perf @ 40k hex | Binding ergonomics | License | Learning curve | Verdict |
+|---|---|---|---|---|---|---|---|
+| **Lua 5.4 + sol2/sol3** | Excellent — header-only wrapper, ~25k LOC C core, trivial CMake | Strong: build a custom `_ENV`/sandbox, no default `io`/`os`/`require`; per-call instruction-count hook for timeout | Excellent (sol2 is among the fastest bindings); interpreter loop fine for tens of thousands of host calls | Best-in-class: `usertype`, overloads, `std::function`, containers, automatic shared_ptr handling | MIT (Lua) + MIT (sol2) | Lowest — the de-facto game/modding language; tiny surface area | **Primary** |
+| LuaJIT + sol2 | Good, but LuaJIT stalled on 5.1 semantics + ARM/Apple-Silicon JIT caveats | Same sandbox story as Lua | Fastest, but we don't need JIT speed for I/O-bound host calls | Same as sol2 | MIT | Same as Lua | Overkill; portability risk on macOS arm64 |
+| Luau (Roblox) | Moderate — C++ build, fewer turnkey C++ binding libs than sol2 | Best-in-class (sandbox + type checker designed for untrusted user scripts) | Very good (near-LuaJIT without JIT) | Good but you hand-roll more glue than sol2 | MIT | Low (Lua-family) | Strong #2 if untrusted-script safety becomes paramount |
+| QuickJS (+ quickjs-ng) | Good — single C file, but you write your own C++ binding glue | Good: no ambient FS/net unless you wire it; interrupt handler for timeouts | Good; ~15% behind Lua-for-speed in micro-benchmarks, fine here | Verbose: manual `JS_NewCFunction`, class IDs, no auto C++ usertypes | MIT | JS is widely known — *broadest* non-gamedev audience | Viable alt if JS familiarity is the priority |
+| duktape | Excellent (two files) | Good | Slower than QuickJS/Lua | Manual, C-style | MIT | JS | Only if footprint trumps speed |
+| V8 | Poor — heavyweight, large build, version churn | Strong but huge surface | Fastest JS, irrelevant here | Complex | BSD | JS | Rejected: disproportionate for an editor plugin |
+| AngelScript | Good — C++-like, registration-based | Strong (statically typed, no ambient access) | Good | Verbose registration; very C++-familiar to *us* | zlib | Medium; small community, niche | Rejected: thin ecosystem, weak modder familiarity |
+| Wren | Good, small | Decent | Good | Manual | MIT | Medium | Rejected: effectively unmaintained |
+| pybind11 / CPython | Embedding CPython is heavy; GIL, packaging, venv hell | Weak — sandboxing Python is notoriously hard | OK | Excellent bindings, but for *exposing C++ to Python apps*, not embedding | PSF/BSD | Python is well known | Rejected: distribution + sandboxing cost too high for a desktop editor |
+| **Pure data-driven (JSON/TOML)** | Trivial (we already parse formats) | Total — data can't execute | N/A (host does the work) | N/A | n/a | Lowest (authored in-editor, no code) | **Tier 1 of the recommendation** |
+
+Precedent worth noting: **Qt Creator 14 (2024) added a first-class plugin system built
+on embedded Lua 5.4**, and sol2 remains the reference C++<->Lua binding. That is a strong
+signal for a Qt6 C++20 app choosing Lua.
+
+## 3. Recommendation — TWO-TIER design
+
+Do **not** pick a single mechanism. Split by use case:
+
+- **Tier 1 — Declarative JSON prefab/pattern format** for *stamping* (use case 1, and the
+  "fill area with this ground/border ruleset" parts of use case 2). No code executes;
+  fully data. Authored in-editor ("Save selection as pattern"), diffable, shareable,
+  safe by construction, instantly replayable, and trivially undoable. This covers the
+  overwhelming majority of what users want and needs **zero** scripting runtime.
+
+- **Tier 2 — Embedded Lua (5.4 via sol2/sol3)** for *generation* (use case 2's noise,
+  neighbour rules, randomness, and the eventual full-map generator). Lua scripts are the
+  only place arbitrary computation lives, and they reach the map **only** through the same
+  narrow host API that Tier 1's interpreter uses.
+
+Rationale: Tier 1 keeps the common, user-facing path safe and code-free (a level designer
+should never write a script to stamp a tent). Tier 2 confines the security/perf surface of
+"real code" to the genuinely procedural cases, behind one audited façade. Both tiers funnel
+through the **identical** host API and therefore through `ObjectCommandController`, so
+**everything is undoable through one code path**.
+
+### Why Lua over JS/AngelScript here
+
+Lowest modder learning curve (it *is* the modding lingua franca), best C++ binding
+ergonomics via sol2 (shared_ptr-aware usertypes map cleanly onto our `MapObject` /
+`Hex` model), trivial sandboxing (drop `io`/`os`/`require`, custom `_ENV`, instruction
+hook), MIT throughout, and a tiny build footprint that won't disturb the existing
+FetchContent/clang pinning recorded in the toolchain memory.
+
+## 4. Pattern/prefab JSON format (Tier 1)
+
+A pattern is captured from a selection, anchored at an origin hex, storing **relative**
+offsets. Object offsets are in hex space; tile offsets in tile space (per the
+TILES vs HEXES distinction in CLAUDE.md — never validate one against the other's range).
+
+```jsonc
+{
+  "name": "small_tent",
+  "version": 1,
+  "anchorHex": 19998,            // authoring origin; offsets are relative to this
+  "size": { "hexW": 6, "hexH": 5 },
+  "rotatable": true,
+  "objects": [
+    { "dxHex": 0,  "dyHex": 0, "proPid": 33555201, "frmPid": 16777345,
+      "direction": 0, "flags": 0 },           // walls/scenery; pro/frm PIDs preserved verbatim
+    { "dxHex": 2,  "dyHex": 0, "proPid": 33555201, "frmPid": 16777345, "direction": 2 }
+  ],
+  "floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 271 },
+             { "dxTile": 1, "dyTile": 0, "tileId": 271 } ],
+  "roof":  [ { "dxTile": 0, "dyTile": 0, "tileId": 4096 } ]
+}
+```
+
+Notes:
+- PIDs (`pro_pid`, `frm_pid`) and `direction` are stored **verbatim** — engine IDs are
+  preserved exactly, per the Engine Data Fidelity rule. The format stores no display labels.
+- **Rotation** at stamp time maps both the offset vectors and each object's `direction`
+  field by the chosen 0–5 step. Hex-grid rotation is not a trivial (x,y) swap; implement a
+  tested `rotateHexOffset(dx, dy, steps)` against the F2 odd/even-row hex layout
+  (`Hex::HEX_WIDTH=16`, `HEX_HEIGHT=12`) and `direction = (direction + steps) % 6`.
+- Tier 1 needs **no scripting engine**: a C++ `PatternStamper` reads JSON and calls the
+  host API directly. Lua is never required to place a prefab.
+
+## 5. Host API (the single façade for both tiers)
+
+One C++ class — call it `MapScriptApi` (a.k.a. the "host API") — wraps a live editing
+session and is the *only* surface either tier touches. It is registered into the Lua state
+as a global table for Tier 2 and called directly by `PatternStamper` for Tier 1. Every
+mutator routes through `ObjectCommandController`, so undo is automatic and uniform.
+
+Proposed surface (Lua-facing names; C++ methods mirror them):
+
+```lua
+-- Queries (no mutation)
+local h    = api.getHex(x, y)              -- -> hex position (0..39999) or nil if off-map
+local x,y  = api.hexToXY(pos)              -- HexagonGrid::coordinatesForPosition
+local t    = api.getFloor(tilePos)         -- -> tileId ; api.getRoof(tilePos)
+local pid  = api.objectAt(hexPos)          -- nil or pro_pid of an object on that hex
+local r    = api.rng(seed)                 -- -> deterministic stream object: r:int(a,b), r:float(), r:chance(p)
+
+-- Iteration over a user-selected area (rectangular or selection mask)
+api.forEachHexInArea(area, function(hexPos, x, y) ... end)
+api.forEachTileInArea(area, function(tilePos, tx, ty) ... end)
+
+-- Mutators (each becomes an undoable step, auto-batched into one macro -- see 6)
+api.placeObject(proPid, hexPos, { direction = 0, frmPid = ..., flags = 0 })
+api.removeObjectAt(hexPos)
+api.paintFloor(tileId, area)               -- or single tilePos
+api.paintRoof(tileId, area)
+api.stampPattern(name, hexPos, rotation)   -- loads a Tier-1 JSON prefab and replays it here
+```
+
+`area` is a host-side value (rectangle from the current selection, or a positions list),
+constructed by the editor and handed to the script — scripts cannot fabricate arbitrary
+file/RAM handles. `rng(seed)` is a host-provided deterministic generator (PCG/xoshiro)
+so generation is reproducible and never reaches into ambient randomness.
+
+`placeObject` mirrors the existing creation path in `EditorWidget.cpp` (~line 1396):
+construct `std::make_shared<MapObject>()`, set `position`/`elevation`/`x`/`y` from the
+target `Hex`, copy `pro_pid`/`frm_pid` verbatim from the PRO/ObjectInfo lookup, build the
+visual `Object` + sprite, then register it — see §6.
+
+## 6. Routing through ObjectCommandController for undo
+
+The host API never mutates `Map` directly; it calls the same controller the UI uses:
+
+- **`placeObject`** -> build `MapObject` + visual `Object` (the §5/EditorWidget pattern),
+  then `ObjectCommandController::registerObjectPlacement(mapObject, object)`.
+- **`stampPattern`** -> for each object entry, `MapObject::cloneDeep()` from a cached
+  prototype (or build fresh), rotate, then `registerObjectPlacement`. cloneDeep is
+  mandatory because `MapObject` is non-copyable (its `inventory` holds `unique_ptr`s);
+  it deep-clones inventory so stamped containers keep their contents.
+- **`paintFloor` / `paintRoof`** -> accumulate `TileChange{ elevation, tileIndex, isRoof,
+  before, after }` (`src/ui/core/TileChange.h`) and call
+  `ObjectCommandController::registerTileEdit(description, changes)`.
+- **`removeObjectAt`** -> collect (mapObject, object) pairs and
+  `registerObjectDeletion(...)`.
+
+### Critical constraint — batch into ONE undo command
+
+`UndoStack` (`src/util/UndoStack.h`) is a **flat `std::function`-based list with no macro
+nesting and a hard `maxCommands` cap (default 100)**. A procedural fill that registers one
+command per hex would (a) blow the cap and silently evict earlier history, and (b) force
+the user to press Ctrl-Z thousands of times. Therefore:
+
+- A whole stamp / area-fill / generation run **must** collapse to a **single**
+  `UndoCommand` whose `undo`/`redo` closures replay the entire batch.
+- Concretely: open a "scripted operation" scope, have the host API **buffer** its object
+  placements/deletions and `TileChange`s instead of pushing each immediately, then on
+  scope close build **one** `UndoCommand` (or extend `ObjectCommandController` with a
+  `beginBatch()/endBatch(description)` that wraps `pushCommand` once). `registerTileEdit`
+  already takes a *vector* of changes — that is the model to follow for objects too.
+- This also bounds the redo path: one closure re-applies, one reverts. `rng(seed)` being
+  deterministic means redo reproduces identical generated content.
+
+> Action item: add `ObjectCommandController::beginBatch()/endBatch(desc)` (or an RAII
+> `ScopedUndoBatch`) so script-driven multi-edits land as one history entry. Without it the
+> 100-command cap makes generation unusable.
+
+## 7. Sandboxing & limits (Tier 2 only)
+
+- Fresh `sol::state` per run with a restricted `_ENV`: expose `api`, `math`, `string`,
+  `table`, `ipairs/pairs/select/...`; **omit** `io`, `os`, `package`/`require`,
+  `dofile`/`loadfile`, `debug`. No filesystem, no network, no process access.
+- Instruction-count `lua_sethook` (or quota in the iteration callbacks) to abort runaway
+  loops over 40,000 hexes with a clear error rather than freezing the UI.
+- Run generation **off the Qt UI thread** or chunked, surfacing progress; never block the
+  event loop during a full-map generate.
+- Cap total buffered edits and surface failures explicitly (per the "no silent fallback"
+  rule) rather than partially applying.
+
+## 8. Suggested sequencing
+
+1. **Host API skeleton** (`MapScriptApi`) over `ObjectCommandController`, plus
+   `beginBatch/endBatch` so any multi-edit is one undo step. Unit-testable headless.
+2. **Tier 1 JSON prefab**: `PatternFormat` (read/write), "Save selection as pattern",
+   `rotateHexOffset` with tests, `PatternStamper`, and `stampPattern` drag-drop with
+   rotation. Ships the highest-value feature with no scripting runtime.
+3. **Tier 2 Lua**: integrate Lua 5.4 + sol2 via FetchContent, sandboxed state, bind the
+   *same* host API, add a script console/runner. Start with area-fill generators
+   (desert+rocks, acid lake + shore border).
+4. **Full-map generator** as a Lua entry point consuming a definition file, reusing
+   `stampPattern` for set-pieces.
+
+## 9. Open questions
+
+- Hex rotation correctness on the F2 odd/even-row layout (needs golden tests).
+- Multi-elevation prefabs (store/stamp across the 3 `ELEVATION_COUNT` slots?).
+- Collision policy on stamp (overwrite vs skip vs error when target hexes are occupied).
+- Whether to lift `UndoStack::maxCommands` or rely solely on batching (batching is enough).

--- a/PLAN.md
+++ b/PLAN.md
@@ -690,15 +690,23 @@ rules (hex 0–39999, 3-elevation framing, exit-grid PIDs 16–23).
   → proc list + the linked `.msg` text gives an AI the conversation tree and behaviour surface
   without running the game. Cross-reference `scripts.lst` (index→name) and the map's
   `MapScript`/object `sid` to answer "what does the NPC on this hex say/do?".
-- **Visual analysis — Large (the only hard part).** To let the AI *see* the map (rendered
-  screenshot per elevation / region), expose an **offscreen render** through the SFML rendering
-  layer (`RenderingEngine`/`MapSpriteLoader`) producing a PNG the AI can read. Everything else is
-  structural and needs no rendering. This is the long pole; start without it.
+- **Visual analysis — Small–Medium (a refactor, not a rewrite).** To let the AI *see* the map
+  (rendered screenshot per elevation/region), reuse the **existing** SFML renderer:
+  `RenderingEngine`/`MapSpriteLoader` already have **zero Qt includes** and `render()` already
+  takes a generic `sf::RenderTarget&`. They just live in the Qt CMake target (`gecko_app`). The
+  clean move is to **extract a Qt-free `gecko_render` library** (renderer + sprite loader +
+  hex/viewport math; CMake-target move, not a code change) that both `gecko_app` (window target)
+  and the headless MCP/CLI use. The CLI renders to an **`sf::RenderTexture`** (offscreen) and does
+  `copyToImage()` → PNG — the same draw code the editor runs each frame, **no duplication**.
+  *Caveat:* `sf::RenderTexture` needs an OpenGL context — automatic on a desktop, but a headless
+  box (Docker/CI) needs `xvfb`/EGL. No Qt event loop is involved.
 
 ## Estimate
 
 A read-only "describe/analyze" server is a **few days**; adding write tools is **another few
 days** (~**1–2 weeks** for a solid read+write server), mostly tool-surface design + a JSON-RPC/CLI
 shim, not format work. Script/dialog understanding reuses the `Msg` reader + the proposed `.int`
-metadata reader. Visual analysis (offscreen render → PNG) is a separate **Large** add-on. Start
-with `gecko-cli` + read tools, since that's immediately useful and de-risks the rest.
+metadata reader. Visual analysis becomes a **Small–Medium** add-on once the Qt-free `gecko_render`
+extraction is done (the renderer is already Qt-free; it just needs to move to a shared library +
+an offscreen `sf::RenderTexture` wrapper). Start with `gecko-cli` + read tools, since that's
+immediately useful and de-risks the rest.

--- a/PLAN.md
+++ b/PLAN.md
@@ -66,6 +66,38 @@ keep. Revisit only if exact byte-parity with engine-saved maps becomes a require
 
 ## Missing in-engine-mapper features (instance & map editing)
 
+> **Status (implemented):** F10–F17 below are now implemented and build cleanly
+> (96 base tests + the 2 MAP-compat regression tests pass). Summary:
+> - **F12 flags** — `ObjectFlagsDialog`, undoable via `registerInstanceEdit`.
+> - **F13 light** — `LightPropertiesDialog`, undoable.
+> - **F14 critter** — `CritterPropertiesDialog` (AI packet numeric, team, HP/rad/poison),
+>   undoable; inventory Add/Remove/quantity now mutate the model (persist on save).
+> - **F15 scenery destination** — `SceneryDestinationDialog` (stairs/ladder built-tile,
+>   elevator type/level), undoable.
+> - **F16 interaction** — `InstancePropertiesDialog` locked/jammed routed to the correct
+>   per-type field (doors → `walkthrough`/openFlags, containers → `unknown11`/data.flags),
+>   undoable.
+> - **F17 map ops** — `MapInfoPanel` "Map Operations": Clear Elevation Objects, Copy
+>   Elevation (tiles + deep-cloned objects via `MapObject::cloneDeep`).
+> - **F10 script attach** — `ScriptSelectorDialog` from scripts.lst; creates a `MapScript`
+>   with engine-correct linkage (per-type SID, fresh object OID, program index,
+>   `local_var_count=0`/`offset=-1` exactly as `scriptAdd`).
+> - **F11 spatial script** — `SpatialScriptDialog` from `MapInfoPanel` creates a spatial
+>   `MapScript` (built-tile + radius).
+>
+> **Known limitations (follow-ups):**
+> - **Undo:** instance edits (F12/13/14-critter/15/16) are undoable; **inventory edits,
+>   script attach/detach, spatial scripts, and map-wide ops are direct mutations without
+>   undo** (matching `MapInfoPanel`'s existing elevation add/remove). Routing these through
+>   `ObjectCommandController` is the main follow-up.
+> - **AI packet / script program** are entered as raw engine numbers / scripts.lst names
+>   (no invented label tables, per the engine-fidelity rule). Local variables for newly
+>   attached scripts are left to the engine at runtime (as the mapper's own `scriptAdd` does).
+> - **F11** is dialog-driven (enter tile/elevation/radius) rather than click-to-place with a
+>   live hex marker + new `EditorMode`; that interactive flow is the remaining enhancement.
+> - **F16 deferred extensions** (per-instance kill-type / custom name) remain out of scope —
+>   they need new serialized fields and are not in the engine mapper.
+
 These are the editor capabilities the fallout2-ce in-engine mapper has that Gecko lacks.
 **Key finding: nearly all of the underlying data already round-trips through our `.map`
 format** — `MapObject` already carries `flags`, `light_radius`/`light_intensity`,

--- a/PLAN.md
+++ b/PLAN.md
@@ -648,3 +648,57 @@ Value is front-loaded, cost is back-loaded — so tier it:
 Bottom line: an "idle animations + lighting" preview is a **Medium** effort on top of what
 exists; full parity with the running game (sound, day/night, critter wander/AI) is **Large**
 and probably not worth chasing for a map editor.
+
+---
+
+# MCP server for AI-assisted map analysis & editing (future)
+
+> Status: idea / scoping. Expose the editor's map model as an MCP (Model Context Protocol)
+> server so an AI assistant can analyze a map, describe it, add/move objects, change scripts,
+> and (eventually) understand it visually and via its scripts/NPC dialogs.
+
+## Why it's cheap here
+
+The four-library split already makes the model, formats, and resources **Qt-free and
+headless-linkable** (`vault` → `gecko_resource` → `gecko_core`; the test suite links them with
+no GUI). So an MCP server **reuses `MapReader`/`MapWriter`, `MapObject`/`MapScript`
+(+ `cloneDeep`, the `makeObjectScript`/`makeSpatialScript` factories), and PID→name resolution
+via the resource layer** — zero format re-implementation, guaranteed fidelity, same validation
+rules (hex 0–39999, 3-elevation framing, exit-grid PIDs 16–23).
+
+## Tool surface (tiers)
+
+- **Read / describe — Small–Medium.** `describe_map` (header, enabled elevations, object/script
+  counts), `list_objects(elevation)` with resolved names, `list_scripts`, `get_hex(pos)`,
+  `find_objects(pid|type)`, exit-grid/transition connectivity. This is the bulk of "analyze the
+  map completely" and is the easy half.
+- **Write — Medium.** `add_object(pid, hex)`, `remove_object`, `edit_object_fields`,
+  `attach_script`/`detach_script`, `place_spatial_script`, `paint_floor/roof`,
+  `clear/copy_elevation`, `save`. Mirrors logic now centralized in `ObjectCommandController` /
+  `MapScript`; headless needs no undo, just model mutation + the existing writer.
+- **Transport — Small.** MCP is JSON-RPC over stdio (`initialize`, `tools/list`, `tools/call`).
+  Lowest-risk: build a headless **`gecko-cli`** (JSON in/out) over the existing libs first
+  (independently testable, reuses the round-trip tests), then wrap it with an MCP server in any
+  language. Alternatively a C++ MCP server linking the libs directly.
+
+## Deeper understanding (the longer-term goals)
+
+- **Script & NPC-dialog analysis — Medium.** "Understand the scripts" pairs the **`.int`
+  metadata reader** (procedure names, exported/imported procs, string table — see the SSL/INT
+  notes; the `.int` has no description) with the **`.msg`** file of the same basename (we already
+  have an `Msg` reader), which holds the NPC's dialogue/display lines. So `describe_script(index)`
+  → proc list + the linked `.msg` text gives an AI the conversation tree and behaviour surface
+  without running the game. Cross-reference `scripts.lst` (index→name) and the map's
+  `MapScript`/object `sid` to answer "what does the NPC on this hex say/do?".
+- **Visual analysis — Large (the only hard part).** To let the AI *see* the map (rendered
+  screenshot per elevation / region), expose an **offscreen render** through the SFML rendering
+  layer (`RenderingEngine`/`MapSpriteLoader`) producing a PNG the AI can read. Everything else is
+  structural and needs no rendering. This is the long pole; start without it.
+
+## Estimate
+
+A read-only "describe/analyze" server is a **few days**; adding write tools is **another few
+days** (~**1–2 weeks** for a solid read+write server), mostly tool-surface design + a JSON-RPC/CLI
+shim, not format work. Script/dialog understanding reuses the `Msg` reader + the proposed `.int`
+metadata reader. Visual analysis (offscreen render → PNG) is a separate **Large** add-on. Start
+with `gecko-cli` + read tools, since that's immediately useful and de-risks the rest.

--- a/PLAN.md
+++ b/PLAN.md
@@ -263,13 +263,13 @@ undo command; built-tile packing, SID encoding and script-record construction ar
 
 ## Known limitations & follow-ups
 
-1. **Undo is partial.** Single-object instance edits (flags, light, critter, destination,
-   locked/jammed) are undoable. **Inventory edits, script attach/detach, spatial-script
-   creation, and map-wide ops (clear/copy elevation) are direct model mutations without undo**
-   — they live in panels holding a raw `Map*`, like the pre-existing elevation add/remove.
-   Routing them through `ObjectCommandController` (a generic `cloneDeep`-based vector-swap
-   command for inventory/clear/copy + a script-edit command, via the existing signal-up
-   pattern) is the main follow-up; also add a cascading script-delete on object deletion.
+1. **Undo coverage.** Instance edits (flags, light, critter, destination, locked/jammed),
+   **inventory** add/remove/quantity, **clear/copy elevation**, and **script attach/detach +
+   spatial-script creation** are now all undoable through `ObjectCommandController`, covered by
+   `UndoStack` + `cloneDeep` unit tests. *Remaining:* the pre-existing elevation add/remove
+   (`MapInfoPanel` checkboxes) is still a direct mutation; a cascading script-delete when an
+   object is deleted; and the command-controller actions themselves aren't integration-tested
+   (they need GameResources/Qt — a `qt_tests` follow-up).
 2. **Exit grids are rectangle-only** — detailed below.
 3. **AI packet / script program are raw values** (engine packet numbers / scripts.lst names),
    not friendly labels — no invented label tables, per the engine-fidelity rule. Real labels
@@ -288,6 +288,13 @@ undo command; built-tile packing, SID encoding and script-record construction ar
 8. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
 9. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
    recompute, multi-hex occupancy overlay, or live light-radius overlay beyond the rebuild.
+10. **PRO-dialog animation preview jitters ("shaky camera").** Playback works, but each frame is
+    centred on its own bounding box instead of being anchored to a fixed reference point. FRM
+    frames carry per-frame signed (x, y) pixel **offsets** (the `Object::shiftX()/shiftY()`
+    values) that the engine accumulates so the sprite's anchor stays put across frames; the
+    preview ignores them, so frames with slightly different centres wobble. **Fix:** position
+    each preview frame by its FRM offset relative to a fixed anchor (mirror how the map
+    renderer/`Object` applies `shiftX/shiftY`) instead of re-centering per frame.
 
 ### Exit-grid shapes (rectangle-only) — limitation #2 in detail
 
@@ -599,3 +606,45 @@ the user to press Ctrl-Z thousands of times. Therefore:
 - Multi-elevation prefabs (store/stamp across the 3 `ELEVATION_COUNT` slots?).
 - Collision policy on stamp (overwrite vs skip vs error when target hexes are occupied).
 - Whether to lift `UndoStack::maxCommands` or rely solely on batching (batching is enough).
+
+---
+
+# In-game preview mode (future idea)
+
+> Status: idea / scoping. A toggle that makes the editor viewport behave more like the
+> running game — idle animations play, ambient sound plays, lighting/darkness renders, and
+> the editor chrome dims — so a designer can sanity-check "does this scene feel right?"
+> without launching Fallout 2.
+
+## What it would involve, by piece (rough effort)
+
+- **Idle animations — Medium.** We already decode FRM frames (the PRO dialog previews them)
+  and `Object::setDirection` sets a frame's texture rect; `TextureManager` stitches FRM frames
+  into sheets. The core work is a preview clock that advances each animated object's frame
+  index over time (honouring the FRM `fps` / `framesPerDirection`, looping idle anims), plus
+  per-object animation state and only animating culled/on-screen objects for perf at map scale.
+  **Depends on** fixing the per-frame offset handling (known limitation #10) or animations will
+  wobble. No new assets needed.
+- **Lighting / darkness — Medium.** Render honouring `header.darkness` and per-object light
+  (`light_radius` / `light_intensity`, already in the model) — an additive light pass / ambient
+  tint in `RenderingEngine`. The data already exists; it's a rendering feature.
+- **Ambient sound — Large.** SFML audio is currently **disabled** (`SFML_BUILD_AUDIO=FALSE`,
+  `cmake/dependencies.cmake`), so step one is enabling it. F2 sounds are **ACM** files (a custom
+  ADPCM-style codec) needing a decoder, and ambient/background audio isn't stored in the `.map`
+  (it's script/worldmap-driven), so "what plays here" has to come from the map script or a
+  convention. Biggest, most independent lift.
+- **"Game-like" chrome — Small.** A mode toggle that hides grid/overlays/selection, dims the
+  panels, and centres on the player start. Cheap polish once the above exist.
+
+## Recommendation / sequencing
+
+Value is front-loaded, cost is back-loaded — so tier it:
+1. **Idle-animation preview** (Medium) — highest value, reuses existing FRM decode + render;
+   gated on fixing the frame-offset bug. Ship as a "Play animations" toggle first.
+2. **Lighting / darkness** (Medium) — independent, data already present.
+3. **Ambient sound** (Large) — only if worth enabling SFML audio + writing an ACM decoder; the
+   long pole and least essential for an editor.
+
+Bottom line: an "idle animations + lighting" preview is a **Medium** effort on top of what
+exists; full parity with the running game (sound, day/night, critter wander/AI) is **Large**
+and probably not worth chasing for a map editor.

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -136,14 +136,26 @@ if(NOT SFML_FOUND)
     FetchContent_MakeAvailable(SFML)
 endif()
 
-# Catch2 for testing
+# Catch2 for testing - prefer system package, fall back to FetchContent
 if(GECK_BUILD_TESTS)
-    FetchContent_Declare(
-            Catch2
-            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_TAG v3.4.0
-            GIT_SHALLOW TRUE
-    )
-    FetchContent_MakeAvailable(Catch2)
-    geck_disable_target_warnings(Catch2 Catch2WithMain)
+    if(GECK_USE_SYSTEM_LIBS)
+        find_package(Catch2 3 QUIET)
+    endif()
+
+    if(NOT Catch2_FOUND)
+        message(STATUS "Using FetchContent for Catch2")
+        FetchContent_Declare(
+                Catch2
+                GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+                # Pinned to the exact v3.4.0 commit rather than the tag, and cloned
+                # in full (no GIT_SHALLOW). A commit hash lets FetchContent verify
+                # the checkout without a network update step on every reconfigure,
+                # which avoids the flaky "fatal: not a git repository" gitupdate
+                # failure; a full clone avoids the incomplete checkouts that a
+                # shallow fetch of a tag occasionally produced.
+                GIT_TAG 6e79e682b726f524310d55dec8ddac4e9c52fb5f # v3.4.0
+        )
+        FetchContent_MakeAvailable(Catch2)
+        geck_disable_target_warnings(Catch2 Catch2WithMain)
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,20 @@ set(GECK_APP_SOURCES
     ui/dialogs/MessageSelectorDialog.cpp
     ui/dialogs/ExitGridPropertiesDialog.h
     ui/dialogs/ExitGridPropertiesDialog.cpp
+    ui/dialogs/ObjectFlagsDialog.h
+    ui/dialogs/ObjectFlagsDialog.cpp
+    ui/dialogs/LightPropertiesDialog.h
+    ui/dialogs/LightPropertiesDialog.cpp
+    ui/dialogs/SceneryDestinationDialog.h
+    ui/dialogs/SceneryDestinationDialog.cpp
+    ui/dialogs/InstancePropertiesDialog.h
+    ui/dialogs/InstancePropertiesDialog.cpp
+    ui/dialogs/CritterPropertiesDialog.h
+    ui/dialogs/CritterPropertiesDialog.cpp
+    ui/dialogs/ScriptSelectorDialog.h
+    ui/dialogs/ScriptSelectorDialog.cpp
+    ui/dialogs/SpatialScriptDialog.h
+    ui/dialogs/SpatialScriptDialog.cpp
     ui/dialogs/AboutDialog.h
     ui/dialogs/AboutDialog.cpp
 

--- a/src/format/map/MapObject.cpp
+++ b/src/format/map/MapObject.cpp
@@ -9,4 +9,60 @@ bool MapObject::isWallObject() const {
     return typeId == static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL);
 }
 
+std::unique_ptr<MapObject> MapObject::cloneDeep() const {
+    auto c = std::make_unique<MapObject>();
+    c->unknown0 = unknown0;
+    c->position = position;
+    c->x = x;
+    c->y = y;
+    c->sx = sx;
+    c->sy = sy;
+    c->frame_number = frame_number;
+    c->direction = direction;
+    c->frm_pid = frm_pid;
+    c->flags = flags;
+    c->elevation = elevation;
+    c->pro_pid = pro_pid;
+    c->critter_index = critter_index;
+    c->light_radius = light_radius;
+    c->light_intensity = light_intensity;
+    c->outline_color = outline_color;
+    c->map_scripts_pid = map_scripts_pid;
+    c->script_id = script_id;
+    c->objects_in_inventory = objects_in_inventory;
+    c->max_inventory_size = max_inventory_size;
+    c->amount = amount;
+    c->unknown10 = unknown10;
+    c->unknown11 = unknown11;
+    c->player_reaction = player_reaction;
+    c->current_mp = current_mp;
+    c->combat_results = combat_results;
+    c->dmg_last_turn = dmg_last_turn;
+    c->ai_packet = ai_packet;
+    c->group_id = group_id;
+    c->who_hit_me = who_hit_me;
+    c->current_hp = current_hp;
+    c->current_rad = current_rad;
+    c->current_poison = current_poison;
+    c->ammo = ammo;
+    c->keycode = keycode;
+    c->ammo_pid = ammo_pid;
+    c->elevhex = elevhex;
+    c->map = map;
+    c->walkthrough = walkthrough;
+    c->elevtype = elevtype;
+    c->elevlevel = elevlevel;
+    c->exit_map = exit_map;
+    c->exit_position = exit_position;
+    c->exit_elevation = exit_elevation;
+    c->exit_orientation = exit_orientation;
+    c->inventory.reserve(inventory.size());
+    for (const auto& item : inventory) {
+        if (item) {
+            c->inventory.push_back(item->cloneDeep());
+        }
+    }
+    return c;
+}
+
 } // namespace geck

--- a/src/format/map/MapObject.h
+++ b/src/format/map/MapObject.h
@@ -95,6 +95,10 @@ struct MapObject {
 
     bool isWallObject() const;
 
+    /// Deep copy of this object, recursively cloning inventory. Needed because
+    /// MapObject is otherwise non-copyable (the inventory holds unique_ptrs).
+    std::unique_ptr<MapObject> cloneDeep() const;
+
     bool isLightSource() const {
         bool hasLight = light_radius > 0 || light_intensity > 0;
         return hasLight;

--- a/src/format/map/MapScript.h
+++ b/src/format/map/MapScript.h
@@ -3,6 +3,8 @@
 #include <inttypes.h>
 #include <string_view>
 
+#include "util/BuiltTile.h"
+
 namespace geck {
 
 struct MapScript {
@@ -35,9 +37,7 @@ struct MapScript {
     };
 
     static ScriptType fromPid(uint32_t val) {
-        unsigned int pid = (val & 0xff000000) >> 24;
-
-        switch (pid) {
+        switch (sidSection(val)) {
             case 0:
                 return ScriptType::SYSTEM;
             case 1:
@@ -68,6 +68,46 @@ struct MapScript {
             default:
                 return "Unknown";
         }
+    }
+
+    // A SID/PID packs the script type in the high byte and the per-type index in
+    // the low 24 bits. The map_scripts section index equals the script type.
+    static constexpr unsigned SID_TYPE_SHIFT = 24;
+    static constexpr uint32_t SID_INDEX_MASK = 0x00FFFFFF;
+    static constexpr uint32_t NONE = 0xFFFFFFFFu; // engine -1 sentinel
+
+    static constexpr uint32_t makeSid(ScriptType type, uint32_t index) {
+        return (static_cast<uint32_t>(type) << SID_TYPE_SHIFT) | (index & SID_INDEX_MASK);
+    }
+    static constexpr int sidSection(uint32_t sid) {
+        return static_cast<int>((sid >> SID_TYPE_SHIFT) & 0xFFu);
+    }
+    static constexpr uint32_t sidIndex(uint32_t sid) {
+        return sid & SID_INDEX_MASK;
+    }
+
+    /// Object-instance script with the engine's scriptAdd defaults (local vars
+    /// allocated at runtime; actionBeingUsed = -1). The owner object references
+    /// this script through its SID (== this script's pid).
+    static MapScript makeObjectScript(ScriptType type, uint32_t scriptId,
+        uint32_t programIndex, uint32_t ownerOid) {
+        MapScript s {};
+        s.pid = makeSid(type, scriptId);
+        s.script_id = programIndex;
+        s.script_oid = ownerOid;
+        s.local_var_offset = NONE;
+        s.local_var_count = 0;
+        s.unknown12 = NONE; // actionBeingUsed
+        return s;
+    }
+
+    /// Spatial (hex trigger-zone) script placed at a tile with a radius.
+    static MapScript makeSpatialScript(uint32_t scriptId, uint32_t programIndex,
+        uint32_t tile, uint32_t elevation, uint32_t radius, uint32_t ownerOid) {
+        MapScript s = makeObjectScript(ScriptType::SPATIAL, scriptId, programIndex, ownerOid);
+        s.timer = built_tile::create(tile, elevation); // spatial: built_tile
+        s.spatial_radius = radius;
+        return s;
     }
 };
 

--- a/src/format/pro/Pro.h
+++ b/src/format/pro/Pro.h
@@ -124,6 +124,14 @@ public:
         ITEM_HIDDEN = 0x08000000,
     };
 
+    // Door/container interaction state. These bits overload OBJECT_IN_RIGHT_HAND /
+    // OBJECT_WORN above; for doors/containers the engine stores them in the
+    // object's data flags, not the main flags word (proto_instance.cc objectLock).
+    enum class InteractionFlags : uint32_t {
+        LOCKED = 0x02000000,
+        JAMMED = 0x04000000,
+    };
+
     // Extended flags helper functions
     static constexpr uint32_t getAnimationPrimary(uint32_t flags) {
         return flags & static_cast<uint32_t>(ObjectFlags::ANIMATION_PRIMARY_MASK);

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -166,6 +166,18 @@ void EditorWidget::registerInventoryEdit(const std::shared_ptr<MapObject>& conta
     _objectCommandController->registerInventoryEdit(container, std::move(before), std::move(after));
 }
 
+void EditorWidget::attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex) {
+    _objectCommandController->attachScript(object, scriptType, programIndex);
+}
+
+void EditorWidget::detachScript(const std::shared_ptr<MapObject>& object) {
+    _objectCommandController->detachScript(object);
+}
+
+void EditorWidget::addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius) {
+    _objectCommandController->addSpatialScript(programIndex, tile, elevation, radius);
+}
+
 EditorWidget::~EditorWidget() {
 }
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -69,7 +69,8 @@ EditorWidget::EditorWidget(resource::GameResources& resources, std::unique_ptr<M
         [this]() { Q_EMIT undoStackChanged(); },
         [this](int elevation) -> std::vector<Tile>& { return ensureElevationTiles(elevation); },
         [this]() { return _currentElevation; },
-        [this](int hexIndex, bool isRoof, int elevation) { updateTileSprite(hexIndex, isRoof, elevation); });
+        [this](int hexIndex, bool isRoof, int elevation) { updateTileSprite(hexIndex, isRoof, elevation); },
+        [this]() { loadTileSprites(); });
     _inputHandler = std::make_unique<InputHandler>();
     _dragDropManager = std::make_unique<DragDropManager>(
         *this,
@@ -149,6 +150,20 @@ void EditorWidget::registerInstanceEdit(const std::shared_ptr<MapObject>& mapObj
     const MapObjectInstanceState& after,
     const std::string& description) {
     _objectCommandController->registerInstanceEdit(mapObject, before, after, description);
+}
+
+void EditorWidget::clearElevationObjects(int elevation) {
+    _objectCommandController->clearElevationObjects(elevation);
+}
+
+void EditorWidget::copyElevation(int fromElevation, int toElevation) {
+    _objectCommandController->copyElevation(fromElevation, toElevation);
+}
+
+void EditorWidget::registerInventoryEdit(const std::shared_ptr<MapObject>& container,
+    std::vector<std::shared_ptr<MapObject>> before,
+    std::vector<std::shared_ptr<MapObject>> after) {
+    _objectCommandController->registerInventoryEdit(container, std::move(before), std::move(after));
 }
 
 EditorWidget::~EditorWidget() {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -144,6 +144,13 @@ void EditorWidget::registerExitGridEdit(const std::vector<std::shared_ptr<MapObj
     _objectCommandController->registerExitGridEdit(exitGrids, beforeStates, afterStates);
 }
 
+void EditorWidget::registerInstanceEdit(const std::shared_ptr<MapObject>& mapObject,
+    const MapObjectInstanceState& before,
+    const MapObjectInstanceState& after,
+    const std::string& description) {
+    _objectCommandController->registerInstanceEdit(mapObject, before, after, description);
+}
+
 EditorWidget::~EditorWidget() {
 }
 

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -201,6 +201,11 @@ public:
         std::vector<std::shared_ptr<MapObject>> before,
         std::vector<std::shared_ptr<MapObject>> after);
 
+    // Script attachment / spatial scripts (undoable).
+    void attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex);
+    void detachScript(const std::shared_ptr<MapObject>& object);
+    void addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
+
 signals:
     void selectionChanged(const selection::SelectionState& selection, int elevation);
     void mapLoadRequested(const std::string& mapPath);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -192,6 +192,15 @@ public:
         const MapObjectInstanceState& after,
         const std::string& description);
 
+    // Map-wide operations (undoable). The confirmation dialog lives in MapInfoPanel.
+    void clearElevationObjects(int elevation);
+    void copyElevation(int fromElevation, int toElevation);
+
+    // Inventory edit (undoable). Snapshots come from SelectionPanel.
+    void registerInventoryEdit(const std::shared_ptr<MapObject>& container,
+        std::vector<std::shared_ptr<MapObject>> before,
+        std::vector<std::shared_ptr<MapObject>> after);
+
 signals:
     void selectionChanged(const selection::SelectionState& selection, int elevation);
     void mapLoadRequested(const std::string& mapPath);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -185,6 +185,13 @@ public:
         const std::vector<ExitGridState>& beforeStates,
         const std::vector<ExitGridState>& afterStates) override;
 
+    // Per-instance property (flags / light / scenery destination / critter) undo
+    // support. The before/after snapshots come from SelectionPanel's editors.
+    void registerInstanceEdit(const std::shared_ptr<MapObject>& mapObject,
+        const MapObjectInstanceState& before,
+        const MapObjectInstanceState& after,
+        const std::string& description);
+
 signals:
     void selectionChanged(const selection::SelectionState& selection, int elevation);
     void mapLoadRequested(const std::string& mapPath);

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -1015,6 +1015,16 @@ void MainWindow::connectPanelSignals() {
                 if (_currentEditorWidget && container)
                     _currentEditorWidget->registerInventoryEdit(container, std::move(before), std::move(after));
             });
+        connect(_selectionPanel, &SelectionPanel::requestAttachScript,
+            this, [this](std::shared_ptr<MapObject> object, int scriptType, uint32_t programIndex) {
+                if (_currentEditorWidget && object)
+                    _currentEditorWidget->attachScript(object, scriptType, programIndex);
+            });
+        connect(_selectionPanel, &SelectionPanel::requestDetachScript,
+            this, [this](std::shared_ptr<MapObject> object) {
+                if (_currentEditorWidget && object)
+                    _currentEditorWidget->detachScript(object);
+            });
         connect(_selectionPanel, &SelectionPanel::requestObjectHighlight,
             this, [this](std::shared_ptr<Object> object) {
                 if (!_currentEditorWidget || !object)
@@ -1116,6 +1126,11 @@ void MainWindow::connectPanelSignals() {
             this, [this](int from, int to) {
                 if (_currentEditorWidget)
                     _currentEditorWidget->copyElevation(from, to);
+            });
+        connect(_mapInfoPanel, &MapInfoPanel::addSpatialScriptRequested,
+            this, [this](int programIndex, int tile, int elevation, int radius) {
+                if (_currentEditorWidget)
+                    _currentEditorWidget->addSpatialScript(static_cast<uint32_t>(programIndex), tile, elevation, radius);
             });
     }
 }

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -375,6 +375,8 @@ void MainWindow::setupMenuBar() {
         if (_currentEditorWidget) {
             _currentEditorWidget->undoLastEdit();
             updateUndoRedoActions();
+            if (_selectionPanel)
+                _selectionPanel->refresh();
         }
     });
 
@@ -385,6 +387,8 @@ void MainWindow::setupMenuBar() {
         if (_currentEditorWidget) {
             _currentEditorWidget->redoLastEdit();
             updateUndoRedoActions();
+            if (_selectionPanel)
+                _selectionPanel->refresh();
         }
     });
 
@@ -1004,6 +1008,13 @@ void MainWindow::connectPanelSignals() {
                 _currentEditorWidget->registerInstanceEdit(object->getMapObjectPtr(),
                     before, after, description.toStdString());
             });
+        connect(_selectionPanel, &SelectionPanel::requestInventoryEdit,
+            this, [this](std::shared_ptr<MapObject> container,
+                       std::vector<std::shared_ptr<MapObject>> before,
+                       std::vector<std::shared_ptr<MapObject>> after) {
+                if (_currentEditorWidget && container)
+                    _currentEditorWidget->registerInventoryEdit(container, std::move(before), std::move(after));
+            });
         connect(_selectionPanel, &SelectionPanel::requestObjectHighlight,
             this, [this](std::shared_ptr<Object> object) {
                 if (!_currentEditorWidget || !object)
@@ -1096,14 +1107,15 @@ void MainWindow::connectPanelSignals() {
                     spdlog::info("MainWindow: Switched away from removed elevation {}", elevation);
                 }
             });
-        connect(_mapInfoPanel, &MapInfoPanel::mapContentChanged,
+        connect(_mapInfoPanel, &MapInfoPanel::clearElevationRequested,
             this, [this](int elevation) {
-                if (!_currentEditorWidget)
-                    return;
-                if (_currentEditorWidget->getCurrentElevation() == elevation) {
-                    _currentEditorWidget->loadTileSprites();
-                    _currentEditorWidget->refreshObjects();
-                }
+                if (_currentEditorWidget)
+                    _currentEditorWidget->clearElevationObjects(elevation);
+            });
+        connect(_mapInfoPanel, &MapInfoPanel::copyElevationRequested,
+            this, [this](int from, int to) {
+                if (_currentEditorWidget)
+                    _currentEditorWidget->copyElevation(from, to);
             });
     }
 }

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -996,6 +996,14 @@ void MainWindow::connectPanelSignals() {
                     }
                 }
             });
+        connect(_selectionPanel, &SelectionPanel::requestInstanceEdit,
+            this, [this](std::shared_ptr<Object> object, MapObjectInstanceState before,
+                       MapObjectInstanceState after, QString description) {
+                if (!_currentEditorWidget || !object || !object->hasMapObject())
+                    return;
+                _currentEditorWidget->registerInstanceEdit(object->getMapObjectPtr(),
+                    before, after, description.toStdString());
+            });
         connect(_selectionPanel, &SelectionPanel::requestObjectHighlight,
             this, [this](std::shared_ptr<Object> object) {
                 if (!_currentEditorWidget || !object)
@@ -1086,6 +1094,15 @@ void MainWindow::connectPanelSignals() {
                             elevationChanged(ELEVATION_3);
                     }
                     spdlog::info("MainWindow: Switched away from removed elevation {}", elevation);
+                }
+            });
+        connect(_mapInfoPanel, &MapInfoPanel::mapContentChanged,
+            this, [this](int elevation) {
+                if (!_currentEditorWidget)
+                    return;
+                if (_currentEditorWidget->getCurrentElevation() == elevation) {
+                    _currentEditorWidget->loadTileSprites();
+                    _currentEditorWidget->refreshObjects();
                 }
             });
     }

--- a/src/ui/dialogs/CritterPropertiesDialog.cpp
+++ b/src/ui/dialogs/CritterPropertiesDialog.cpp
@@ -1,0 +1,58 @@
+#include "CritterPropertiesDialog.h"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace geck {
+
+namespace {
+    QSpinBox* makeSpin(QWidget* parent, int value, int max) {
+        auto* spin = new QSpinBox(parent);
+        spin->setRange(0, max);
+        spin->setValue(value);
+        return spin;
+    }
+} // namespace
+
+CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t team, uint32_t hp,
+    uint32_t radiation, uint32_t poison, QWidget* parent)
+    : QDialog(parent) {
+
+    setWindowTitle("Critter Properties");
+
+    auto* mainLayout = new QVBoxLayout(this);
+    auto* formLayout = new QFormLayout();
+
+    _aiPacketSpin = makeSpin(this, static_cast<int>(aiPacket), 32000);
+    _aiPacketSpin->setToolTip("Raw AI packet number (from the game's AI definitions).");
+    formLayout->addRow("AI packet:", _aiPacketSpin);
+
+    _teamSpin = makeSpin(this, static_cast<int>(team), 32000);
+    formLayout->addRow("Team:", _teamSpin);
+
+    _hpSpin = makeSpin(this, static_cast<int>(hp), 32000);
+    formLayout->addRow("Current HP:", _hpSpin);
+
+    _radiationSpin = makeSpin(this, static_cast<int>(radiation), 32000);
+    formLayout->addRow("Radiation:", _radiationSpin);
+
+    _poisonSpin = makeSpin(this, static_cast<int>(poison), 32000);
+    formLayout->addRow("Poison:", _poisonSpin);
+
+    mainLayout->addLayout(formLayout);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+}
+
+uint32_t CritterPropertiesDialog::getAiPacket() const { return static_cast<uint32_t>(_aiPacketSpin->value()); }
+uint32_t CritterPropertiesDialog::getTeam() const { return static_cast<uint32_t>(_teamSpin->value()); }
+uint32_t CritterPropertiesDialog::getHp() const { return static_cast<uint32_t>(_hpSpin->value()); }
+uint32_t CritterPropertiesDialog::getRadiation() const { return static_cast<uint32_t>(_radiationSpin->value()); }
+uint32_t CritterPropertiesDialog::getPoison() const { return static_cast<uint32_t>(_poisonSpin->value()); }
+
+} // namespace geck

--- a/src/ui/dialogs/CritterPropertiesDialog.h
+++ b/src/ui/dialogs/CritterPropertiesDialog.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+
+class QSpinBox;
+
+namespace geck {
+
+/// @brief Editor for a critter instance's combat/state fields.
+///
+/// Edits the per-instance critter data the engine stores on the object and the
+/// .map already round-trips: AI packet, team/group, current HP, radiation and
+/// poison (see mp_instance.cc protoInstCritterEdit, object.cc critter data).
+/// The AI packet is shown as its raw engine number rather than a name table, to
+/// avoid inventing labels that may not match the loaded game data.
+class CritterPropertiesDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    CritterPropertiesDialog(uint32_t aiPacket, uint32_t team, uint32_t hp,
+        uint32_t radiation, uint32_t poison, QWidget* parent = nullptr);
+
+    uint32_t getAiPacket() const;
+    uint32_t getTeam() const;
+    uint32_t getHp() const;
+    uint32_t getRadiation() const;
+    uint32_t getPoison() const;
+
+private:
+    QSpinBox* _aiPacketSpin;
+    QSpinBox* _teamSpin;
+    QSpinBox* _hpSpin;
+    QSpinBox* _radiationSpin;
+    QSpinBox* _poisonSpin;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/InstancePropertiesDialog.cpp
+++ b/src/ui/dialogs/InstancePropertiesDialog.cpp
@@ -5,7 +5,14 @@
 #include <QGroupBox>
 #include <QVBoxLayout>
 
+#include "format/pro/Pro.h"
+
 namespace geck {
+
+namespace {
+    constexpr uint32_t FLAG_LOCKED = static_cast<uint32_t>(Pro::InteractionFlags::LOCKED);
+    constexpr uint32_t FLAG_JAMMED = static_cast<uint32_t>(Pro::InteractionFlags::JAMMED);
+} // namespace
 
 InstancePropertiesDialog::InstancePropertiesDialog(bool isDoor, uint32_t doorOpenFlags,
     uint32_t containerDataFlags, QWidget* parent)

--- a/src/ui/dialogs/InstancePropertiesDialog.cpp
+++ b/src/ui/dialogs/InstancePropertiesDialog.cpp
@@ -1,0 +1,70 @@
+#include "InstancePropertiesDialog.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QVBoxLayout>
+
+namespace geck {
+
+InstancePropertiesDialog::InstancePropertiesDialog(bool isDoor, uint32_t doorOpenFlags,
+    uint32_t containerDataFlags, QWidget* parent)
+    : QDialog(parent)
+    , _isDoor(isDoor)
+    , _doorOpenFlags(doorOpenFlags)
+    , _containerDataFlags(containerDataFlags) {
+
+    setWindowTitle(isDoor ? "Door Interaction" : "Container Interaction");
+
+    const uint32_t source = isDoor ? doorOpenFlags : containerDataFlags;
+
+    auto* mainLayout = new QVBoxLayout(this);
+
+    auto* group = new QGroupBox("Access", this);
+    auto* groupLayout = new QVBoxLayout(group);
+
+    _lockedBox = new QCheckBox("Locked", this);
+    _lockedBox->setChecked((source & FLAG_LOCKED) != 0);
+    groupLayout->addWidget(_lockedBox);
+
+    _jammedBox = new QCheckBox("Jammed", this);
+    _jammedBox->setChecked((source & FLAG_JAMMED) != 0);
+    groupLayout->addWidget(_jammedBox);
+
+    mainLayout->addWidget(group);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+}
+
+uint32_t InstancePropertiesDialog::getDoorOpenFlags() const {
+    if (!_isDoor) {
+        return _doorOpenFlags; // unchanged for containers
+    }
+    uint32_t result = _doorOpenFlags & ~(FLAG_LOCKED | FLAG_JAMMED);
+    if (_lockedBox->isChecked()) {
+        result |= FLAG_LOCKED;
+    }
+    if (_jammedBox->isChecked()) {
+        result |= FLAG_JAMMED;
+    }
+    return result;
+}
+
+uint32_t InstancePropertiesDialog::getContainerDataFlags() const {
+    if (_isDoor) {
+        return _containerDataFlags; // unchanged for doors
+    }
+    uint32_t result = _containerDataFlags & ~(FLAG_LOCKED | FLAG_JAMMED);
+    if (_lockedBox->isChecked()) {
+        result |= FLAG_LOCKED;
+    }
+    if (_jammedBox->isChecked()) {
+        result |= FLAG_JAMMED;
+    }
+    return result;
+}
+
+} // namespace geck

--- a/src/ui/dialogs/InstancePropertiesDialog.h
+++ b/src/ui/dialogs/InstancePropertiesDialog.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+
+class QCheckBox;
+
+namespace geck {
+
+/// @brief Editor for door/container interaction state: locked and jammed.
+///
+/// The engine keeps these bits in different fields depending on type
+/// (proto_instance.cc objectIsLocked / objectLock):
+///   - doors: obj->data.scenery.door.openFlags  (our MapObject.walkthrough)
+///   - containers: obj->data.flags              (our MapObject.unknown11)
+/// Both use the same bit values (LOCKED 0x02000000, JAMMED 0x04000000). The
+/// dialog edits whichever field applies and returns the other unchanged. No
+/// .map format change - both fields already round-trip.
+class InstancePropertiesDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    /// @param isDoor              true for doors, false for containers
+    /// @param doorOpenFlags       MapObject.walkthrough (door open/lock flags)
+    /// @param containerDataFlags  MapObject.unknown11 (object data flags)
+    InstancePropertiesDialog(bool isDoor, uint32_t doorOpenFlags, uint32_t containerDataFlags,
+        QWidget* parent = nullptr);
+
+    uint32_t getDoorOpenFlags() const;
+    uint32_t getContainerDataFlags() const;
+
+    static constexpr uint32_t FLAG_LOCKED = 0x02000000;
+    static constexpr uint32_t FLAG_JAMMED = 0x04000000;
+
+private:
+    bool _isDoor;
+    uint32_t _doorOpenFlags;
+    uint32_t _containerDataFlags;
+    QCheckBox* _lockedBox;
+    QCheckBox* _jammedBox;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/InstancePropertiesDialog.h
+++ b/src/ui/dialogs/InstancePropertiesDialog.h
@@ -8,15 +8,12 @@ class QCheckBox;
 
 namespace geck {
 
-/// @brief Editor for door/container interaction state: locked and jammed.
+/// @brief Editor for door/container locked & jammed state.
 ///
-/// The engine keeps these bits in different fields depending on type
-/// (proto_instance.cc objectIsLocked / objectLock):
-///   - doors: obj->data.scenery.door.openFlags  (our MapObject.walkthrough)
-///   - containers: obj->data.flags              (our MapObject.unknown11)
-/// Both use the same bit values (LOCKED 0x02000000, JAMMED 0x04000000). The
-/// dialog edits whichever field applies and returns the other unchanged. No
-/// .map format change - both fields already round-trip.
+/// The engine keeps these bits in different fields by type (proto_instance.cc
+/// objectIsLocked): doors use openFlags (our MapObject.walkthrough), containers
+/// use the object data flags (our MapObject.unknown11). The dialog edits
+/// whichever applies and returns the other unchanged.
 class InstancePropertiesDialog : public QDialog {
     Q_OBJECT
 
@@ -29,9 +26,6 @@ public:
 
     uint32_t getDoorOpenFlags() const;
     uint32_t getContainerDataFlags() const;
-
-    static constexpr uint32_t FLAG_LOCKED = 0x02000000;
-    static constexpr uint32_t FLAG_JAMMED = 0x04000000;
 
 private:
     bool _isDoor;

--- a/src/ui/dialogs/LightPropertiesDialog.cpp
+++ b/src/ui/dialogs/LightPropertiesDialog.cpp
@@ -1,0 +1,52 @@
+#include "LightPropertiesDialog.h"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+#include <algorithm>
+
+namespace geck {
+
+LightPropertiesDialog::LightPropertiesDialog(uint32_t lightRadius, uint32_t lightIntensity, QWidget* parent)
+    : QDialog(parent) {
+
+    setWindowTitle("Light Properties");
+
+    auto* mainLayout = new QVBoxLayout(this);
+    auto* formLayout = new QFormLayout();
+
+    _distanceSpin = new QSpinBox(this);
+    _distanceSpin->setRange(0, MAX_DISTANCE);
+    _distanceSpin->setValue(static_cast<int>(std::min<uint32_t>(lightRadius, MAX_DISTANCE)));
+    _distanceSpin->setSuffix(" hexes");
+    formLayout->addRow("Light distance:", _distanceSpin);
+
+    _intensitySpin = new QSpinBox(this);
+    _intensitySpin->setRange(0, MAX_PERCENT);
+    // Raw intensity -> percentage. Clamp to the engine's 100% ceiling.
+    uint32_t clampedRaw = std::min<uint32_t>(lightIntensity, LIGHT_SCALE);
+    int percent = static_cast<int>((static_cast<uint64_t>(clampedRaw) * MAX_PERCENT) / LIGHT_SCALE);
+    _intensitySpin->setValue(percent);
+    _intensitySpin->setSuffix(" %");
+    formLayout->addRow("Light intensity:", _intensitySpin);
+
+    mainLayout->addLayout(formLayout);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+}
+
+uint32_t LightPropertiesDialog::getLightRadius() const {
+    return static_cast<uint32_t>(_distanceSpin->value());
+}
+
+uint32_t LightPropertiesDialog::getLightIntensity() const {
+    // Percentage -> raw, matching the engine scale. 100% maps exactly to LIGHT_SCALE.
+    return static_cast<uint32_t>((static_cast<uint64_t>(_intensitySpin->value()) * LIGHT_SCALE) / MAX_PERCENT);
+}
+
+} // namespace geck

--- a/src/ui/dialogs/LightPropertiesDialog.h
+++ b/src/ui/dialogs/LightPropertiesDialog.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+
+class QSpinBox;
+
+namespace geck {
+
+/// @brief Editor for an object instance's light distance and intensity.
+///
+/// Mirrors the fallout2-ce mapper instance light editor: distance is 0-8 hexes,
+/// intensity is entered as a 0-100% value and stored raw against the engine's
+/// light scale (0x10000 == 100%). See object.cc objectSetLight and
+/// mp_instance.cc (kInstMaxLightDistance / kInstMaxLightPct / kInstLightScale).
+class LightPropertiesDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    LightPropertiesDialog(uint32_t lightRadius, uint32_t lightIntensity, QWidget* parent = nullptr);
+
+    uint32_t getLightRadius() const;    ///< 0-8 hexes
+    uint32_t getLightIntensity() const; ///< raw 0-65536
+
+    static constexpr int MAX_DISTANCE = 8;
+    static constexpr int MAX_PERCENT = 100;
+    static constexpr uint32_t LIGHT_SCALE = 0x10000; // 65536 == 100%
+
+private:
+    QSpinBox* _distanceSpin;
+    QSpinBox* _intensitySpin;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/ObjectFlagsDialog.cpp
+++ b/src/ui/dialogs/ObjectFlagsDialog.cpp
@@ -1,0 +1,77 @@
+#include "ObjectFlagsDialog.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QVBoxLayout>
+
+#include "format/pro/Pro.h"
+
+namespace geck {
+
+namespace {
+    constexpr uint32_t bit(Pro::ObjectFlags f) { return static_cast<uint32_t>(f); }
+} // namespace
+
+ObjectFlagsDialog::ObjectFlagsDialog(uint32_t flags, uint32_t objectType, QWidget* parent)
+    : QDialog(parent)
+    , _originalFlags(flags) {
+
+    setWindowTitle("Object Flags");
+
+    auto* mainLayout = new QVBoxLayout(this);
+
+    const bool isItem = objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::ITEM);
+    const bool isWallOrScenery = objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL)
+        || objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::SCENERY);
+
+    auto* behaviourGroup = new QGroupBox("Behaviour", this);
+    auto* behaviourLayout = new QVBoxLayout(behaviourGroup);
+    addFlag(behaviourLayout, "Flat", bit(Pro::ObjectFlags::OBJECT_FLAT));
+    addFlag(behaviourLayout, "No Block", bit(Pro::ObjectFlags::OBJECT_NO_BLOCK));
+    addFlag(behaviourLayout, "Multi Hex", bit(Pro::ObjectFlags::OBJECT_MULTIHEX));
+    addFlag(behaviourLayout, "Shoot Thru", bit(Pro::ObjectFlags::OBJECT_SHOOT_THRU));
+    addFlag(behaviourLayout, "Light Thru", bit(Pro::ObjectFlags::OBJECT_LIGHT_THRU));
+    if (isWallOrScenery) {
+        addFlag(behaviourLayout, "Wall Trans End", bit(Pro::ObjectFlags::OBJECT_WALL_TRANS_END));
+    }
+    if (isItem) {
+        addFlag(behaviourLayout, "No Highlight", bit(Pro::ObjectFlags::OBJECT_NO_HIGHLIGHT));
+    }
+    mainLayout->addWidget(behaviourGroup);
+
+    auto* transparencyGroup = new QGroupBox("Transparency", this);
+    auto* transparencyLayout = new QVBoxLayout(transparencyGroup);
+    addFlag(transparencyLayout, "None", bit(Pro::ObjectFlags::OBJECT_TRANS_NONE));
+    addFlag(transparencyLayout, "Red", bit(Pro::ObjectFlags::OBJECT_TRANS_RED));
+    addFlag(transparencyLayout, "Glass", bit(Pro::ObjectFlags::OBJECT_TRANS_GLASS));
+    addFlag(transparencyLayout, "Steam", bit(Pro::ObjectFlags::OBJECT_TRANS_STEAM));
+    addFlag(transparencyLayout, "Energy", bit(Pro::ObjectFlags::OBJECT_TRANS_ENERGY));
+    mainLayout->addWidget(transparencyGroup);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+}
+
+void ObjectFlagsDialog::addFlag(QLayout* layout, const QString& label, uint32_t bit) {
+    auto* box = new QCheckBox(label, this);
+    box->setChecked((_originalFlags & bit) != 0);
+    layout->addWidget(box);
+    _entries.push_back({ box, bit });
+    _shownMask |= bit;
+}
+
+uint32_t ObjectFlagsDialog::getFlags() const {
+    // Preserve every bit we did not expose, then OR back the checked ones.
+    uint32_t result = _originalFlags & ~_shownMask;
+    for (const auto& entry : _entries) {
+        if (entry.box->isChecked()) {
+            result |= entry.bit;
+        }
+    }
+    return result;
+}
+
+} // namespace geck

--- a/src/ui/dialogs/ObjectFlagsDialog.h
+++ b/src/ui/dialogs/ObjectFlagsDialog.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+#include <vector>
+
+class QCheckBox;
+
+namespace geck {
+
+/// @brief Editor for the per-instance object flags stored in MapObject.flags.
+///
+/// Exposes the same user-togglable flags as the fallout2-ce mapper instance
+/// editor (regModFlagsDialog): Flat, No Block, Multi Hex, the transparency set,
+/// Shoot Thru, Light Thru, Wall Trans End, and (items only) No Highlight. Bits
+/// that are not shown for the object's type are preserved untouched, so the
+/// animation bits and engine-managed flags are never clobbered.
+class ObjectFlagsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    /// @param flags      current MapObject.flags value
+    /// @param objectType Pro::OBJECT_TYPE ordinal (pro_pid >> 24)
+    ObjectFlagsDialog(uint32_t flags, uint32_t objectType, QWidget* parent = nullptr);
+
+    /// Returns the edited flags, preserving any bits not shown for this type.
+    uint32_t getFlags() const;
+
+private:
+    struct Entry {
+        QCheckBox* box;
+        uint32_t bit;
+    };
+
+    void addFlag(class QLayout* layout, const QString& label, uint32_t bit);
+
+    uint32_t _originalFlags;
+    uint32_t _shownMask = 0; // union of bits exposed as checkboxes
+    std::vector<Entry> _entries;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/SceneryDestinationDialog.cpp
+++ b/src/ui/dialogs/SceneryDestinationDialog.cpp
@@ -5,7 +5,14 @@
 #include <QSpinBox>
 #include <QVBoxLayout>
 
+#include "editor/HexagonGrid.h"
+#include "util/BuiltTile.h"
+
 namespace geck {
+
+namespace {
+    constexpr int MAX_HEX_TILE = HexagonGrid::POSITION_COUNT - 1;
+} // namespace
 
 SceneryDestinationDialog::SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType,
     uint32_t elevhex, uint32_t map, uint32_t elevtype, uint32_t elevlevel, QWidget* parent)
@@ -32,8 +39,8 @@ SceneryDestinationDialog::SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType
         _elevLevelSpin->setValue(static_cast<int>(elevlevel));
         formLayout->addRow("Elevator level:", _elevLevelSpin);
     } else {
-        const int tile = static_cast<int>(elevhex & BUILT_TILE_TILE_MASK);
-        const int elevation = static_cast<int>((elevhex & BUILT_TILE_ELEVATION_MASK) >> BUILT_TILE_ELEVATION_SHIFT);
+        const int tile = static_cast<int>(built_tile::tileOf(elevhex));
+        const int elevation = static_cast<int>(built_tile::elevationOf(elevhex));
 
         _tileSpin = new QSpinBox(this);
         _tileSpin->setRange(0, MAX_HEX_TILE);
@@ -63,9 +70,8 @@ uint32_t SceneryDestinationDialog::getElevhex() const {
     if (_isElevator) {
         return _elevhex;
     }
-    const uint32_t tile = static_cast<uint32_t>(_tileSpin->value()) & BUILT_TILE_TILE_MASK;
-    const uint32_t elevation = (static_cast<uint32_t>(_elevationSpin->value()) << BUILT_TILE_ELEVATION_SHIFT) & BUILT_TILE_ELEVATION_MASK;
-    return tile | elevation;
+    return built_tile::create(static_cast<uint32_t>(_tileSpin->value()),
+        static_cast<uint32_t>(_elevationSpin->value()));
 }
 
 uint32_t SceneryDestinationDialog::getMap() const {

--- a/src/ui/dialogs/SceneryDestinationDialog.cpp
+++ b/src/ui/dialogs/SceneryDestinationDialog.cpp
@@ -1,0 +1,83 @@
+#include "SceneryDestinationDialog.h"
+
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace geck {
+
+SceneryDestinationDialog::SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType,
+    uint32_t elevhex, uint32_t map, uint32_t elevtype, uint32_t elevlevel, QWidget* parent)
+    : QDialog(parent)
+    , _isElevator(sceneryType == Pro::SCENERY_TYPE::ELEVATOR)
+    , _elevhex(elevhex)
+    , _map(map)
+    , _elevtype(elevtype)
+    , _elevlevel(elevlevel) {
+
+    setWindowTitle("Scenery Destination");
+
+    auto* mainLayout = new QVBoxLayout(this);
+    auto* formLayout = new QFormLayout();
+
+    if (_isElevator) {
+        _elevTypeSpin = new QSpinBox(this);
+        _elevTypeSpin->setRange(-1, 32000);
+        _elevTypeSpin->setValue(static_cast<int>(elevtype));
+        formLayout->addRow("Elevator type:", _elevTypeSpin);
+
+        _elevLevelSpin = new QSpinBox(this);
+        _elevLevelSpin->setRange(-1, 32000);
+        _elevLevelSpin->setValue(static_cast<int>(elevlevel));
+        formLayout->addRow("Elevator level:", _elevLevelSpin);
+    } else {
+        const int tile = static_cast<int>(elevhex & BUILT_TILE_TILE_MASK);
+        const int elevation = static_cast<int>((elevhex & BUILT_TILE_ELEVATION_MASK) >> BUILT_TILE_ELEVATION_SHIFT);
+
+        _tileSpin = new QSpinBox(this);
+        _tileSpin->setRange(0, MAX_HEX_TILE);
+        _tileSpin->setValue(tile > MAX_HEX_TILE ? 0 : tile);
+        formLayout->addRow("Destination tile:", _tileSpin);
+
+        _elevationSpin = new QSpinBox(this);
+        _elevationSpin->setRange(0, 2);
+        _elevationSpin->setValue(elevation > 2 ? 0 : elevation);
+        formLayout->addRow("Destination elevation:", _elevationSpin);
+
+        _mapSpin = new QSpinBox(this);
+        _mapSpin->setRange(0, 32000);
+        _mapSpin->setValue(static_cast<int>(map));
+        formLayout->addRow("Destination map:", _mapSpin);
+    }
+
+    mainLayout->addLayout(formLayout);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttonBox);
+}
+
+uint32_t SceneryDestinationDialog::getElevhex() const {
+    if (_isElevator) {
+        return _elevhex;
+    }
+    const uint32_t tile = static_cast<uint32_t>(_tileSpin->value()) & BUILT_TILE_TILE_MASK;
+    const uint32_t elevation = (static_cast<uint32_t>(_elevationSpin->value()) << BUILT_TILE_ELEVATION_SHIFT) & BUILT_TILE_ELEVATION_MASK;
+    return tile | elevation;
+}
+
+uint32_t SceneryDestinationDialog::getMap() const {
+    return _isElevator ? _map : static_cast<uint32_t>(_mapSpin->value());
+}
+
+uint32_t SceneryDestinationDialog::getElevtype() const {
+    return _isElevator ? static_cast<uint32_t>(_elevTypeSpin->value()) : _elevtype;
+}
+
+uint32_t SceneryDestinationDialog::getElevlevel() const {
+    return _isElevator ? static_cast<uint32_t>(_elevLevelSpin->value()) : _elevlevel;
+}
+
+} // namespace geck

--- a/src/ui/dialogs/SceneryDestinationDialog.h
+++ b/src/ui/dialogs/SceneryDestinationDialog.h
@@ -13,11 +13,9 @@ namespace geck {
 /// @brief Editor for a scenery transition destination (stairs / ladders /
 /// elevators).
 ///
-/// Stairs and ladders store their target as a packed "built tile" (hex tile in
-/// the low bits, elevation in bits 29-31 - engine builtTileCreate) plus a
-/// destination map id. Elevators instead store a type and a current level.
-/// Matches proto.cc scenery objectDataRead/Write and mp_instance.cc
-/// protoInstSceneryEdit. No .map format change - all fields already round-trip.
+/// Stairs and ladders store their target as a packed built tile plus a
+/// destination map id; elevators store a type and a current level. Matches
+/// proto.cc scenery objectDataRead/Write and mp_instance.cc protoInstSceneryEdit.
 class SceneryDestinationDialog : public QDialog {
     Q_OBJECT
 
@@ -32,13 +30,6 @@ public:
     uint32_t getMap() const;
     uint32_t getElevtype() const;
     uint32_t getElevlevel() const;
-
-    // Engine built-tile packing (obj_types.h): tile in the low bits, elevation in
-    // bits 29-31.
-    static constexpr uint32_t BUILT_TILE_TILE_MASK = 0x3FFFFFF;
-    static constexpr int BUILT_TILE_ELEVATION_SHIFT = 29;
-    static constexpr uint32_t BUILT_TILE_ELEVATION_MASK = 0xE0000000;
-    static constexpr int MAX_HEX_TILE = 39999;
 
 private:
     bool _isElevator;

--- a/src/ui/dialogs/SceneryDestinationDialog.h
+++ b/src/ui/dialogs/SceneryDestinationDialog.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+
+#include "format/pro/Pro.h"
+
+class QSpinBox;
+
+namespace geck {
+
+/// @brief Editor for a scenery transition destination (stairs / ladders /
+/// elevators).
+///
+/// Stairs and ladders store their target as a packed "built tile" (hex tile in
+/// the low bits, elevation in bits 29-31 - engine builtTileCreate) plus a
+/// destination map id. Elevators instead store a type and a current level.
+/// Matches proto.cc scenery objectDataRead/Write and mp_instance.cc
+/// protoInstSceneryEdit. No .map format change - all fields already round-trip.
+class SceneryDestinationDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType,
+        uint32_t elevhex, uint32_t map, uint32_t elevtype, uint32_t elevlevel,
+        QWidget* parent = nullptr);
+
+    // Returns the (possibly edited) field values. Fields that don't apply to this
+    // scenery type are returned unchanged.
+    uint32_t getElevhex() const;
+    uint32_t getMap() const;
+    uint32_t getElevtype() const;
+    uint32_t getElevlevel() const;
+
+    // Engine built-tile packing (obj_types.h): tile in the low bits, elevation in
+    // bits 29-31.
+    static constexpr uint32_t BUILT_TILE_TILE_MASK = 0x3FFFFFF;
+    static constexpr int BUILT_TILE_ELEVATION_SHIFT = 29;
+    static constexpr uint32_t BUILT_TILE_ELEVATION_MASK = 0xE0000000;
+    static constexpr int MAX_HEX_TILE = 39999;
+
+private:
+    bool _isElevator;
+    uint32_t _elevhex;
+    uint32_t _map;
+    uint32_t _elevtype;
+    uint32_t _elevlevel;
+
+    // Stairs/ladder controls
+    QSpinBox* _tileSpin = nullptr;
+    QSpinBox* _elevationSpin = nullptr;
+    QSpinBox* _mapSpin = nullptr;
+
+    // Elevator controls
+    QSpinBox* _elevTypeSpin = nullptr;
+    QSpinBox* _elevLevelSpin = nullptr;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/ScriptSelectorDialog.cpp
+++ b/src/ui/dialogs/ScriptSelectorDialog.cpp
@@ -1,0 +1,59 @@
+#include "ScriptSelectorDialog.h"
+
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QVBoxLayout>
+
+namespace geck {
+
+ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<std::string>& scriptNames,
+    int currentIndex, QWidget* parent)
+    : QDialog(parent) {
+
+    setWindowTitle("Select Script");
+    resize(360, 460);
+
+    auto* mainLayout = new QVBoxLayout(this);
+
+    _filterEdit = new QLineEdit(this);
+    _filterEdit->setPlaceholderText("Filter scripts...");
+    mainLayout->addWidget(_filterEdit);
+
+    _listWidget = new QListWidget(this);
+    for (size_t i = 0; i < scriptNames.size(); ++i) {
+        // Show "index: name" but carry the program index in the item's data.
+        auto* item = new QListWidgetItem(
+            QString("%1: %2").arg(i).arg(QString::fromStdString(scriptNames[i])), _listWidget);
+        item->setData(Qt::UserRole, static_cast<int>(i));
+    }
+    mainLayout->addWidget(_listWidget);
+
+    if (currentIndex >= 0 && currentIndex < _listWidget->count()) {
+        _listWidget->setCurrentRow(currentIndex);
+    }
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(_listWidget, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
+    connect(_filterEdit, &QLineEdit::textChanged, this, &ScriptSelectorDialog::onFilterChanged);
+    mainLayout->addWidget(buttonBox);
+}
+
+void ScriptSelectorDialog::onFilterChanged(const QString& text) {
+    for (int i = 0; i < _listWidget->count(); ++i) {
+        auto* item = _listWidget->item(i);
+        item->setHidden(!text.isEmpty() && !item->text().contains(text, Qt::CaseInsensitive));
+    }
+}
+
+int ScriptSelectorDialog::selectedIndex() const {
+    auto* item = _listWidget->currentItem();
+    if (!item || item->isHidden()) {
+        return -1;
+    }
+    return item->data(Qt::UserRole).toInt();
+}
+
+} // namespace geck

--- a/src/ui/dialogs/ScriptSelectorDialog.h
+++ b/src/ui/dialogs/ScriptSelectorDialog.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QDialog>
+
+#include <vector>
+#include <string>
+
+class QListWidget;
+class QLineEdit;
+
+namespace geck {
+
+/// @brief Picks a script program from scripts.lst.
+///
+/// The returned value is the 0-based line index in scripts.lst, which is the
+/// script "program index" the engine stores as Script::index (our
+/// MapScript.script_id). The script *type* (item/critter) is decided by the
+/// object being scripted, not here - see objectSetScript in the engine.
+class ScriptSelectorDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    /// @param scriptNames  scripts.lst entries (index == program index)
+    /// @param currentIndex program index to preselect, or -1
+    ScriptSelectorDialog(const std::vector<std::string>& scriptNames, int currentIndex, QWidget* parent = nullptr);
+
+    /// Selected program index, or -1 if none.
+    int selectedIndex() const;
+
+private slots:
+    void onFilterChanged(const QString& text);
+
+private:
+    QLineEdit* _filterEdit;
+    QListWidget* _listWidget;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -11,6 +11,8 @@
 #include <QSpinBox>
 #include <QVBoxLayout>
 
+#include "editor/HexagonGrid.h"
+
 namespace geck {
 
 SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent)
@@ -30,7 +32,7 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptN
     formLayout->addRow("Script:", scriptRow);
 
     _tileSpin = new QSpinBox(this);
-    _tileSpin->setRange(0, MAX_HEX_TILE);
+    _tileSpin->setRange(0, HexagonGrid::POSITION_COUNT - 1);
     formLayout->addRow("Hex tile:", _tileSpin);
 
     _elevationCombo = new QComboBox(this);

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -1,0 +1,80 @@
+#include "SpatialScriptDialog.h"
+
+#include "ScriptSelectorDialog.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace geck {
+
+SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent)
+    : QDialog(parent)
+    , _scriptNames(scriptNames) {
+
+    setWindowTitle("Add Spatial Script");
+
+    auto* mainLayout = new QVBoxLayout(this);
+    auto* formLayout = new QFormLayout();
+
+    auto* scriptRow = new QHBoxLayout();
+    _scriptLabel = new QLabel("None");
+    auto* chooseButton = new QPushButton("Choose...");
+    scriptRow->addWidget(_scriptLabel, 1);
+    scriptRow->addWidget(chooseButton);
+    formLayout->addRow("Script:", scriptRow);
+
+    _tileSpin = new QSpinBox(this);
+    _tileSpin->setRange(0, MAX_HEX_TILE);
+    formLayout->addRow("Hex tile:", _tileSpin);
+
+    _elevationCombo = new QComboBox(this);
+    _elevationCombo->addItem("Elevation 1", 0);
+    _elevationCombo->addItem("Elevation 2", 1);
+    _elevationCombo->addItem("Elevation 3", 2);
+    formLayout->addRow("Elevation:", _elevationCombo);
+
+    _radiusSpin = new QSpinBox(this);
+    _radiusSpin->setRange(0, MAX_RADIUS);
+    _radiusSpin->setValue(3);
+    formLayout->addRow("Radius:", _radiusSpin);
+
+    mainLayout->addLayout(formLayout);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    _okButton = buttonBox->button(QDialogButtonBox::Ok);
+    _okButton->setEnabled(false); // need a script first
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(chooseButton, &QPushButton::clicked, this, &SpatialScriptDialog::onChooseScript);
+    mainLayout->addWidget(buttonBox);
+}
+
+void SpatialScriptDialog::onChooseScript() {
+    ScriptSelectorDialog dialog(_scriptNames, _programIndex, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const int index = dialog.selectedIndex();
+    if (index < 0) {
+        return;
+    }
+    _programIndex = index;
+    if (static_cast<size_t>(index) < _scriptNames.size()) {
+        _scriptLabel->setText(QString("%1: %2").arg(index).arg(QString::fromStdString(_scriptNames[index])));
+    } else {
+        _scriptLabel->setText(QString("Script #%1").arg(index));
+    }
+    _okButton->setEnabled(true);
+}
+
+int SpatialScriptDialog::tile() const { return _tileSpin->value(); }
+int SpatialScriptDialog::elevation() const { return _elevationCombo->currentData().toInt(); }
+int SpatialScriptDialog::radius() const { return _radiusSpin->value(); }
+
+} // namespace geck

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QDialog>
+
+#include <vector>
+#include <string>
+
+class QLabel;
+class QSpinBox;
+class QComboBox;
+class QPushButton;
+
+namespace geck {
+
+/// @brief Creates a spatial (hex trigger-zone) script: a scripts.lst program
+/// placed at a hex with a radius. Mirrors the engine's map_scr_add_spatial - the
+/// script record carries the built-tile position and radius; no saved object is
+/// involved (the engine's hex marker is editor-only / NO_SAVE).
+class SpatialScriptDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent = nullptr);
+
+    int programIndex() const { return _programIndex; }
+    int tile() const;
+    int elevation() const;
+    int radius() const;
+
+    static constexpr int MAX_HEX_TILE = 39999;
+    static constexpr int MAX_RADIUS = 50;
+
+private slots:
+    void onChooseScript();
+
+private:
+    std::vector<std::string> _scriptNames;
+    int _programIndex = -1;
+
+    QLabel* _scriptLabel;
+    QSpinBox* _tileSpin;
+    QComboBox* _elevationCombo;
+    QSpinBox* _radiusSpin;
+    QPushButton* _okButton;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -27,8 +27,7 @@ public:
     int elevation() const;
     int radius() const;
 
-    static constexpr int MAX_HEX_TILE = 39999;
-    static constexpr int MAX_RADIUS = 50;
+    static constexpr int MAX_RADIUS = 50; // engine win_get_num_i range in map_scr_add_spatial
 
 private slots:
     void onChooseScript();

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -528,17 +528,31 @@ bool ObjectCommandController::clearElevationObjects(int elevation) {
     std::vector<std::shared_ptr<MapObject>> before = it->second;
     std::vector<std::shared_ptr<MapObject>> after; // empty
 
+    // Removing the objects must also remove their attached scripts, otherwise the
+    // map keeps orphaned MapScript records pointing at OIDs that no longer exist.
+    // Prune by SID so the objects' own map_scripts_pid stays intact for undo.
+    ScriptSections beforeScripts = snapshotScripts();
+    it->second.clear();
+    for (const auto& obj : before) {
+        if (obj && obj->map_scripts_pid != -1) {
+            eraseScript(static_cast<uint32_t>(obj->map_scripts_pid));
+        }
+    }
+    ScriptSections afterScripts = snapshotScripts();
+
     UndoCommand cmd;
     cmd.description = "Clear Elevation Objects";
-    cmd.undo = [this, elevation, before]() {
+    cmd.undo = [this, elevation, before, beforeScripts]() {
         _map->getMapFile().map_objects[elevation] = before;
+        restoreScripts(beforeScripts);
         _refreshObjects();
     };
-    cmd.redo = [this, elevation, after]() {
+    cmd.redo = [this, elevation, after, afterScripts]() {
         _map->getMapFile().map_objects[elevation] = after;
+        restoreScripts(afterScripts);
         _refreshObjects();
     };
-    cmd.redo();
+    // The edit was already applied above; only register the undo/redo handlers.
     return pushCommand(std::move(cmd));
 }
 
@@ -570,6 +584,11 @@ bool ObjectCommandController::copyElevation(int fromElevation, int toElevation) 
             }
             auto clone = std::shared_ptr<MapObject>(o->cloneDeep());
             clone->elevation = static_cast<uint32_t>(toElevation);
+            // Scripts are not copied, so detach the clone's linkage; otherwise it
+            // would duplicate the source object's OID and share its SID/script.
+            clone->map_scripts_pid = -1;
+            clone->script_id = -1;
+            clone->unknown0 = 0;
             afterObjects.push_back(std::move(clone));
         }
     }
@@ -640,19 +659,43 @@ uint32_t ObjectCommandController::allocateObjectId() const {
     return maxId + 1;
 }
 
+ObjectCommandController::ScriptSections ObjectCommandController::snapshotScripts() const {
+    static_assert(SCRIPT_SECTIONS == Map::SCRIPT_SECTIONS,
+        "ScriptSections snapshot size must match Map::SCRIPT_SECTIONS");
+    ScriptSections snapshot;
+    const auto& mapFile = _map->getMapFile();
+    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+        snapshot.sections[section] = mapFile.map_scripts[section];
+        snapshot.counts[section] = mapFile.scripts_in_section[section];
+    }
+    return snapshot;
+}
+
+void ObjectCommandController::restoreScripts(const ScriptSections& snapshot) {
+    auto& mapFile = _map->getMapFile();
+    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+        mapFile.map_scripts[section] = snapshot.sections[section];
+        mapFile.scripts_in_section[section] = snapshot.counts[section];
+    }
+}
+
+void ObjectCommandController::eraseScript(uint32_t sid) {
+    const int section = MapScript::sidSection(sid);
+    if (section < 0 || section >= Map::SCRIPT_SECTIONS) {
+        return;
+    }
+    auto& vec = _map->getMapFile().map_scripts[section];
+    vec.erase(std::remove_if(vec.begin(), vec.end(),
+                  [sid](const MapScript& s) { return s.pid == sid; }),
+        vec.end());
+    _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
+}
+
 void ObjectCommandController::removeObjectScript(MapObject& object) {
     if (!_map || object.map_scripts_pid == -1) {
         return;
     }
-    const uint32_t sid = static_cast<uint32_t>(object.map_scripts_pid);
-    const int section = MapScript::sidSection(sid);
-    if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
-        auto& vec = _map->getMapFile().map_scripts[section];
-        vec.erase(std::remove_if(vec.begin(), vec.end(),
-                      [sid](const MapScript& s) { return s.pid == sid; }),
-            vec.end());
-        _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
-    }
+    eraseScript(static_cast<uint32_t>(object.map_scripts_pid));
     object.map_scripts_pid = -1;
 }
 

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -608,6 +608,154 @@ bool ObjectCommandController::copyElevation(int fromElevation, int toElevation) 
     return pushCommand(std::move(cmd));
 }
 
+uint32_t ObjectCommandController::allocateScriptId(int section) const {
+    if (!_map || section < 0 || section >= Map::SCRIPT_SECTIONS) {
+        return 0;
+    }
+    uint32_t nextId = 0;
+    for (const auto& s : _map->getMapFile().map_scripts[section]) {
+        nextId = std::max(nextId, MapScript::sidIndex(s.pid) + 1);
+    }
+    return nextId;
+}
+
+uint32_t ObjectCommandController::allocateObjectId() const {
+    if (!_map) {
+        return 1;
+    }
+    uint32_t maxId = 0;
+    const auto& mapFile = _map->getMapFile();
+    for (const auto& [elevation, objects] : mapFile.map_objects) {
+        for (const auto& obj : objects) {
+            if (obj) {
+                maxId = std::max(maxId, obj->unknown0);
+            }
+        }
+    }
+    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+        for (const auto& s : mapFile.map_scripts[section]) {
+            maxId = std::max(maxId, s.script_oid);
+        }
+    }
+    return maxId + 1;
+}
+
+void ObjectCommandController::removeObjectScript(MapObject& object) {
+    if (!_map || object.map_scripts_pid == -1) {
+        return;
+    }
+    const uint32_t sid = static_cast<uint32_t>(object.map_scripts_pid);
+    const int section = MapScript::sidSection(sid);
+    if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
+        auto& vec = _map->getMapFile().map_scripts[section];
+        vec.erase(std::remove_if(vec.begin(), vec.end(),
+                      [sid](const MapScript& s) { return s.pid == sid; }),
+            vec.end());
+        _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
+    }
+    object.map_scripts_pid = -1;
+}
+
+void ObjectCommandController::applyScriptSnapshot(int section, const std::shared_ptr<MapObject>& object,
+    const std::vector<MapScript>& sectionScripts, uint32_t oid, int32_t sid) {
+    if (!_map || section < 0 || section >= Map::SCRIPT_SECTIONS) {
+        return;
+    }
+    auto& mapFile = _map->getMapFile();
+    mapFile.map_scripts[section] = sectionScripts;
+    mapFile.scripts_in_section[section] = static_cast<int>(sectionScripts.size());
+    if (object) {
+        object->unknown0 = oid;
+        object->map_scripts_pid = sid;
+    }
+}
+
+bool ObjectCommandController::recordScriptEdit(const std::string& description, int section,
+    const std::shared_ptr<MapObject>& object,
+    std::vector<MapScript> beforeSection, uint32_t beforeOid, int32_t beforeSid) {
+    if (!_map) {
+        return false;
+    }
+    // The caller already applied the edit; capture the resulting "after" state.
+    std::vector<MapScript> afterSection = _map->getMapFile().map_scripts[section];
+    uint32_t afterOid = object ? object->unknown0 : 0;
+    int32_t afterSid = object ? object->map_scripts_pid : -1;
+
+    UndoCommand cmd;
+    cmd.description = description;
+    cmd.undo = [this, section, object, beforeSection, beforeOid, beforeSid]() {
+        applyScriptSnapshot(section, object, beforeSection, beforeOid, beforeSid);
+    };
+    cmd.redo = [this, section, object, afterSection, afterOid, afterSid]() {
+        applyScriptSnapshot(section, object, afterSection, afterOid, afterSid);
+    };
+    return pushCommand(std::move(cmd));
+}
+
+bool ObjectCommandController::attachScript(const std::shared_ptr<MapObject>& object,
+    int scriptType, uint32_t programIndex) {
+    if (!_map || !object || scriptType < 0 || scriptType >= Map::SCRIPT_SECTIONS) {
+        return false;
+    }
+    const int section = scriptType;
+    auto& mapFile = _map->getMapFile();
+
+    std::vector<MapScript> beforeSection = mapFile.map_scripts[section];
+    const uint32_t beforeOid = object->unknown0;
+    const int32_t beforeSid = object->map_scripts_pid;
+
+    // Replace any existing script (same object type -> same section).
+    removeObjectScript(*object);
+
+    const uint32_t scriptId = allocateScriptId(section);
+    const uint32_t oid = allocateObjectId();
+    MapScript script = MapScript::makeObjectScript(static_cast<MapScript::ScriptType>(scriptType),
+        scriptId, programIndex, oid);
+    mapFile.map_scripts[section].push_back(script);
+    mapFile.scripts_in_section[section] = static_cast<int>(mapFile.map_scripts[section].size());
+    object->unknown0 = oid;
+    object->map_scripts_pid = static_cast<int32_t>(script.pid);
+
+    return recordScriptEdit("Attach Script", section, object, std::move(beforeSection), beforeOid, beforeSid);
+}
+
+bool ObjectCommandController::detachScript(const std::shared_ptr<MapObject>& object) {
+    if (!_map || !object || object->map_scripts_pid == -1) {
+        return false;
+    }
+    const int section = MapScript::sidSection(static_cast<uint32_t>(object->map_scripts_pid));
+    if (section < 0 || section >= Map::SCRIPT_SECTIONS) {
+        return false;
+    }
+
+    std::vector<MapScript> beforeSection = _map->getMapFile().map_scripts[section];
+    const uint32_t beforeOid = object->unknown0;
+    const int32_t beforeSid = object->map_scripts_pid;
+
+    removeObjectScript(*object);
+
+    return recordScriptEdit("Detach Script", section, object, std::move(beforeSection), beforeOid, beforeSid);
+}
+
+bool ObjectCommandController::addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius) {
+    if (!_map) {
+        return false;
+    }
+    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    auto& mapFile = _map->getMapFile();
+
+    std::vector<MapScript> beforeSection = mapFile.map_scripts[section];
+
+    const uint32_t scriptId = allocateScriptId(section);
+    const uint32_t oid = allocateObjectId();
+    MapScript script = MapScript::makeSpatialScript(scriptId, programIndex,
+        static_cast<uint32_t>(tile), static_cast<uint32_t>(elevation), static_cast<uint32_t>(radius), oid);
+    mapFile.map_scripts[section].push_back(script);
+    mapFile.scripts_in_section[section] = static_cast<int>(mapFile.map_scripts[section].size());
+
+    return recordScriptEdit("Add Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
+}
+
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {
     _undoStack.push(std::move(cmd));
     if (_onStackChanged) {

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -28,7 +28,8 @@ ObjectCommandController::ObjectCommandController(resource::GameResources& resour
     std::function<void()> onStackChanged,
     std::function<std::vector<Tile>&(int)> ensureElevationTiles,
     std::function<int()> getCurrentElevation,
-    std::function<void(int, bool, int)> updateTileSprite)
+    std::function<void(int, bool, int)> updateTileSprite,
+    std::function<void()> reloadTiles)
     : _resources(resources)
     , _map(map)
     , _hexgrid(hexgrid)
@@ -40,7 +41,8 @@ ObjectCommandController::ObjectCommandController(resource::GameResources& resour
     , _onStackChanged(std::move(onStackChanged))
     , _ensureElevationTiles(std::move(ensureElevationTiles))
     , _getCurrentElevation(std::move(getCurrentElevation))
-    , _updateTileSprite(std::move(updateTileSprite)) {
+    , _updateTileSprite(std::move(updateTileSprite))
+    , _reloadTiles(std::move(reloadTiles)) {
 }
 
 void ObjectCommandController::applyTileChanges(const std::vector<TileChange>& changes, bool applyAfterState) {
@@ -468,6 +470,140 @@ bool ObjectCommandController::registerInstanceEdit(const std::shared_ptr<MapObje
         _refreshObjects();
     };
 
+    cmd.redo();
+    return pushCommand(std::move(cmd));
+}
+
+std::vector<std::shared_ptr<MapObject>> ObjectCommandController::cloneInventory(
+    const std::vector<std::unique_ptr<MapObject>>& inventory) {
+    std::vector<std::shared_ptr<MapObject>> out;
+    out.reserve(inventory.size());
+    for (const auto& item : inventory) {
+        if (item) {
+            out.push_back(std::shared_ptr<MapObject>(item->cloneDeep()));
+        }
+    }
+    return out;
+}
+
+namespace {
+    void restoreInventory(MapObject& container, const std::vector<std::shared_ptr<MapObject>>& snapshot) {
+        container.inventory.clear();
+        container.inventory.reserve(snapshot.size());
+        for (const auto& item : snapshot) {
+            if (item) {
+                container.inventory.push_back(item->cloneDeep());
+            }
+        }
+        container.objects_in_inventory = static_cast<uint32_t>(container.inventory.size());
+    }
+} // namespace
+
+bool ObjectCommandController::registerInventoryEdit(const std::shared_ptr<MapObject>& container,
+    std::vector<std::shared_ptr<MapObject>> before,
+    std::vector<std::shared_ptr<MapObject>> after) {
+    if (!container) {
+        return false;
+    }
+
+    UndoCommand cmd;
+    cmd.description = "Edit Inventory";
+    cmd.undo = [container, before]() { restoreInventory(*container, before); };
+    cmd.redo = [container, after]() { restoreInventory(*container, after); };
+    // The caller already applied the edit, so do not run redo() here.
+    return pushCommand(std::move(cmd));
+}
+
+bool ObjectCommandController::clearElevationObjects(int elevation) {
+    if (!_map) {
+        return false;
+    }
+    auto& mapFile = _map->getMapFile();
+    auto it = mapFile.map_objects.find(elevation);
+    if (it == mapFile.map_objects.end() || it->second.empty()) {
+        return false;
+    }
+
+    // shared_ptr copy keeps the removed objects alive in the command for undo.
+    std::vector<std::shared_ptr<MapObject>> before = it->second;
+    std::vector<std::shared_ptr<MapObject>> after; // empty
+
+    UndoCommand cmd;
+    cmd.description = "Clear Elevation Objects";
+    cmd.undo = [this, elevation, before]() {
+        _map->getMapFile().map_objects[elevation] = before;
+        _refreshObjects();
+    };
+    cmd.redo = [this, elevation, after]() {
+        _map->getMapFile().map_objects[elevation] = after;
+        _refreshObjects();
+    };
+    cmd.redo();
+    return pushCommand(std::move(cmd));
+}
+
+bool ObjectCommandController::copyElevation(int fromElevation, int toElevation) {
+    if (!_map || fromElevation == toElevation) {
+        return false;
+    }
+    auto& mapFile = _map->getMapFile();
+
+    // Destination "before": share ownership of existing objects + copy its tiles.
+    std::vector<std::shared_ptr<MapObject>> beforeObjects;
+    if (auto it = mapFile.map_objects.find(toElevation); it != mapFile.map_objects.end()) {
+        beforeObjects = it->second;
+    }
+    std::vector<Tile> beforeTiles;
+    bool haveBeforeTiles = false;
+    if (auto it = mapFile.tiles.find(toElevation); it != mapFile.tiles.end()) {
+        beforeTiles = it->second;
+        haveBeforeTiles = true;
+    }
+
+    // Destination "after": deep-cloned source objects (retargeted) + source tiles.
+    std::vector<std::shared_ptr<MapObject>> afterObjects;
+    if (auto it = mapFile.map_objects.find(fromElevation); it != mapFile.map_objects.end()) {
+        afterObjects.reserve(it->second.size());
+        for (const auto& o : it->second) {
+            if (!o) {
+                continue;
+            }
+            auto clone = std::shared_ptr<MapObject>(o->cloneDeep());
+            clone->elevation = static_cast<uint32_t>(toElevation);
+            afterObjects.push_back(std::move(clone));
+        }
+    }
+    std::vector<Tile> afterTiles;
+    bool haveAfterTiles = false;
+    if (auto it = mapFile.tiles.find(fromElevation); it != mapFile.tiles.end()) {
+        afterTiles = it->second;
+        haveAfterTiles = true;
+    }
+
+    UndoCommand cmd;
+    cmd.description = "Copy Elevation";
+    cmd.undo = [this, toElevation, beforeObjects, beforeTiles, haveBeforeTiles]() {
+        auto& mf = _map->getMapFile();
+        mf.map_objects[toElevation] = beforeObjects;
+        if (haveBeforeTiles) {
+            mf.tiles[toElevation] = beforeTiles;
+        }
+        _refreshObjects();
+        if (_reloadTiles) {
+            _reloadTiles();
+        }
+    };
+    cmd.redo = [this, toElevation, afterObjects, afterTiles, haveAfterTiles]() {
+        auto& mf = _map->getMapFile();
+        mf.map_objects[toElevation] = afterObjects;
+        if (haveAfterTiles) {
+            mf.tiles[toElevation] = afterTiles;
+        }
+        _refreshObjects();
+        if (_reloadTiles) {
+            _reloadTiles();
+        }
+    };
     cmd.redo();
     return pushCommand(std::move(cmd));
 }

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -412,6 +412,66 @@ bool ObjectCommandController::registerExitGridEdit(const std::vector<std::shared
     return pushCommand(std::move(cmd));
 }
 
+MapObjectInstanceState ObjectCommandController::captureInstanceState(const MapObject& o) {
+    MapObjectInstanceState s;
+    s.flags = o.flags;
+    s.dataFlags = o.unknown11;
+    s.lightRadius = o.light_radius;
+    s.lightIntensity = o.light_intensity;
+    s.walkthrough = o.walkthrough;
+    s.map = o.map;
+    s.elevhex = o.elevhex;
+    s.elevtype = o.elevtype;
+    s.elevlevel = o.elevlevel;
+    s.aiPacket = o.ai_packet;
+    s.groupId = o.group_id;
+    s.currentHp = o.current_hp;
+    s.currentRad = o.current_rad;
+    s.currentPoison = o.current_poison;
+    return s;
+}
+
+void ObjectCommandController::applyInstanceState(MapObject& o, const MapObjectInstanceState& s) {
+    o.flags = s.flags;
+    o.unknown11 = s.dataFlags;
+    o.light_radius = s.lightRadius;
+    o.light_intensity = s.lightIntensity;
+    o.walkthrough = s.walkthrough;
+    o.map = s.map;
+    o.elevhex = s.elevhex;
+    o.elevtype = s.elevtype;
+    o.elevlevel = s.elevlevel;
+    o.ai_packet = s.aiPacket;
+    o.group_id = s.groupId;
+    o.current_hp = s.currentHp;
+    o.current_rad = s.currentRad;
+    o.current_poison = s.currentPoison;
+}
+
+bool ObjectCommandController::registerInstanceEdit(const std::shared_ptr<MapObject>& mapObject,
+    const MapObjectInstanceState& before,
+    const MapObjectInstanceState& after,
+    const std::string& description) {
+    if (!mapObject) {
+        spdlog::warn("registerInstanceEdit: null mapObject");
+        return false;
+    }
+
+    UndoCommand cmd;
+    cmd.description = description;
+    cmd.undo = [this, mapObject, before]() {
+        applyInstanceState(*mapObject, before);
+        _refreshObjects();
+    };
+    cmd.redo = [this, mapObject, after]() {
+        applyInstanceState(*mapObject, after);
+        _refreshObjects();
+    };
+
+    cmd.redo();
+    return pushCommand(std::move(cmd));
+}
+
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {
     _undoStack.push(std::move(cmd));
     if (_onStackChanged) {

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -508,8 +508,8 @@ bool ObjectCommandController::registerInventoryEdit(const std::shared_ptr<MapObj
 
     UndoCommand cmd;
     cmd.description = "Edit Inventory";
-    cmd.undo = [container, before]() { restoreInventory(*container, before); };
-    cmd.redo = [container, after]() { restoreInventory(*container, after); };
+    cmd.undo = [container, before = std::move(before)]() { restoreInventory(*container, before); };
+    cmd.redo = [container, after = std::move(after)]() { restoreInventory(*container, after); };
     // The caller already applied the edit, so do not run redo() here.
     return pushCommand(std::move(cmd));
 }
@@ -685,9 +685,7 @@ void ObjectCommandController::eraseScript(uint32_t sid) {
         return;
     }
     auto& vec = _map->getMapFile().map_scripts[section];
-    vec.erase(std::remove_if(vec.begin(), vec.end(),
-                  [sid](const MapScript& s) { return s.pid == sid; }),
-        vec.end());
+    std::erase_if(vec, [sid](const MapScript& s) { return s.pid == sid; });
     _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
 }
 
@@ -726,10 +724,10 @@ bool ObjectCommandController::recordScriptEdit(const std::string& description, i
 
     UndoCommand cmd;
     cmd.description = description;
-    cmd.undo = [this, section, object, beforeSection, beforeOid, beforeSid]() {
+    cmd.undo = [this, section, object, beforeSection = std::move(beforeSection), beforeOid, beforeSid]() {
         applyScriptSnapshot(section, object, beforeSection, beforeOid, beforeSid);
     };
-    cmd.redo = [this, section, object, afterSection, afterOid, afterSid]() {
+    cmd.redo = [this, section, object, afterSection = std::move(afterSection), afterOid, afterSid]() {
         applyScriptSnapshot(section, object, afterSection, afterOid, afterSid);
     };
     return pushCommand(std::move(cmd));

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -34,11 +34,8 @@ struct ExitGridCommandState {
     uint32_t proPid;
 };
 
-/// Snapshot of the per-instance, UI-editable fields of a MapObject. The unified
-/// instance-edit undo command (registerInstanceEdit) uses this so the flag,
-/// light, scenery-destination and critter editors all share one code path. Every
-/// field here already round-trips through the .map format, so editing them is a
-/// purely in-memory change with no serialization impact.
+/// Snapshot of a MapObject's UI-editable per-instance fields, shared by the
+/// flag/light/destination/interaction/critter editors via registerInstanceEdit.
 struct MapObjectInstanceState {
     uint32_t flags = 0;
     uint32_t dataFlags = 0; // MapObject.unknown11 == engine obj->data.flags (container lock/jam)

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -66,7 +66,8 @@ public:
         std::function<void()> onStackChanged,
         std::function<std::vector<Tile>&(int)> ensureElevationTiles,
         std::function<int()> getCurrentElevation,
-        std::function<void(int, bool, int)> updateTileSprite);
+        std::function<void(int, bool, int)> updateTileSprite,
+        std::function<void()> reloadTiles);
 
     void addPlacedObject(const std::shared_ptr<MapObject>& mapObject, const std::shared_ptr<Object>& object);
     void removePlacedObject(const std::shared_ptr<MapObject>& mapObject, const std::shared_ptr<Object>& object);
@@ -102,6 +103,24 @@ public:
     /// Records an undoable tile edit (the change was already applied by the caller).
     void registerTileEdit(const std::string& description, const std::vector<TileChange>& changes);
 
+    /// Deep-clones a container/critter inventory into a detached snapshot (the
+    /// inventory holds unique_ptrs, so a snapshot must clone).
+    static std::vector<std::shared_ptr<MapObject>> cloneInventory(
+        const std::vector<std::unique_ptr<MapObject>>& inventory);
+
+    /// Records an undoable inventory change. The caller has already applied the
+    /// edit; `before`/`after` are cloneInventory() snapshots taken around it.
+    bool registerInventoryEdit(const std::shared_ptr<MapObject>& container,
+        std::vector<std::shared_ptr<MapObject>> before,
+        std::vector<std::shared_ptr<MapObject>> after);
+
+    /// Deletes every object on an elevation as one undoable command. Returns false
+    /// if the elevation has no objects.
+    bool clearElevationObjects(int elevation);
+    /// Copies tiles + objects (deep-cloned) from one elevation to another as one
+    /// undoable command, overwriting the destination.
+    bool copyElevation(int fromElevation, int toElevation);
+
 private:
     static void applyInstanceState(MapObject& object, const MapObjectInstanceState& state);
 
@@ -117,6 +136,7 @@ private:
     std::function<std::vector<Tile>&(int)> _ensureElevationTiles;
     std::function<int()> _getCurrentElevation;
     std::function<void(int, bool, int)> _updateTileSprite;
+    std::function<void()> _reloadTiles;
 };
 
 } // namespace geck

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics.hpp>
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -119,7 +120,8 @@ public:
     /// if the elevation has no objects.
     bool clearElevationObjects(int elevation);
     /// Copies tiles + objects (deep-cloned) from one elevation to another as one
-    /// undoable command, overwriting the destination.
+    /// undoable command, overwriting the destination. Scripts are not copied; the
+    /// cloned objects are detached from any source scripts.
     bool copyElevation(int fromElevation, int toElevation);
 
     // Script attachment (undoable). `scriptType` is the MapScript section/type
@@ -130,6 +132,20 @@ public:
     bool addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
 
 private:
+    // Number of map_scripts sections; mirrors Map::SCRIPT_SECTIONS (asserted in .cpp).
+    static constexpr int SCRIPT_SECTIONS = 5;
+
+    /// Snapshot of all map_scripts sections and their counts, for undoing bulk
+    /// edits that touch scripts across sections (e.g. clearing an elevation).
+    struct ScriptSections {
+        std::array<std::vector<MapScript>, SCRIPT_SECTIONS> sections;
+        std::array<int, SCRIPT_SECTIONS> counts{};
+    };
+
+    ScriptSections snapshotScripts() const;
+    void restoreScripts(const ScriptSections& snapshot);
+    /// Removes the script whose pid == sid from its section, updating the count.
+    void eraseScript(uint32_t sid);
     uint32_t allocateScriptId(int section) const;
     uint32_t allocateObjectId() const;
     void removeObjectScript(MapObject& object);

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -34,6 +34,28 @@ struct ExitGridCommandState {
     uint32_t proPid;
 };
 
+/// Snapshot of the per-instance, UI-editable fields of a MapObject. The unified
+/// instance-edit undo command (registerInstanceEdit) uses this so the flag,
+/// light, scenery-destination and critter editors all share one code path. Every
+/// field here already round-trips through the .map format, so editing them is a
+/// purely in-memory change with no serialization impact.
+struct MapObjectInstanceState {
+    uint32_t flags = 0;
+    uint32_t dataFlags = 0; // MapObject.unknown11 == engine obj->data.flags (container lock/jam)
+    uint32_t lightRadius = 0;
+    uint32_t lightIntensity = 0;
+    uint32_t walkthrough = 0; // doors: engine obj->data.scenery.door.openFlags (lock/jam)
+    uint32_t map = 0;
+    uint32_t elevhex = 0;
+    uint32_t elevtype = 0;
+    uint32_t elevlevel = 0;
+    uint32_t aiPacket = 0;
+    uint32_t groupId = 0;
+    uint32_t currentHp = 0;
+    uint32_t currentRad = 0;
+    uint32_t currentPoison = 0;
+};
+
 class ObjectCommandController {
 public:
     ObjectCommandController(resource::GameResources& resources,
@@ -67,12 +89,25 @@ public:
         const std::vector<ExitGridCommandState>& beforeStates,
         const std::vector<ExitGridCommandState>& afterStates);
 
+    /// Captures the editable per-instance fields of a MapObject.
+    static MapObjectInstanceState captureInstanceState(const MapObject& object);
+
+    /// Records an undoable change to a single object's per-instance fields. The
+    /// after-state is applied immediately (redo); objects are refreshed so light
+    /// overlays and flag-derived visuals update.
+    bool registerInstanceEdit(const std::shared_ptr<MapObject>& mapObject,
+        const MapObjectInstanceState& before,
+        const MapObjectInstanceState& after,
+        const std::string& description);
+
     /// Applies the before/after state of tile edits and refreshes affected sprites.
     void applyTileChanges(const std::vector<TileChange>& changes, bool applyAfterState);
     /// Records an undoable tile edit (the change was already applied by the caller).
     void registerTileEdit(const std::string& description, const std::vector<TileChange>& changes);
 
 private:
+    static void applyInstanceState(MapObject& object, const MapObjectInstanceState& state);
+
     resource::GameResources& _resources;
     std::unique_ptr<Map>& _map;
     const HexagonGrid& _hexgrid;

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "util/UndoStack.h"
+#include "format/map/MapScript.h"
 
 namespace geck {
 
@@ -121,7 +122,23 @@ public:
     /// undoable command, overwriting the destination.
     bool copyElevation(int fromElevation, int toElevation);
 
+    // Script attachment (undoable). `scriptType` is the MapScript section/type
+    // (ITEM for items/scenery/walls, CRITTER for critters); `programIndex` is the
+    // scripts.lst line. attachScript replaces any existing script on the object.
+    bool attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex);
+    bool detachScript(const std::shared_ptr<MapObject>& object);
+    bool addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
+
 private:
+    uint32_t allocateScriptId(int section) const;
+    uint32_t allocateObjectId() const;
+    void removeObjectScript(MapObject& object);
+    void applyScriptSnapshot(int section, const std::shared_ptr<MapObject>& object,
+        const std::vector<MapScript>& sectionScripts, uint32_t oid, int32_t sid);
+    bool recordScriptEdit(const std::string& description, int section,
+        const std::shared_ptr<MapObject>& object,
+        std::vector<MapScript> beforeSection, uint32_t beforeOid, int32_t beforeSid);
+
     static void applyInstanceState(MapObject& object, const MapObjectInstanceState& state);
 
     resource::GameResources& _resources;

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -875,43 +875,9 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
         return;
     }
 
-    auto& mapFile = _map->getMapFile();
-    const int spatialSection = static_cast<int>(MapScript::ScriptType::SPATIAL);
-
-    // Next free script id within the spatial pool.
-    uint32_t scriptId = 0;
-    for (const auto& s : mapFile.map_scripts[spatialSection]) {
-        scriptId = std::max(scriptId, MapScript::sidIndex(s.pid) + 1);
-    }
-
-    // A fresh owner OID. The engine ignores it for spatial scripts, but keeping
-    // it unique avoids clashes with object OIDs.
-    uint32_t oid = 0;
-    for (const auto& [elevation, objects] : mapFile.map_objects) {
-        for (const auto& obj : objects) {
-            if (obj) {
-                oid = std::max(oid, obj->unknown0);
-            }
-        }
-    }
-    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
-        for (const auto& s : mapFile.map_scripts[section]) {
-            oid = std::max(oid, s.script_oid);
-        }
-    }
-    ++oid;
-
-    MapScript script = MapScript::makeSpatialScript(scriptId,
-        static_cast<uint32_t>(dialog.programIndex()),
-        static_cast<uint32_t>(dialog.tile()),
-        static_cast<uint32_t>(dialog.elevation()),
-        static_cast<uint32_t>(dialog.radius()), oid);
-
-    mapFile.map_scripts[spatialSection].push_back(script);
-    mapFile.scripts_in_section[spatialSection] = static_cast<int>(mapFile.map_scripts[spatialSection].size());
-
-    spdlog::info("MapInfoPanel: Added spatial script {} at tile {} elev {} radius {}",
-        dialog.programIndex(), dialog.tile(), dialog.elevation(), dialog.radius());
+    // Direct (synchronous) connection: the script is created before this returns.
+    Q_EMIT addSpatialScriptRequested(dialog.programIndex(), dialog.tile(),
+        dialog.elevation(), dialog.radius());
     updateMapScriptsDisplay();
 }
 

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -806,7 +806,7 @@ void MapInfoPanel::onClearElevationClicked() {
     }
 
     const auto reply = QMessageBox::question(this, "Clear Elevation",
-        QString("Delete all %1 object(s) on Elevation %2?\n\nThis cannot be undone.")
+        QString("Delete all %1 object(s) on Elevation %2?")
             .arg(count)
             .arg(elevation + 1),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
@@ -814,9 +814,7 @@ void MapInfoPanel::onClearElevationClicked() {
         return;
     }
 
-    it->second.clear();
-    spdlog::info("MapInfoPanel: Cleared {} object(s) on elevation {}", count, elevation);
-    Q_EMIT mapContentChanged(elevation);
+    Q_EMIT clearElevationRequested(elevation);
 }
 
 void MapInfoPanel::onCopyElevationClicked() {
@@ -849,7 +847,7 @@ void MapInfoPanel::onCopyElevationClicked() {
     const size_t dstObjs = mapFile.map_objects.count(to) ? mapFile.map_objects.at(to).size() : 0;
     const auto reply = QMessageBox::question(this, "Copy Elevation",
         QString("Copy tiles and objects from Elevation %1 to Elevation %2?\n\n"
-                "This overwrites Elevation %2 (%3 existing object(s)) and cannot be undone.")
+                "This overwrites Elevation %2 (%3 existing object(s)).")
             .arg(from + 1)
             .arg(to + 1)
             .arg(dstObjs),
@@ -858,30 +856,7 @@ void MapInfoPanel::onCopyElevationClicked() {
         return;
     }
 
-    // Tiles (Tile is copyable).
-    auto tileIt = mapFile.tiles.find(from);
-    if (tileIt != mapFile.tiles.end()) {
-        mapFile.tiles[to] = tileIt->second;
-    }
-
-    // Objects: deep-clone each and retarget the clone's elevation.
-    auto& dst = mapFile.map_objects[to];
-    dst.clear();
-    auto srcIt = mapFile.map_objects.find(from);
-    if (srcIt != mapFile.map_objects.end()) {
-        dst.reserve(srcIt->second.size());
-        for (const auto& obj : srcIt->second) {
-            if (!obj) {
-                continue;
-            }
-            auto clone = obj->cloneDeep();
-            clone->elevation = static_cast<uint32_t>(to);
-            dst.push_back(std::shared_ptr<MapObject>(std::move(clone)));
-        }
-    }
-
-    spdlog::info("MapInfoPanel: Copied elevation {} to {} ({} object(s))", from, to, dst.size());
-    Q_EMIT mapContentChanged(to);
+    Q_EMIT copyElevationRequested(from, to);
 }
 
 void MapInfoPanel::onAddSpatialScriptClicked() {

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -787,8 +787,8 @@ void MapInfoPanel::onElevationCheckboxChanged() {
     }
 }
 
-// Bulk map operations mutate the model directly and (like elevation add/remove
-// above) are confirmed rather than undoable.
+// Bulk map operations confirm with the user, then emit a request the editor
+// routes through ObjectCommandController so they are recorded as one undoable command.
 void MapInfoPanel::onClearElevationClicked() {
     if (!_map) {
         return;

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -11,6 +11,8 @@
 #include <filesystem>
 
 #include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
 #include "format/gam/Gam.h"
 #include "format/lst/Lst.h"
 #include "resource/GameResources.h"
@@ -18,6 +20,7 @@
 #include "util/ResourcePaths.h"
 #include "util/Coordinates.h"
 #include "ui/IconHelper.h"
+#include "ui/dialogs/SpatialScriptDialog.h"
 
 namespace geck {
 
@@ -49,6 +52,10 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     , _globalVarsTree(nullptr)
     , _mapScriptsGroup(nullptr)
     , _mapScriptsLabel(nullptr)
+    , _mapOperationsGroup(nullptr)
+    , _clearElevationCombo(nullptr)
+    , _copyFromCombo(nullptr)
+    , _copyToCombo(nullptr)
     , _resources(resources)
     , _map(nullptr)
     , _mapScriptName("no script") {
@@ -205,6 +212,48 @@ void MapInfoPanel::setupUI() {
     scriptsLayout->addWidget(_mapScriptsLabel);
 
     _contentLayout->addWidget(_mapScriptsGroup);
+
+    // === Map Operations group (clear / copy elevation) ===
+    _mapOperationsGroup = new QGroupBox("Map Operations");
+    QFormLayout* opsLayout = new QFormLayout(_mapOperationsGroup);
+
+    auto makeElevationCombo = []() {
+        auto* combo = new QComboBox();
+        combo->addItem("Elevation 1", ELEVATION_1);
+        combo->addItem("Elevation 2", ELEVATION_2);
+        combo->addItem("Elevation 3", ELEVATION_3);
+        return combo;
+    };
+
+    QHBoxLayout* clearRow = new QHBoxLayout();
+    _clearElevationCombo = makeElevationCombo();
+    auto* clearButton = new QPushButton("Clear Objects");
+    clearButton->setToolTip("Delete every object on the chosen elevation (tiles are kept).");
+    clearRow->addWidget(_clearElevationCombo, 1);
+    clearRow->addWidget(clearButton);
+    opsLayout->addRow("Clear:", clearRow);
+
+    QHBoxLayout* copyRow = new QHBoxLayout();
+    _copyFromCombo = makeElevationCombo();
+    _copyToCombo = makeElevationCombo();
+    _copyToCombo->setCurrentIndex(1);
+    auto* copyButton = new QPushButton("Copy");
+    copyButton->setToolTip("Copy tiles and objects from one elevation to another (overwrites the destination).");
+    copyRow->addWidget(_copyFromCombo, 1);
+    copyRow->addWidget(new QLabel("to"));
+    copyRow->addWidget(_copyToCombo, 1);
+    copyRow->addWidget(copyButton);
+    opsLayout->addRow("Copy:", copyRow);
+
+    auto* spatialScriptButton = new QPushButton("Add Spatial Script...");
+    spatialScriptButton->setToolTip("Place a spatial (hex trigger-zone) script at a tile with a radius.");
+    opsLayout->addRow("Scripts:", spatialScriptButton);
+
+    connect(clearButton, &QPushButton::clicked, this, &MapInfoPanel::onClearElevationClicked);
+    connect(copyButton, &QPushButton::clicked, this, &MapInfoPanel::onCopyElevationClicked);
+    connect(spatialScriptButton, &QPushButton::clicked, this, &MapInfoPanel::onAddSpatialScriptClicked);
+
+    _contentLayout->addWidget(_mapOperationsGroup);
 
     _contentLayout->addStretch();
 
@@ -736,6 +785,177 @@ void MapInfoPanel::onElevationCheckboxChanged() {
             spdlog::debug("MapInfoPanel: Elevation removal cancelled by user");
         }
     }
+}
+
+// Bulk map operations mutate the model directly and (like elevation add/remove
+// above) are confirmed rather than undoable.
+void MapInfoPanel::onClearElevationClicked() {
+    if (!_map) {
+        return;
+    }
+
+    const int elevation = _clearElevationCombo->currentData().toInt();
+    auto& mapFile = _map->getMapFile();
+
+    auto it = mapFile.map_objects.find(elevation);
+    const size_t count = (it != mapFile.map_objects.end()) ? it->second.size() : 0;
+    if (count == 0) {
+        QMessageBox::information(this, "Clear Elevation",
+            QString("Elevation %1 has no objects to clear.").arg(elevation + 1));
+        return;
+    }
+
+    const auto reply = QMessageBox::question(this, "Clear Elevation",
+        QString("Delete all %1 object(s) on Elevation %2?\n\nThis cannot be undone.")
+            .arg(count)
+            .arg(elevation + 1),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    it->second.clear();
+    spdlog::info("MapInfoPanel: Cleared {} object(s) on elevation {}", count, elevation);
+    Q_EMIT mapContentChanged(elevation);
+}
+
+void MapInfoPanel::onCopyElevationClicked() {
+    if (!_map) {
+        return;
+    }
+
+    const int from = _copyFromCombo->currentData().toInt();
+    const int to = _copyToCombo->currentData().toInt();
+    if (from == to) {
+        QMessageBox::information(this, "Copy Elevation",
+            "Source and destination elevations are the same.");
+        return;
+    }
+
+    auto& mapFile = _map->getMapFile();
+
+    // Both elevations must be enabled (present) for a meaningful, saveable copy.
+    if (!Map::elevationIsPresent(mapFile.header.flags, from)) {
+        QMessageBox::warning(this, "Copy Elevation",
+            QString("Source Elevation %1 is not enabled.").arg(from + 1));
+        return;
+    }
+    if (!Map::elevationIsPresent(mapFile.header.flags, to)) {
+        QMessageBox::warning(this, "Copy Elevation",
+            QString("Destination Elevation %1 is not enabled. Enable it first.").arg(to + 1));
+        return;
+    }
+
+    const size_t dstObjs = mapFile.map_objects.count(to) ? mapFile.map_objects.at(to).size() : 0;
+    const auto reply = QMessageBox::question(this, "Copy Elevation",
+        QString("Copy tiles and objects from Elevation %1 to Elevation %2?\n\n"
+                "This overwrites Elevation %2 (%3 existing object(s)) and cannot be undone.")
+            .arg(from + 1)
+            .arg(to + 1)
+            .arg(dstObjs),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    // Tiles (Tile is copyable).
+    auto tileIt = mapFile.tiles.find(from);
+    if (tileIt != mapFile.tiles.end()) {
+        mapFile.tiles[to] = tileIt->second;
+    }
+
+    // Objects: deep-clone each and retarget the clone's elevation.
+    auto& dst = mapFile.map_objects[to];
+    dst.clear();
+    auto srcIt = mapFile.map_objects.find(from);
+    if (srcIt != mapFile.map_objects.end()) {
+        dst.reserve(srcIt->second.size());
+        for (const auto& obj : srcIt->second) {
+            if (!obj) {
+                continue;
+            }
+            auto clone = obj->cloneDeep();
+            clone->elevation = static_cast<uint32_t>(to);
+            dst.push_back(std::shared_ptr<MapObject>(std::move(clone)));
+        }
+    }
+
+    spdlog::info("MapInfoPanel: Copied elevation {} to {} ({} object(s))", from, to, dst.size());
+    Q_EMIT mapContentChanged(to);
+}
+
+void MapInfoPanel::onAddSpatialScriptClicked() {
+    if (!_map) {
+        return;
+    }
+
+    auto* scriptsLst = _resources.repository().load<Lst>(std::string(ResourcePaths::Lst::SCRIPTS));
+    if (!scriptsLst) {
+        QMessageBox::warning(this, "Add Spatial Script", "Could not load scripts.lst.");
+        return;
+    }
+
+    SpatialScriptDialog dialog(scriptsLst->list(), this);
+    if (dialog.exec() != QDialog::Accepted || dialog.programIndex() < 0) {
+        return;
+    }
+
+    auto& mapFile = _map->getMapFile();
+
+    // SPATIAL is section index 1 (engine SCRIPT_TYPE_SPATIAL).
+    constexpr int SPATIAL_SECTION = 1;
+
+    // Allocate the next free script id within the spatial pool.
+    uint32_t scriptId = 0;
+    {
+        bool any = false;
+        for (const auto& s : mapFile.map_scripts[SPATIAL_SECTION]) {
+            uint32_t id = s.pid & 0x00FFFFFF;
+            scriptId = any ? std::max(scriptId, id) : id;
+            any = true;
+        }
+        scriptId = any ? scriptId + 1 : 0;
+    }
+
+    // Allocate a fresh owner OID (unused by the engine for spatial scripts, but
+    // kept unique to avoid clashes with object OIDs).
+    uint32_t oid = 0;
+    for (const auto& [elevation, objects] : mapFile.map_objects) {
+        for (const auto& obj : objects) {
+            if (obj) {
+                oid = std::max(oid, obj->unknown0);
+            }
+        }
+    }
+    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+        for (const auto& s : mapFile.map_scripts[section]) {
+            oid = std::max(oid, s.script_oid);
+        }
+    }
+    ++oid;
+
+    const int tile = dialog.tile();
+    const int elevation = dialog.elevation();
+    // Engine built-tile packing: tile in the low bits, elevation in bits 29-31.
+    const uint32_t builtTile = (static_cast<uint32_t>(tile) & 0x3FFFFFF)
+        | ((static_cast<uint32_t>(elevation) << 29) & 0xE0000000);
+
+    MapScript script{};
+    script.pid = (static_cast<uint32_t>(SPATIAL_SECTION) << 24) | scriptId;
+    script.timer = builtTile;                                    // SPATIAL: built_tile
+    script.spatial_radius = static_cast<uint32_t>(dialog.radius());
+    script.script_id = static_cast<uint32_t>(dialog.programIndex());
+    script.script_oid = oid;
+    script.local_var_offset = 0xFFFFFFFF; // -1, matches scriptAdd
+    script.local_var_count = 0;
+    script.unknown12 = 0xFFFFFFFF; // actionBeingUsed == -1
+
+    mapFile.map_scripts[SPATIAL_SECTION].push_back(script);
+    mapFile.scripts_in_section[SPATIAL_SECTION] = static_cast<int>(mapFile.map_scripts[SPATIAL_SECTION].size());
+
+    spdlog::info("MapInfoPanel: Added spatial script {} at tile {} elev {} radius {}",
+        dialog.programIndex(), tile, elevation, dialog.radius());
+    updateMapScriptsDisplay();
 }
 
 } // namespace geck

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -901,24 +901,16 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
     }
 
     auto& mapFile = _map->getMapFile();
+    const int spatialSection = static_cast<int>(MapScript::ScriptType::SPATIAL);
 
-    // SPATIAL is section index 1 (engine SCRIPT_TYPE_SPATIAL).
-    constexpr int SPATIAL_SECTION = 1;
-
-    // Allocate the next free script id within the spatial pool.
+    // Next free script id within the spatial pool.
     uint32_t scriptId = 0;
-    {
-        bool any = false;
-        for (const auto& s : mapFile.map_scripts[SPATIAL_SECTION]) {
-            uint32_t id = s.pid & 0x00FFFFFF;
-            scriptId = any ? std::max(scriptId, id) : id;
-            any = true;
-        }
-        scriptId = any ? scriptId + 1 : 0;
+    for (const auto& s : mapFile.map_scripts[spatialSection]) {
+        scriptId = std::max(scriptId, MapScript::sidIndex(s.pid) + 1);
     }
 
-    // Allocate a fresh owner OID (unused by the engine for spatial scripts, but
-    // kept unique to avoid clashes with object OIDs).
+    // A fresh owner OID. The engine ignores it for spatial scripts, but keeping
+    // it unique avoids clashes with object OIDs.
     uint32_t oid = 0;
     for (const auto& [elevation, objects] : mapFile.map_objects) {
         for (const auto& obj : objects) {
@@ -934,27 +926,17 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
     }
     ++oid;
 
-    const int tile = dialog.tile();
-    const int elevation = dialog.elevation();
-    // Engine built-tile packing: tile in the low bits, elevation in bits 29-31.
-    const uint32_t builtTile = (static_cast<uint32_t>(tile) & 0x3FFFFFF)
-        | ((static_cast<uint32_t>(elevation) << 29) & 0xE0000000);
+    MapScript script = MapScript::makeSpatialScript(scriptId,
+        static_cast<uint32_t>(dialog.programIndex()),
+        static_cast<uint32_t>(dialog.tile()),
+        static_cast<uint32_t>(dialog.elevation()),
+        static_cast<uint32_t>(dialog.radius()), oid);
 
-    MapScript script{};
-    script.pid = (static_cast<uint32_t>(SPATIAL_SECTION) << 24) | scriptId;
-    script.timer = builtTile;                                    // SPATIAL: built_tile
-    script.spatial_radius = static_cast<uint32_t>(dialog.radius());
-    script.script_id = static_cast<uint32_t>(dialog.programIndex());
-    script.script_oid = oid;
-    script.local_var_offset = 0xFFFFFFFF; // -1, matches scriptAdd
-    script.local_var_count = 0;
-    script.unknown12 = 0xFFFFFFFF; // actionBeingUsed == -1
-
-    mapFile.map_scripts[SPATIAL_SECTION].push_back(script);
-    mapFile.scripts_in_section[SPATIAL_SECTION] = static_cast<int>(mapFile.map_scripts[SPATIAL_SECTION].size());
+    mapFile.map_scripts[spatialSection].push_back(script);
+    mapFile.scripts_in_section[spatialSection] = static_cast<int>(mapFile.map_scripts[spatialSection].size());
 
     spdlog::info("MapInfoPanel: Added spatial script {} at tile {} elev {} radius {}",
-        dialog.programIndex(), tile, elevation, dialog.radius());
+        dialog.programIndex(), dialog.tile(), dialog.elevation(), dialog.radius());
     updateMapScriptsDisplay();
 }
 

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -50,6 +50,7 @@ signals:
     /// are undoable. The confirmation dialog lives here in the panel.
     void clearElevationRequested(int elevation);
     void copyElevationRequested(int fromElevation, int toElevation);
+    void addSpatialScriptRequested(int programIndex, int tile, int elevation, int radius);
 
 private slots:
     void onFieldChanged();

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -46,6 +46,9 @@ signals:
     void timestampChanged(int timestamp);
     void elevationAdded(int elevation);
     void elevationRemoved(int elevation);
+    /// Emitted after a bulk map operation (clear/copy elevation) mutates the
+    /// model, so the editor can reload sprites for the affected elevation.
+    void mapContentChanged(int elevation);
 
 private slots:
     void onFieldChanged();
@@ -53,6 +56,9 @@ private slots:
     void onSelectPositionClicked();
     void onCenterViewClicked();
     void onElevationCheckboxChanged();
+    void onClearElevationClicked();
+    void onCopyElevationClicked();
+    void onAddSpatialScriptClicked();
 
 private:
     void setupUI();
@@ -95,6 +101,12 @@ private:
     // Map scripts group (placeholder)
     QGroupBox* _mapScriptsGroup;
     QLabel* _mapScriptsLabel;
+
+    // Map operations group (clear / copy elevation)
+    QGroupBox* _mapOperationsGroup;
+    QComboBox* _clearElevationCombo;
+    QComboBox* _copyFromCombo;
+    QComboBox* _copyToCombo;
 
     resource::GameResources& _resources;
     Map* _map;

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -46,9 +46,10 @@ signals:
     void timestampChanged(int timestamp);
     void elevationAdded(int elevation);
     void elevationRemoved(int elevation);
-    /// Emitted after a bulk map operation (clear/copy elevation) mutates the
-    /// model, so the editor can reload sprites for the affected elevation.
-    void mapContentChanged(int elevation);
+    /// Bulk map operations, routed to the editor's ObjectCommandController so they
+    /// are undoable. The confirmation dialog lives here in the panel.
+    void clearElevationRequested(int elevation);
+    void copyElevationRequested(int fromElevation, int toElevation);
 
 private slots:
     void onFieldChanged();

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1348,6 +1348,23 @@ MapObject* SelectionPanel::selectedInventoryHolder() const {
     return _selectedObject.value()->getMapObjectPtr().get();
 }
 
+void SelectionPanel::refresh() {
+    if (_selectedObject && _selectedObject.value()) {
+        updateObjectInfo();
+    }
+}
+
+void SelectionPanel::commitInventoryEdit(std::vector<std::shared_ptr<MapObject>> before) {
+    auto* holder = selectedInventoryHolder();
+    if (!holder) {
+        return;
+    }
+    auto after = ObjectCommandController::cloneInventory(holder->inventory);
+    populateInventoryTree();
+    Q_EMIT requestInventoryEdit(_selectedObject.value()->getMapObjectPtr(),
+        std::move(before), std::move(after));
+}
+
 void SelectionPanel::onAddInventoryClicked() {
     auto* holder = selectedInventoryHolder();
     if (!holder) {
@@ -1375,6 +1392,8 @@ void SelectionPanel::onAddInventoryClicked() {
         return;
     }
 
+    auto before = ObjectCommandController::cloneInventory(holder->inventory);
+
     auto item = std::make_unique<MapObject>();
     item->pro_pid = itemPid;
     item->frm_pid = pro->header.FID;
@@ -1385,7 +1404,7 @@ void SelectionPanel::onAddInventoryClicked() {
     holder->inventory.push_back(std::move(item));
     holder->objects_in_inventory = static_cast<uint32_t>(holder->inventory.size());
 
-    populateInventoryTree();
+    commitInventoryEdit(std::move(before));
 }
 
 void SelectionPanel::onRemoveInventoryClicked() {
@@ -1400,10 +1419,11 @@ void SelectionPanel::onRemoveInventoryClicked() {
         return;
     }
 
+    auto before = ObjectCommandController::cloneInventory(holder->inventory);
     holder->inventory.erase(holder->inventory.begin() + row);
     holder->objects_in_inventory = static_cast<uint32_t>(holder->inventory.size());
 
-    populateInventoryTree();
+    commitInventoryEdit(std::move(before));
 }
 
 void SelectionPanel::onInventoryItemChanged(QTreeWidgetItem* item, int column) {
@@ -1428,6 +1448,7 @@ void SelectionPanel::onInventoryItemChanged(QTreeWidgetItem* item, int column) {
         return;
     }
 
+    auto before = ObjectCommandController::cloneInventory(holder->inventory);
     holder->inventory[row]->amount = static_cast<uint32_t>(newAmount);
 
     // Refresh the icon to reflect the new quantity.
@@ -1440,6 +1461,10 @@ void SelectionPanel::onInventoryItemChanged(QTreeWidgetItem* item, int column) {
     icon.addPixmap(iconWithQuantity, QIcon::Normal, QIcon::Off);
     item->setIcon(COLUMN_ICON, icon);
     item->setSizeHint(COLUMN_ICON, QSize(ICON_SIZE, ICON_SIZE));
+
+    auto after = ObjectCommandController::cloneInventory(holder->inventory);
+    Q_EMIT requestInventoryEdit(_selectedObject.value()->getMapObjectPtr(),
+        std::move(before), std::move(after));
 }
 
 void SelectionPanel::resizeEvent(QResizeEvent* event) {

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1185,26 +1185,19 @@ void SelectionPanel::onEditCritterClicked() {
     Q_EMIT requestInstanceEdit(object, before, after, "Edit Critter Properties");
 }
 
-// --- F10: object-instance script attachment ---------------------------------
-// These mutate the map's script sections and the object's SID/OID directly
-// (the model is reachable via _map, like MapInfoPanel's operations). The wiring
-// mirrors the engine's objectSetScript: a new per-type script id, a fresh
-// object OID, and the chosen scripts.lst program index. Local-variable setup is
-// left to the engine at runtime (count 0 / offset -1, exactly as scriptAdd).
-// Script edits are not routed through the undo stack yet (tracked in PLAN.md).
+// Script attachment mutates the map's script sections and the object's SID/OID
+// directly (model reached via _map, like MapInfoPanel). Mirrors the engine's
+// objectSetScript. Not yet routed through the undo stack (tracked in PLAN.md).
 
 uint32_t SelectionPanel::allocateScriptId(int section) const {
     if (!_map || section < 0 || section >= Map::SCRIPT_SECTIONS) {
         return 0;
     }
-    uint32_t maxId = 0;
-    bool any = false;
+    uint32_t nextId = 0;
     for (const auto& s : _map->getMapFile().map_scripts[section]) {
-        uint32_t id = s.pid & 0x00FFFFFF;
-        maxId = any ? std::max(maxId, id) : id;
-        any = true;
+        nextId = std::max(nextId, MapScript::sidIndex(s.pid) + 1);
     }
-    return any ? maxId + 1 : 0;
+    return nextId;
 }
 
 uint32_t SelectionPanel::allocateObjectId() const {
@@ -1233,7 +1226,7 @@ void SelectionPanel::detachScriptInternal(MapObject& object) {
         return;
     }
     const uint32_t sid = static_cast<uint32_t>(object.map_scripts_pid);
-    const int section = static_cast<int>((sid >> 24) & 0xFF);
+    const int section = MapScript::sidSection(sid);
     if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
         auto& vec = _map->getMapFile().map_scripts[section];
         vec.erase(std::remove_if(vec.begin(), vec.end(),
@@ -1261,7 +1254,7 @@ void SelectionPanel::updateScriptSection() {
     QString text;
     if (attached) {
         const uint32_t sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
-        const int section = static_cast<int>((sid >> 24) & 0xFF);
+        const int section = MapScript::sidSection(sid);
         if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
             for (const auto& s : _map->getMapFile().map_scripts[section]) {
                 if (s.pid == sid) {
@@ -1308,27 +1301,24 @@ void SelectionPanel::onAttachScriptClicked() {
 
     const uint32_t objectType = mapObject->pro_pid >> 24;
     // Critters use the CRITTER section; items/scenery/walls use the ITEM section.
-    const int scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER)) ? 4 : 3;
+    const MapScript::ScriptType scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER))
+        ? MapScript::ScriptType::CRITTER
+        : MapScript::ScriptType::ITEM;
+    const int section = static_cast<int>(scriptType);
 
     // Re-attaching: drop any existing script first.
     detachScriptInternal(*mapObject);
 
     auto& mapFile = _map->getMapFile();
-    const uint32_t scriptId = allocateScriptId(scriptType);
     const uint32_t oid = allocateObjectId();
 
-    MapScript script{};
-    script.pid = (static_cast<uint32_t>(scriptType) << 24) | scriptId;
-    script.script_id = static_cast<uint32_t>(programIndex); // scripts.lst program index
-    script.script_oid = oid;                                // owner OID
-    script.local_var_offset = 0xFFFFFFFF;                   // -1, matches scriptAdd
-    script.local_var_count = 0;
-    script.unknown12 = 0xFFFFFFFF; // actionBeingUsed == -1 (engine scriptAdd default)
+    MapScript script = MapScript::makeObjectScript(scriptType, allocateScriptId(section),
+        static_cast<uint32_t>(programIndex), oid);
 
-    mapFile.map_scripts[scriptType].push_back(script);
-    mapFile.scripts_in_section[scriptType] = static_cast<int>(mapFile.map_scripts[scriptType].size());
+    mapFile.map_scripts[section].push_back(script);
+    mapFile.scripts_in_section[section] = static_cast<int>(mapFile.map_scripts[section].size());
 
-    mapObject->unknown0 = oid;                // object OID
+    mapObject->unknown0 = oid;                                     // object OID
     mapObject->map_scripts_pid = static_cast<int32_t>(script.pid); // SID
 
     updateScriptSection();

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -41,10 +41,10 @@
 
 namespace geck {
 
+using ui::inventory::COLUMN_AMOUNT;
 using ui::inventory::COLUMN_ICON;
 using ui::inventory::COLUMN_NAME;
 using ui::inventory::COLUMN_TYPE;
-using ui::inventory::COLUMN_AMOUNT;
 
 /// Spinbox-based delegate for editing the inventory amount column.
 class SelectionPanel::AmountDelegate : public QStyledItemDelegate {
@@ -1275,10 +1275,9 @@ void SelectionPanel::onDetachScriptClicked() {
     updateScriptSection();
 }
 
-// Inventory edits mutate the selected container/critter's MapObject inventory
-// directly and keep objects_in_inventory in sync so they persist on save. These
-// edits are not yet routed through the undo stack (the inventory's unique_ptr
-// ownership makes snapshotting awkward) - tracked in PLAN.md F14.
+// Returns the selected object's MapObject (the inventory holder). The inventory
+// section is only shown for container/critter types, so callers reach this only
+// for objects that can hold inventory; it does not re-check that here.
 MapObject* SelectionPanel::selectedInventoryHolder() const {
     if (!_selectedObject || !_selectedObject.value()) {
         return nullptr;

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1185,57 +1185,8 @@ void SelectionPanel::onEditCritterClicked() {
     Q_EMIT requestInstanceEdit(object, before, after, "Edit Critter Properties");
 }
 
-// Script attachment mutates the map's script sections and the object's SID/OID
-// directly (model reached via _map, like MapInfoPanel). Mirrors the engine's
-// objectSetScript. Not yet routed through the undo stack (tracked in PLAN.md).
-
-uint32_t SelectionPanel::allocateScriptId(int section) const {
-    if (!_map || section < 0 || section >= Map::SCRIPT_SECTIONS) {
-        return 0;
-    }
-    uint32_t nextId = 0;
-    for (const auto& s : _map->getMapFile().map_scripts[section]) {
-        nextId = std::max(nextId, MapScript::sidIndex(s.pid) + 1);
-    }
-    return nextId;
-}
-
-uint32_t SelectionPanel::allocateObjectId() const {
-    if (!_map) {
-        return 1;
-    }
-    uint32_t maxId = 0;
-    const auto& mapFile = _map->getMapFile();
-    for (const auto& [elevation, objects] : mapFile.map_objects) {
-        for (const auto& obj : objects) {
-            if (obj) {
-                maxId = std::max(maxId, obj->unknown0);
-            }
-        }
-    }
-    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
-        for (const auto& s : mapFile.map_scripts[section]) {
-            maxId = std::max(maxId, s.script_oid);
-        }
-    }
-    return maxId + 1;
-}
-
-void SelectionPanel::detachScriptInternal(MapObject& object) {
-    if (!_map || object.map_scripts_pid == -1) {
-        return;
-    }
-    const uint32_t sid = static_cast<uint32_t>(object.map_scripts_pid);
-    const int section = MapScript::sidSection(sid);
-    if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
-        auto& vec = _map->getMapFile().map_scripts[section];
-        vec.erase(std::remove_if(vec.begin(), vec.end(),
-                      [sid](const MapScript& s) { return s.pid == sid; }),
-            vec.end());
-        _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
-    }
-    object.map_scripts_pid = -1;
-}
+// Script attach/detach open the picker here, then route the change through the
+// editor's ObjectCommandController (via MainWindow) so it is undoable.
 
 void SelectionPanel::updateScriptSection() {
     if (!_scriptContainer) {
@@ -1301,26 +1252,13 @@ void SelectionPanel::onAttachScriptClicked() {
 
     const uint32_t objectType = mapObject->pro_pid >> 24;
     // Critters use the CRITTER section; items/scenery/walls use the ITEM section.
-    const MapScript::ScriptType scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER))
-        ? MapScript::ScriptType::CRITTER
-        : MapScript::ScriptType::ITEM;
-    const int section = static_cast<int>(scriptType);
+    const int scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER))
+        ? static_cast<int>(MapScript::ScriptType::CRITTER)
+        : static_cast<int>(MapScript::ScriptType::ITEM);
 
-    // Re-attaching: drop any existing script first.
-    detachScriptInternal(*mapObject);
-
-    auto& mapFile = _map->getMapFile();
-    const uint32_t oid = allocateObjectId();
-
-    MapScript script = MapScript::makeObjectScript(scriptType, allocateScriptId(section),
-        static_cast<uint32_t>(programIndex), oid);
-
-    mapFile.map_scripts[section].push_back(script);
-    mapFile.scripts_in_section[section] = static_cast<int>(mapFile.map_scripts[section].size());
-
-    mapObject->unknown0 = oid;                                     // object OID
-    mapObject->map_scripts_pid = static_cast<int32_t>(script.pid); // SID
-
+    // Direct (synchronous) connection: the model is mutated before this returns,
+    // so updateScriptSection() reads the new state.
+    Q_EMIT requestAttachScript(mapObject, scriptType, static_cast<uint32_t>(programIndex));
     updateScriptSection();
     Q_EMIT statusMessage(QString("Attached script %1 to object").arg(programIndex));
 }
@@ -1333,7 +1271,7 @@ void SelectionPanel::onDetachScriptClicked() {
     if (!mapObject) {
         return;
     }
-    detachScriptInternal(*mapObject);
+    Q_EMIT requestDetachScript(mapObject);
     updateScriptSection();
 }
 

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -2,8 +2,18 @@
 #include "ui/common/InventoryItemUiHelper.h"
 #include "ui/dialogs/FrmSelectorDialog.h"
 #include "ui/dialogs/ProEditorDialog.h"
+#include "ui/dialogs/ObjectFlagsDialog.h"
+#include "ui/dialogs/LightPropertiesDialog.h"
+#include "ui/dialogs/SceneryDestinationDialog.h"
+#include "ui/dialogs/InstancePropertiesDialog.h"
+#include "ui/dialogs/CritterPropertiesDialog.h"
+#include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
+#include "util/ResourcePaths.h"
+#include "format/map/MapScript.h"
+
+#include <algorithm>
 
 #include <QFormLayout>
 #include <QPixmap>
@@ -152,6 +162,15 @@ SelectionPanel::SelectionPanel(resource::GameResources& resources, QWidget* pare
     , _changeFrmButton(nullptr)
     , _editProButton(nullptr)
     , _editExitGridButton(nullptr)
+    , _editFlagsButton(nullptr)
+    , _editLightButton(nullptr)
+    , _editDestinationButton(nullptr)
+    , _editInteractionButton(nullptr)
+    , _editCritterButton(nullptr)
+    , _scriptContainer(nullptr)
+    , _scriptValueEdit(nullptr)
+    , _attachScriptButton(nullptr)
+    , _detachScriptButton(nullptr)
     , _inventoryGroup(nullptr)
     , _inventoryViewStack(nullptr)
     , _inventoryTree(nullptr)
@@ -287,6 +306,55 @@ void SelectionPanel::setupUI() {
     _editExitGridButton->setVisible(false); // Only shown for exit-grid marker objects
     connect(_editExitGridButton, &QPushButton::clicked, this, &SelectionPanel::onEditExitGridClicked);
     objectFormLayout->addRow("", _editExitGridButton);
+
+    // Per-instance editors. Visibility is decided per object type in updateObjectInfo().
+    _editFlagsButton = new QPushButton("Edit Flags...");
+    _editFlagsButton->setVisible(false);
+    connect(_editFlagsButton, &QPushButton::clicked, this, &SelectionPanel::onEditFlagsClicked);
+    objectFormLayout->addRow("", _editFlagsButton);
+
+    _editLightButton = new QPushButton("Edit Light...");
+    _editLightButton->setVisible(false);
+    connect(_editLightButton, &QPushButton::clicked, this, &SelectionPanel::onEditLightClicked);
+    objectFormLayout->addRow("", _editLightButton);
+
+    _editDestinationButton = new QPushButton("Edit Destination...");
+    _editDestinationButton->setVisible(false);
+    connect(_editDestinationButton, &QPushButton::clicked, this, &SelectionPanel::onEditDestinationClicked);
+    objectFormLayout->addRow("", _editDestinationButton);
+
+    _editInteractionButton = new QPushButton("Edit Interaction...");
+    _editInteractionButton->setVisible(false);
+    connect(_editInteractionButton, &QPushButton::clicked, this, &SelectionPanel::onEditInteractionClicked);
+    objectFormLayout->addRow("", _editInteractionButton);
+
+    _editCritterButton = new QPushButton("Edit Critter...");
+    _editCritterButton->setVisible(false);
+    connect(_editCritterButton, &QPushButton::clicked, this, &SelectionPanel::onEditCritterClicked);
+    objectFormLayout->addRow("", _editCritterButton);
+
+    // Script attachment controls (spanning row, shown for scriptable objects).
+    _scriptContainer = new QWidget();
+    QVBoxLayout* scriptLayout = new QVBoxLayout(_scriptContainer);
+    scriptLayout->setContentsMargins(0, 0, 0, 0);
+    QHBoxLayout* scriptValueRow = new QHBoxLayout();
+    scriptValueRow->addWidget(new QLabel("Script:"));
+    _scriptValueEdit = new QLineEdit();
+    _scriptValueEdit->setReadOnly(true);
+    _scriptValueEdit->setPlaceholderText("None");
+    scriptValueRow->addWidget(_scriptValueEdit, 1);
+    scriptLayout->addLayout(scriptValueRow);
+    QHBoxLayout* scriptButtonRow = new QHBoxLayout();
+    _attachScriptButton = new QPushButton("Attach Script...");
+    _detachScriptButton = new QPushButton("Detach");
+    _detachScriptButton->setEnabled(false);
+    connect(_attachScriptButton, &QPushButton::clicked, this, &SelectionPanel::onAttachScriptClicked);
+    connect(_detachScriptButton, &QPushButton::clicked, this, &SelectionPanel::onDetachScriptClicked);
+    scriptButtonRow->addWidget(_attachScriptButton);
+    scriptButtonRow->addWidget(_detachScriptButton);
+    scriptLayout->addLayout(scriptButtonRow);
+    _scriptContainer->setVisible(false);
+    objectFormLayout->addRow(_scriptContainer);
 
     objectInfoMainLayout->addLayout(leftSideLayout);
     objectInfoMainLayout->addLayout(objectFormLayout, 1);
@@ -481,6 +549,41 @@ void SelectionPanel::updateObjectInfo() {
                 _editExitGridButton->setEnabled(false);
             }
 
+            // Per-instance editors, gated by object type.
+            const auto objectType = pro->type();
+            const bool isScenery = objectType == Pro::OBJECT_TYPE::SCENERY;
+            Pro::SCENERY_TYPE sceneryType = Pro::SCENERY_TYPE::GENERIC;
+            if (isScenery) {
+                sceneryType = static_cast<Pro::SCENERY_TYPE>(pro->objectSubtypeId());
+            }
+            const bool hasDestination = isScenery
+                && (sceneryType == Pro::SCENERY_TYPE::STAIRS
+                    || sceneryType == Pro::SCENERY_TYPE::LADDER_TOP
+                    || sceneryType == Pro::SCENERY_TYPE::LADDER_BOTTOM
+                    || sceneryType == Pro::SCENERY_TYPE::ELEVATOR);
+            const bool isDoor = isScenery && sceneryType == Pro::SCENERY_TYPE::DOOR;
+            const bool isContainer = objectType == Pro::OBJECT_TYPE::ITEM
+                && pro->itemType() == Pro::ITEM_TYPE::CONTAINER;
+
+            // Flags and light apply to every real object (exit-grid markers use
+            // their own editor, handled above).
+            _editFlagsButton->setVisible(true);
+            _editLightButton->setVisible(true);
+            _editDestinationButton->setVisible(hasDestination);
+            _editInteractionButton->setVisible(isDoor || isContainer);
+            _editCritterButton->setVisible(objectType == Pro::OBJECT_TYPE::CRITTER);
+
+            // Scripts can be attached to items, critters, scenery and walls
+            // (engine mapper instance editors). Tiles/misc markers cannot.
+            const bool scriptable = objectType == Pro::OBJECT_TYPE::ITEM
+                || objectType == Pro::OBJECT_TYPE::CRITTER
+                || objectType == Pro::OBJECT_TYPE::SCENERY
+                || objectType == Pro::OBJECT_TYPE::WALL;
+            _scriptContainer->setVisible(scriptable);
+            if (scriptable) {
+                updateScriptSection();
+            }
+
             // Convert the SFML sprite to a QPixmap for display.
             const auto& sprite = _selectedObject.value()->getSprite();
             const auto& texture = sprite.getTexture();
@@ -616,6 +719,12 @@ void geck::SelectionPanel::clearObjectInfo() {
     _editProButton->setEnabled(false);
     _editExitGridButton->setEnabled(false);
     _editExitGridButton->setVisible(false);
+    _editFlagsButton->setVisible(false);
+    _editLightButton->setVisible(false);
+    _editDestinationButton->setVisible(false);
+    _editInteractionButton->setVisible(false);
+    _editCritterButton->setVisible(false);
+    _scriptContainer->setVisible(false);
 
     _hoverSpriteLabel->clear();
     _hoverSpriteLabel->setText("No object selected");
@@ -905,54 +1014,442 @@ void SelectionPanel::onEditExitGridClicked() {
     Q_EMIT requestExitGridEditor(_selectedObject.value());
 }
 
+void SelectionPanel::onEditFlagsClicked() {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return;
+    }
+    auto object = _selectedObject.value();
+    auto mapObject = object->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    const uint32_t objectType = mapObject->pro_pid >> 24;
+    ObjectFlagsDialog dialog(mapObject->flags, objectType, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const uint32_t newFlags = dialog.getFlags();
+    if (newFlags == mapObject->flags) {
+        return;
+    }
+
+    auto before = ObjectCommandController::captureInstanceState(*mapObject);
+    auto after = before;
+    after.flags = newFlags;
+    Q_EMIT requestInstanceEdit(object, before, after, "Edit Object Flags");
+}
+
+void SelectionPanel::onEditLightClicked() {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return;
+    }
+    auto object = _selectedObject.value();
+    auto mapObject = object->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    LightPropertiesDialog dialog(mapObject->light_radius, mapObject->light_intensity, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const uint32_t newRadius = dialog.getLightRadius();
+    const uint32_t newIntensity = dialog.getLightIntensity();
+    if (newRadius == mapObject->light_radius && newIntensity == mapObject->light_intensity) {
+        return;
+    }
+
+    auto before = ObjectCommandController::captureInstanceState(*mapObject);
+    auto after = before;
+    after.lightRadius = newRadius;
+    after.lightIntensity = newIntensity;
+    Q_EMIT requestInstanceEdit(object, before, after, "Edit Light Properties");
+}
+
+void SelectionPanel::onEditDestinationClicked() {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return;
+    }
+    auto object = _selectedObject.value();
+    auto mapObject = object->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    Pro::SCENERY_TYPE sceneryType = Pro::SCENERY_TYPE::GENERIC;
+    try {
+        auto pro = _resources.repository().load<Pro>(ProHelper::basePath(_resources, mapObject->pro_pid));
+        if (!pro || pro->type() != Pro::OBJECT_TYPE::SCENERY) {
+            return;
+        }
+        sceneryType = static_cast<Pro::SCENERY_TYPE>(pro->objectSubtypeId());
+    } catch (const std::exception& e) {
+        spdlog::warn("onEditDestinationClicked: failed to load pro: {}", e.what());
+        return;
+    }
+
+    SceneryDestinationDialog dialog(sceneryType, mapObject->elevhex, mapObject->map,
+        mapObject->elevtype, mapObject->elevlevel, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    auto before = ObjectCommandController::captureInstanceState(*mapObject);
+    auto after = before;
+    after.elevhex = dialog.getElevhex();
+    after.map = dialog.getMap();
+    after.elevtype = dialog.getElevtype();
+    after.elevlevel = dialog.getElevlevel();
+    if (after.elevhex == before.elevhex && after.map == before.map
+        && after.elevtype == before.elevtype && after.elevlevel == before.elevlevel) {
+        return;
+    }
+    Q_EMIT requestInstanceEdit(object, before, after, "Edit Scenery Destination");
+}
+
+void SelectionPanel::onEditInteractionClicked() {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return;
+    }
+    auto object = _selectedObject.value();
+    auto mapObject = object->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    bool isDoor = false;
+    try {
+        auto pro = _resources.repository().load<Pro>(ProHelper::basePath(_resources, mapObject->pro_pid));
+        if (!pro) {
+            return;
+        }
+        isDoor = pro->type() == Pro::OBJECT_TYPE::SCENERY
+            && static_cast<Pro::SCENERY_TYPE>(pro->objectSubtypeId()) == Pro::SCENERY_TYPE::DOOR;
+    } catch (const std::exception& e) {
+        spdlog::warn("onEditInteractionClicked: failed to load pro: {}", e.what());
+        return;
+    }
+
+    // Doors keep lock/jam in their openFlags (our `walkthrough`); containers keep
+    // them in the object data flags (our `unknown11`). The dialog edits whichever
+    // applies and leaves the other untouched.
+    InstancePropertiesDialog dialog(isDoor, mapObject->walkthrough, mapObject->unknown11, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const uint32_t newWalkthrough = dialog.getDoorOpenFlags();
+    const uint32_t newDataFlags = dialog.getContainerDataFlags();
+    if (newWalkthrough == mapObject->walkthrough && newDataFlags == mapObject->unknown11) {
+        return;
+    }
+
+    auto before = ObjectCommandController::captureInstanceState(*mapObject);
+    auto after = before;
+    after.walkthrough = newWalkthrough;
+    after.dataFlags = newDataFlags;
+    Q_EMIT requestInstanceEdit(object, before, after, "Edit Interaction State");
+}
+
+void SelectionPanel::onEditCritterClicked() {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return;
+    }
+    auto object = _selectedObject.value();
+    auto mapObject = object->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    CritterPropertiesDialog dialog(mapObject->ai_packet, mapObject->group_id,
+        mapObject->current_hp, mapObject->current_rad, mapObject->current_poison, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    auto before = ObjectCommandController::captureInstanceState(*mapObject);
+    auto after = before;
+    after.aiPacket = dialog.getAiPacket();
+    after.groupId = dialog.getTeam();
+    after.currentHp = dialog.getHp();
+    after.currentRad = dialog.getRadiation();
+    after.currentPoison = dialog.getPoison();
+    if (after.aiPacket == before.aiPacket && after.groupId == before.groupId
+        && after.currentHp == before.currentHp && after.currentRad == before.currentRad
+        && after.currentPoison == before.currentPoison) {
+        return;
+    }
+    Q_EMIT requestInstanceEdit(object, before, after, "Edit Critter Properties");
+}
+
+// --- F10: object-instance script attachment ---------------------------------
+// These mutate the map's script sections and the object's SID/OID directly
+// (the model is reachable via _map, like MapInfoPanel's operations). The wiring
+// mirrors the engine's objectSetScript: a new per-type script id, a fresh
+// object OID, and the chosen scripts.lst program index. Local-variable setup is
+// left to the engine at runtime (count 0 / offset -1, exactly as scriptAdd).
+// Script edits are not routed through the undo stack yet (tracked in PLAN.md).
+
+uint32_t SelectionPanel::allocateScriptId(int section) const {
+    if (!_map || section < 0 || section >= Map::SCRIPT_SECTIONS) {
+        return 0;
+    }
+    uint32_t maxId = 0;
+    bool any = false;
+    for (const auto& s : _map->getMapFile().map_scripts[section]) {
+        uint32_t id = s.pid & 0x00FFFFFF;
+        maxId = any ? std::max(maxId, id) : id;
+        any = true;
+    }
+    return any ? maxId + 1 : 0;
+}
+
+uint32_t SelectionPanel::allocateObjectId() const {
+    if (!_map) {
+        return 1;
+    }
+    uint32_t maxId = 0;
+    const auto& mapFile = _map->getMapFile();
+    for (const auto& [elevation, objects] : mapFile.map_objects) {
+        for (const auto& obj : objects) {
+            if (obj) {
+                maxId = std::max(maxId, obj->unknown0);
+            }
+        }
+    }
+    for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+        for (const auto& s : mapFile.map_scripts[section]) {
+            maxId = std::max(maxId, s.script_oid);
+        }
+    }
+    return maxId + 1;
+}
+
+void SelectionPanel::detachScriptInternal(MapObject& object) {
+    if (!_map || object.map_scripts_pid == -1) {
+        return;
+    }
+    const uint32_t sid = static_cast<uint32_t>(object.map_scripts_pid);
+    const int section = static_cast<int>((sid >> 24) & 0xFF);
+    if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
+        auto& vec = _map->getMapFile().map_scripts[section];
+        vec.erase(std::remove_if(vec.begin(), vec.end(),
+                      [sid](const MapScript& s) { return s.pid == sid; }),
+            vec.end());
+        _map->getMapFile().scripts_in_section[section] = static_cast<int>(vec.size());
+    }
+    object.map_scripts_pid = -1;
+}
+
+void SelectionPanel::updateScriptSection() {
+    if (!_scriptContainer) {
+        return;
+    }
+    if (!_selectedObject || !_selectedObject.value() || !_map) {
+        _scriptValueEdit->clear();
+        _attachScriptButton->setEnabled(false);
+        _detachScriptButton->setEnabled(false);
+        return;
+    }
+
+    auto mapObject = _selectedObject.value()->getMapObjectPtr();
+    const bool attached = mapObject && mapObject->map_scripts_pid != -1;
+
+    QString text;
+    if (attached) {
+        const uint32_t sid = static_cast<uint32_t>(mapObject->map_scripts_pid);
+        const int section = static_cast<int>((sid >> 24) & 0xFF);
+        if (section >= 0 && section < Map::SCRIPT_SECTIONS) {
+            for (const auto& s : _map->getMapFile().map_scripts[section]) {
+                if (s.pid == sid) {
+                    auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+                    if (lst && s.script_id < lst->list().size()) {
+                        text = QString::fromStdString(lst->list().at(s.script_id));
+                    } else {
+                        text = QString("Script #%1").arg(s.script_id);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    _scriptValueEdit->setText(text);
+    _attachScriptButton->setEnabled(true);
+    _detachScriptButton->setEnabled(attached);
+}
+
+void SelectionPanel::onAttachScriptClicked() {
+    if (!_selectedObject || !_selectedObject.value() || !_map) {
+        return;
+    }
+    auto mapObject = _selectedObject.value()->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+
+    auto* scriptsLst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+    if (!scriptsLst) {
+        QMessageBox::warning(this, "Attach Script", "Could not load scripts.lst.");
+        return;
+    }
+
+    ScriptSelectorDialog dialog(scriptsLst->list(), -1, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const int programIndex = dialog.selectedIndex();
+    if (programIndex < 0) {
+        return;
+    }
+
+    const uint32_t objectType = mapObject->pro_pid >> 24;
+    // Critters use the CRITTER section; items/scenery/walls use the ITEM section.
+    const int scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER)) ? 4 : 3;
+
+    // Re-attaching: drop any existing script first.
+    detachScriptInternal(*mapObject);
+
+    auto& mapFile = _map->getMapFile();
+    const uint32_t scriptId = allocateScriptId(scriptType);
+    const uint32_t oid = allocateObjectId();
+
+    MapScript script{};
+    script.pid = (static_cast<uint32_t>(scriptType) << 24) | scriptId;
+    script.script_id = static_cast<uint32_t>(programIndex); // scripts.lst program index
+    script.script_oid = oid;                                // owner OID
+    script.local_var_offset = 0xFFFFFFFF;                   // -1, matches scriptAdd
+    script.local_var_count = 0;
+    script.unknown12 = 0xFFFFFFFF; // actionBeingUsed == -1 (engine scriptAdd default)
+
+    mapFile.map_scripts[scriptType].push_back(script);
+    mapFile.scripts_in_section[scriptType] = static_cast<int>(mapFile.map_scripts[scriptType].size());
+
+    mapObject->unknown0 = oid;                // object OID
+    mapObject->map_scripts_pid = static_cast<int32_t>(script.pid); // SID
+
+    updateScriptSection();
+    Q_EMIT statusMessage(QString("Attached script %1 to object").arg(programIndex));
+}
+
+void SelectionPanel::onDetachScriptClicked() {
+    if (!_selectedObject || !_selectedObject.value() || !_map) {
+        return;
+    }
+    auto mapObject = _selectedObject.value()->getMapObjectPtr();
+    if (!mapObject) {
+        return;
+    }
+    detachScriptInternal(*mapObject);
+    updateScriptSection();
+}
+
+// Inventory edits mutate the selected container/critter's MapObject inventory
+// directly and keep objects_in_inventory in sync so they persist on save. These
+// edits are not yet routed through the undo stack (the inventory's unique_ptr
+// ownership makes snapshotting awkward) - tracked in PLAN.md F14.
+MapObject* SelectionPanel::selectedInventoryHolder() const {
+    if (!_selectedObject || !_selectedObject.value()) {
+        return nullptr;
+    }
+    return _selectedObject.value()->getMapObjectPtr().get();
+}
+
 void SelectionPanel::onAddInventoryClicked() {
-    // TODO: implement inventory management
-    spdlog::debug("SelectionPanel::onAddInventoryClicked: Add inventory functionality not yet implemented");
+    auto* holder = selectedInventoryHolder();
+    if (!holder) {
+        return;
+    }
+
+    bool ok = false;
+    const int index = QInputDialog::getInt(this, "Add Inventory Item",
+        "Item proto index:", 1, 1, 0x00FFFFFF, 1, &ok);
+    if (!ok) {
+        return;
+    }
+
+    const uint32_t itemPid = (static_cast<uint32_t>(Pro::OBJECT_TYPE::ITEM) << 24) | static_cast<uint32_t>(index);
+
+    Pro* pro = nullptr;
+    try {
+        pro = _resources.repository().load<Pro>(ProHelper::basePath(_resources, itemPid));
+    } catch (const std::exception& e) {
+        spdlog::warn("onAddInventoryClicked: failed to load proto for pid {}: {}", itemPid, e.what());
+    }
+    if (!pro) {
+        QMessageBox::warning(this, "Add Inventory Item",
+            QString("No item prototype found for index %1.").arg(index));
+        return;
+    }
+
+    auto item = std::make_unique<MapObject>();
+    item->pro_pid = itemPid;
+    item->frm_pid = pro->header.FID;
+    item->amount = 1;
+    item->elevation = holder->elevation;
+    item->position = holder->position;
+
+    holder->inventory.push_back(std::move(item));
+    holder->objects_in_inventory = static_cast<uint32_t>(holder->inventory.size());
+
+    populateInventoryTree();
 }
 
 void SelectionPanel::onRemoveInventoryClicked() {
     QTreeWidgetItem* currentItem = _inventoryTree->currentItem();
-    if (!currentItem) {
+    auto* holder = selectedInventoryHolder();
+    if (!currentItem || !holder) {
         return;
     }
 
-    // TODO: implement inventory management
-    // Visual-only for now: removes the row but not the underlying inventory item.
-    delete currentItem;
-    spdlog::debug("SelectionPanel::onRemoveInventoryClicked: Remove inventory functionality partially implemented");
+    const int row = _inventoryTree->indexOfTopLevelItem(currentItem);
+    if (row < 0 || row >= static_cast<int>(holder->inventory.size())) {
+        return;
+    }
+
+    holder->inventory.erase(holder->inventory.begin() + row);
+    holder->objects_in_inventory = static_cast<uint32_t>(holder->inventory.size());
+
+    populateInventoryTree();
 }
 
 void SelectionPanel::onInventoryItemChanged(QTreeWidgetItem* item, int column) {
     if (!item || column != COLUMN_AMOUNT) {
         return;
     }
-
-    // TODO: implement inventory management
-    // Visual-only for now: refreshes the icon but does not persist the new amount.
-    bool ok;
-    int newAmount = item->text(COLUMN_AMOUNT).toInt(&ok);
-    if (ok && newAmount >= 0) {
-        uint32_t pid = item->data(COLUMN_ICON, Qt::UserRole).toUInt();
-        spdlog::debug("SelectionPanel::onInventoryItemChanged: Changing amount for PID {} to {}", pid, newAmount);
-
-        QPixmap iconWithQuantity = ui::inventory::loadItemIcon(_resources, pid, ICON_SIZE, true);
-        if (iconWithQuantity.isNull()) {
-            iconWithQuantity = createPlaceholderIcon();
-        }
-        spdlog::debug("SelectionPanel::onInventoryItemChanged: Updating icon for PID {} with size {}x{}",
-            pid, iconWithQuantity.width(), iconWithQuantity.height());
-
-        // Create QIcon explicitly with the correct size to avoid scaling issues
-        QIcon icon;
-        icon.addPixmap(iconWithQuantity, QIcon::Normal, QIcon::Off);
-        item->setIcon(COLUMN_ICON, icon);
-
-        // Set explicit size hint to ensure proper icon display
-        item->setSizeHint(COLUMN_ICON, QSize(ICON_SIZE, ICON_SIZE));
-    } else {
-        // TODO: revert to the actual amount from the underlying data instead of 1.
-        item->setText(COLUMN_AMOUNT, "1");
+    auto* holder = selectedInventoryHolder();
+    if (!holder) {
+        return;
     }
+
+    const int row = _inventoryTree->indexOfTopLevelItem(item);
+    if (row < 0 || row >= static_cast<int>(holder->inventory.size())) {
+        return;
+    }
+
+    bool ok = false;
+    const int newAmount = item->text(COLUMN_AMOUNT).toInt(&ok);
+    if (!ok || newAmount < 1) {
+        // Revert to the stored amount.
+        item->setText(COLUMN_AMOUNT, QString::number(holder->inventory[row]->amount));
+        return;
+    }
+
+    holder->inventory[row]->amount = static_cast<uint32_t>(newAmount);
+
+    // Refresh the icon to reflect the new quantity.
+    uint32_t pid = item->data(COLUMN_ICON, Qt::UserRole).toUInt();
+    QPixmap iconWithQuantity = ui::inventory::loadItemIcon(_resources, pid, ICON_SIZE, true);
+    if (iconWithQuantity.isNull()) {
+        iconWithQuantity = createPlaceholderIcon();
+    }
+    QIcon icon;
+    icon.addPixmap(iconWithQuantity, QIcon::Normal, QIcon::Off);
+    item->setIcon(COLUMN_ICON, icon);
+    item->setSizeHint(COLUMN_ICON, QSize(ICON_SIZE, ICON_SIZE));
 }
 
 void SelectionPanel::resizeEvent(QResizeEvent* event) {
@@ -1167,7 +1664,11 @@ void SelectionPanel::populateInventoryTree() {
     options.userRoleIsPid = true;
     options.userRoleColumn = ui::inventory::COLUMN_ICON;
     options.iconProvider = [this](const MapObject& item) { return getItemIconWithQuantity(item); };
+    // Block itemChanged while we repopulate so the per-row amount handler does not
+    // fire against half-built rows.
+    _inventoryTree->blockSignals(true);
     ui::inventory::populateInventoryTree(_inventoryTree, _resources, mapObject->inventory, options);
+    _inventoryTree->blockSignals(false);
 
     if (_inventoryTree->topLevelItemCount() == 0) {
         _inventoryViewStack->setCurrentWidget(_emptyInventoryLabel);

--- a/src/ui/panels/SelectionPanel.h
+++ b/src/ui/panels/SelectionPanel.h
@@ -128,7 +128,8 @@ private:
     void setupInventorySection();
     void updateInventorySection();
     void populateInventoryTree();
-    /// The selected object's MapObject if it can hold inventory, else nullptr.
+    /// The selected object's MapObject (the inventory holder), or nullptr if
+    /// nothing is selected.
     MapObject* selectedInventoryHolder() const;
     /// Captures the after-snapshot, refreshes the tree, and emits an undoable
     /// inventory edit. `before` is the snapshot taken before the mutation.

--- a/src/ui/panels/SelectionPanel.h
+++ b/src/ui/panels/SelectionPanel.h
@@ -86,6 +86,11 @@ signals:
         std::vector<std::shared_ptr<MapObject>> before,
         std::vector<std::shared_ptr<MapObject>> after);
 
+    /// Script attach/detach, routed to the editor's ObjectCommandController so
+    /// they are undoable.
+    void requestAttachScript(std::shared_ptr<MapObject> object, int scriptType, uint32_t programIndex);
+    void requestDetachScript(std::shared_ptr<MapObject> object);
+
 public slots:
     void selectObject(std::shared_ptr<Object> selectedObject);
     void selectTile(int tileIndex, int elevation, bool isRoof);
@@ -129,13 +134,8 @@ private:
     /// inventory edit. `before` is the snapshot taken before the mutation.
     void commitInventoryEdit(std::vector<std::shared_ptr<MapObject>> before);
 
-    // Script attachment (F10)
+    // Script attachment: refreshes the displayed script name/buttons.
     void updateScriptSection();
-    void detachScriptInternal(MapObject& object);
-    /// Next free script id within a section (the low 24 bits of the SID).
-    uint32_t allocateScriptId(int section) const;
-    /// Next free object OID across all objects and script owners.
-    uint32_t allocateObjectId() const;
     QPixmap getItemIconWithQuantity(const MapObject& item) const;
     QPixmap createPlaceholderIcon() const;
 

--- a/src/ui/panels/SelectionPanel.h
+++ b/src/ui/panels/SelectionPanel.h
@@ -20,6 +20,7 @@
 #include "editor/Object.h"
 #include "format/map/Tile.h"
 #include "selection/SelectionState.h"
+#include "ui/editing/ObjectCommandController.h"
 
 namespace geck {
 
@@ -71,6 +72,15 @@ signals:
     void statusMessage(const QString& message);
     void requestExitGridEditor(std::shared_ptr<Object> object);
 
+    /// Emitted when an in-panel instance editor (flags, light, scenery
+    /// destination, interaction) produces a before/after change. MainWindow
+    /// forwards it to the active EditorWidget so it is recorded as one undoable
+    /// command.
+    void requestInstanceEdit(std::shared_ptr<Object> object,
+        MapObjectInstanceState before,
+        MapObjectInstanceState after,
+        QString description);
+
 public slots:
     void selectObject(std::shared_ptr<Object> selectedObject);
     void selectTile(int tileIndex, int elevation, bool isRoof);
@@ -81,6 +91,13 @@ private slots:
     void onChangeFrmClicked();
     void onEditProClicked();
     void onEditExitGridClicked();
+    void onEditFlagsClicked();
+    void onEditLightClicked();
+    void onEditDestinationClicked();
+    void onEditInteractionClicked();
+    void onEditCritterClicked();
+    void onAttachScriptClicked();
+    void onDetachScriptClicked();
     void onAddInventoryClicked();
     void onRemoveInventoryClicked();
     void onInventoryItemChanged(QTreeWidgetItem* item, int column);
@@ -99,6 +116,16 @@ private:
     void setupInventorySection();
     void updateInventorySection();
     void populateInventoryTree();
+    /// The selected object's MapObject if it can hold inventory, else nullptr.
+    MapObject* selectedInventoryHolder() const;
+
+    // Script attachment (F10)
+    void updateScriptSection();
+    void detachScriptInternal(MapObject& object);
+    /// Next free script id within a section (the low 24 bits of the SID).
+    uint32_t allocateScriptId(int section) const;
+    /// Next free object OID across all objects and script owners.
+    uint32_t allocateObjectId() const;
     QPixmap getItemIconWithQuantity(const MapObject& item) const;
     QPixmap createPlaceholderIcon() const;
 
@@ -129,6 +156,17 @@ private:
     QPushButton* _changeFrmButton;
     QPushButton* _editProButton;
     QPushButton* _editExitGridButton;
+    QPushButton* _editFlagsButton;
+    QPushButton* _editLightButton;
+    QPushButton* _editDestinationButton;
+    QPushButton* _editInteractionButton;
+    QPushButton* _editCritterButton;
+
+    // Script attachment controls (shown for scriptable object types)
+    QWidget* _scriptContainer;
+    QLineEdit* _scriptValueEdit;
+    QPushButton* _attachScriptButton;
+    QPushButton* _detachScriptButton;
 
     // Inventory section (appears when object has inventory)
     QGroupBox* _inventoryGroup;

--- a/src/ui/panels/SelectionPanel.h
+++ b/src/ui/panels/SelectionPanel.h
@@ -81,11 +81,18 @@ signals:
         MapObjectInstanceState after,
         QString description);
 
+    /// Emitted after an inventory edit so it is recorded as one undoable command.
+    void requestInventoryEdit(std::shared_ptr<MapObject> container,
+        std::vector<std::shared_ptr<MapObject>> before,
+        std::vector<std::shared_ptr<MapObject>> after);
+
 public slots:
     void selectObject(std::shared_ptr<Object> selectedObject);
     void selectTile(int tileIndex, int elevation, bool isRoof);
     void clearSelection();
     void handleSelectionChanged(const selection::SelectionState& selection, int elevation);
+    /// Re-reads the selected object's fields (e.g. after an undo/redo).
+    void refresh();
 
 private slots:
     void onChangeFrmClicked();
@@ -118,6 +125,9 @@ private:
     void populateInventoryTree();
     /// The selected object's MapObject if it can hold inventory, else nullptr.
     MapObject* selectedInventoryHolder() const;
+    /// Captures the after-snapshot, refreshes the tree, and emits an undoable
+    /// inventory edit. `before` is the snapshot taken before the mutation.
+    void commitInventoryEdit(std::vector<std::shared_ptr<MapObject>> before);
 
     // Script attachment (F10)
     void updateScriptSection();

--- a/src/util/BuiltTile.h
+++ b/src/util/BuiltTile.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace geck::built_tile {
+
+// Engine "built tile" packing (fallout2-ce obj_types.h): the hex tile occupies
+// the low bits and the elevation occupies bits 29-31. Used for scenery
+// transition destinations and spatial-script positions.
+inline constexpr uint32_t TILE_MASK = 0x03FFFFFF;
+inline constexpr int ELEVATION_SHIFT = 29;
+inline constexpr uint32_t ELEVATION_MASK = 0xE0000000;
+
+constexpr uint32_t create(uint32_t tile, uint32_t elevation) {
+    return (tile & TILE_MASK) | ((elevation << ELEVATION_SHIFT) & ELEVATION_MASK);
+}
+
+constexpr uint32_t tileOf(uint32_t builtTile) { return builtTile & TILE_MASK; }
+
+constexpr uint32_t elevationOf(uint32_t builtTile) {
+    return (builtTile & ELEVATION_MASK) >> ELEVATION_SHIFT;
+}
+
+} // namespace geck::built_tile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(general_tests
     general/test_viewport_controller.cpp
     general/test_map_factory.cpp
     general/test_map_roundtrip.cpp
+    general/test_undo_stack.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(general_tests
     general/test_map_factory.cpp
     general/test_map_roundtrip.cpp
     general/test_undo_stack.cpp
+    general/test_object_command_controller.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_map_roundtrip.cpp
+++ b/tests/general/test_map_roundtrip.cpp
@@ -253,6 +253,38 @@ TEST_CASE("MAP round-trip preserves all object types and inventory", "[map][roun
     std::filesystem::remove(path, ec);
 }
 
+// MapObject::cloneDeep underpins the inventory and copy-elevation undo commands,
+// so its deep-copy semantics (including nested inventory) must hold: the clone
+// matches field-for-field, and mutating the clone never touches the original.
+TEST_CASE("MapObject::cloneDeep deep-copies fields and inventory", "[map][clone]") {
+    MapObject original;
+    fillBase(original, 7);
+    original.pro_pid = pidOf(Pro::OBJECT_TYPE::ITEM, 200);
+    original.elevation = 2;
+    original.objects_in_inventory = 1;
+
+    auto child = std::make_unique<MapObject>();
+    fillBase(*child, 8);
+    child->pro_pid = pidOf(Pro::OBJECT_TYPE::ITEM, 201);
+    child->elevation = 2;
+    child->amount = 9;
+    original.inventory.push_back(std::move(child));
+
+    auto clone = original.cloneDeep();
+    REQUIRE(clone != nullptr);
+    checkBase(*clone, original);
+    REQUIRE(clone->inventory.size() == 1);
+    checkBase(*clone->inventory[0], *original.inventory[0]);
+    CHECK(clone->inventory[0]->amount == 9);
+
+    // The clone is independent: editing it must not affect the original.
+    CHECK(clone->inventory[0].get() != original.inventory[0].get());
+    clone->inventory[0]->amount = 999;
+    clone->elevation = 0;
+    CHECK(original.inventory[0]->amount == 9);
+    CHECK(original.elevation == 2);
+}
+
 // A map with only elevation 0 enabled (flags disable elevations 1 and 2) must
 // still round-trip. The engine frames the object section as exactly three
 // per-elevation count blocks regardless of which elevations are enabled

--- a/tests/general/test_object_command_controller.cpp
+++ b/tests/general/test_object_command_controller.cpp
@@ -1,0 +1,218 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <SFML/Graphics.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "resource/GameResources.h"
+#include "ui/editing/ObjectCommandController.h"
+#include "ui/rendering/MapSpriteLoader.h"
+#include "util/UndoStack.h"
+
+using namespace geck;
+
+namespace {
+
+constexpr int ITEM_SECTION = static_cast<int>(MapScript::ScriptType::ITEM);
+
+// Wires an ObjectCommandController to a fresh empty map. The resource and sprite
+// dependencies are unused by the elevation commands under test (they only touch
+// the map's objects and scripts), so default-constructed instances suffice.
+struct ControllerFixture {
+    resource::GameResources resources;
+    HexagonGrid hexgrid;
+    MapSpriteLoader spriteLoader{ resources, hexgrid };
+    std::vector<std::shared_ptr<Object>> objects;
+    std::vector<sf::Sprite> overlays;
+    UndoStack undoStack;
+    std::unique_ptr<Map> map;
+    ObjectCommandController controller;
+
+    ControllerFixture()
+        : map(std::make_unique<Map>("test.map"))
+        , controller(
+              resources, map, hexgrid, spriteLoader, objects, overlays, undoStack,
+              [] {}, [] {},
+              [this](int elevation) -> std::vector<Tile>& { return map->getMapFile().tiles[elevation]; },
+              [] { return 0; },
+              [](int, bool, int) {}, [] {}) {
+        map->setMapFile(std::make_unique<Map::MapFile>(Map::createEmptyMapFile()));
+    }
+
+    Map::MapFile& mapFile() { return map->getMapFile(); }
+
+    // Adds an object on `elevation` carrying an attached ITEM script and returns it.
+    std::shared_ptr<MapObject> addScriptedObject(int elevation, uint32_t oid, uint32_t scriptIndex) {
+        auto& mf = mapFile();
+        MapScript script = MapScript::makeObjectScript(
+            MapScript::ScriptType::ITEM, scriptIndex, /*programIndex*/ 100, oid);
+
+        auto obj = std::make_shared<MapObject>();
+        obj->elevation = static_cast<uint32_t>(elevation);
+        obj->unknown0 = oid;
+        obj->map_scripts_pid = static_cast<int32_t>(script.pid);
+
+        mf.map_scripts[ITEM_SECTION].push_back(script);
+        mf.scripts_in_section[ITEM_SECTION] = static_cast<int>(mf.map_scripts[ITEM_SECTION].size());
+        mf.map_objects[elevation].push_back(obj);
+        return obj;
+    }
+};
+
+} // namespace
+
+TEST_CASE("clearElevationObjects removes attached scripts and undo restores both", "[undo][controller]") {
+    ControllerFixture fx;
+    fx.addScriptedObject(0, 1, 0);
+    fx.addScriptedObject(0, 2, 1);
+
+    REQUIRE(fx.mapFile().map_objects[0].size() == 2);
+    REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].size() == 2);
+
+    REQUIRE(fx.controller.clearElevationObjects(0));
+
+    // Objects and their scripts are gone, with the section count kept in sync.
+    CHECK(fx.mapFile().map_objects[0].empty());
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].empty());
+    CHECK(fx.mapFile().scripts_in_section[ITEM_SECTION] == 0);
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().map_objects[0].size() == 2);
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 2);
+    CHECK(fx.mapFile().scripts_in_section[ITEM_SECTION] == 2);
+
+    REQUIRE(fx.undoStack.redo());
+    CHECK(fx.mapFile().map_objects[0].empty());
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].empty());
+}
+
+TEST_CASE("clearElevationObjects returns false for an empty elevation", "[undo][controller]") {
+    ControllerFixture fx;
+    CHECK_FALSE(fx.controller.clearElevationObjects(0));
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("copyElevation detaches cloned objects from source scripts", "[undo][controller]") {
+    ControllerFixture fx;
+    auto src = fx.addScriptedObject(0, 5, 0);
+    const size_t scriptsBefore = fx.mapFile().map_scripts[ITEM_SECTION].size();
+
+    REQUIRE(fx.controller.copyElevation(0, 1));
+
+    REQUIRE(fx.mapFile().map_objects[1].size() == 1);
+    auto clone = fx.mapFile().map_objects[1].front();
+
+    // The clone is a distinct object detached from the source's script: no shared
+    // SID and no duplicated OID, so it cannot collide with the original.
+    CHECK(clone.get() != src.get());
+    CHECK(clone->map_scripts_pid == -1);
+    CHECK(clone->script_id == -1);
+    CHECK(clone->unknown0 == 0u);
+    CHECK(clone->elevation == 1u);
+
+    // Scripts are not copied; the section and the source object are untouched.
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == scriptsBefore);
+    CHECK(src->map_scripts_pid != -1);
+    CHECK(fx.mapFile().map_objects[0].size() == 1);
+
+    // Undo restores the destination to its prior (empty) state.
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().map_objects[1].empty());
+
+    REQUIRE(fx.undoStack.redo());
+    CHECK(fx.mapFile().map_objects[1].size() == 1);
+}
+
+TEST_CASE("copyElevation rejects copying an elevation onto itself", "[undo][controller]") {
+    ControllerFixture fx;
+    fx.addScriptedObject(0, 1, 0);
+    CHECK_FALSE(fx.controller.copyElevation(0, 0));
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("registerInstanceEdit applies the after-state and reverts on undo", "[undo][controller]") {
+    ControllerFixture fx;
+    auto obj = std::make_shared<MapObject>(); // starts in the before-state (all zero)
+
+    MapObjectInstanceState before; // default-constructed zeros
+    MapObjectInstanceState after;
+    after.flags = 0x10;
+    after.lightRadius = 5;
+
+    REQUIRE(fx.controller.registerInstanceEdit(obj, before, after, "Edit Flags"));
+    CHECK(obj->flags == 0x10u);
+    CHECK(obj->light_radius == 5u);
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(obj->flags == 0u);
+    CHECK(obj->light_radius == 0u);
+
+    REQUIRE(fx.undoStack.redo());
+    CHECK(obj->flags == 0x10u);
+    CHECK(obj->light_radius == 5u);
+}
+
+TEST_CASE("registerInstanceEdit rejects a null object", "[undo][controller]") {
+    ControllerFixture fx;
+    CHECK_FALSE(fx.controller.registerInstanceEdit(nullptr, {}, {}, "Edit"));
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("attachScript and detachScript are undoable", "[undo][controller]") {
+    ControllerFixture fx;
+    auto obj = std::make_shared<MapObject>();
+    REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].empty());
+
+    REQUIRE(fx.controller.attachScript(obj, ITEM_SECTION, /*programIndex*/ 42));
+    REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
+    REQUIRE(obj->map_scripts_pid != -1);
+    const int32_t attachedSid = obj->map_scripts_pid;
+
+    // Undo removes the script and unlinks the object.
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].empty());
+    CHECK(obj->map_scripts_pid == -1);
+
+    // Redo re-attaches the same script.
+    REQUIRE(fx.undoStack.redo());
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
+    CHECK(obj->map_scripts_pid == attachedSid);
+
+    // Detaching removes it again, and undo restores the linkage.
+    REQUIRE(fx.controller.detachScript(obj));
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].empty());
+    CHECK(obj->map_scripts_pid == -1);
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
+    CHECK(obj->map_scripts_pid == attachedSid);
+}
+
+TEST_CASE("registerInventoryEdit restores inventory snapshots", "[undo][controller]") {
+    ControllerFixture fx;
+    auto container = std::make_shared<MapObject>();
+
+    auto before = ObjectCommandController::cloneInventory(container->inventory); // empty
+
+    auto item = std::make_unique<MapObject>();
+    item->pro_pid = 1234;
+    container->inventory.push_back(std::move(item)); // caller applies the edit
+    auto after = ObjectCommandController::cloneInventory(container->inventory);
+
+    REQUIRE(fx.controller.registerInventoryEdit(container, before, after));
+    CHECK(container->inventory.size() == 1);
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(container->inventory.empty());
+
+    REQUIRE(fx.undoStack.redo());
+    REQUIRE(container->inventory.size() == 1);
+    CHECK(container->inventory.front()->pro_pid == 1234u);
+}

--- a/tests/general/test_object_command_controller.cpp
+++ b/tests/general/test_object_command_controller.cpp
@@ -39,10 +39,12 @@ struct ControllerFixture {
         : map(std::make_unique<Map>("test.map"))
         , controller(
               resources, map, hexgrid, spriteLoader, objects, overlays, undoStack,
-              [] {}, [] {},
+              [] { /* refreshObjects: no rendering in tests */ },
+              [] { /* onStackChanged: no UI to notify */ },
               [this](int elevation) -> std::vector<Tile>& { return map->getMapFile().tiles[elevation]; },
               [] { return 0; },
-              [](int, bool, int) {}, [] {}) {
+              [](int, bool, int) { /* updateTileSprite: no rendering in tests */ },
+              [] { /* reloadTiles: no rendering in tests */ }) {
         map->setMapFile(std::make_unique<Map::MapFile>(Map::createEmptyMapFile()));
     }
 
@@ -170,10 +172,12 @@ TEST_CASE("attachScript and detachScript are undoable", "[undo][controller]") {
     auto obj = std::make_shared<MapObject>();
     REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].empty());
 
+    // First ITEM script in an empty section gets index 0, so the SID is deterministic.
+    const int32_t expectedSid = static_cast<int32_t>(MapScript::makeSid(MapScript::ScriptType::ITEM, 0));
+
     REQUIRE(fx.controller.attachScript(obj, ITEM_SECTION, /*programIndex*/ 42));
     REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
-    REQUIRE(obj->map_scripts_pid != -1);
-    const int32_t attachedSid = obj->map_scripts_pid;
+    CHECK(obj->map_scripts_pid == expectedSid);
 
     // Undo removes the script and unlinks the object.
     REQUIRE(fx.undoStack.undo());
@@ -183,7 +187,7 @@ TEST_CASE("attachScript and detachScript are undoable", "[undo][controller]") {
     // Redo re-attaches the same script.
     REQUIRE(fx.undoStack.redo());
     CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
-    CHECK(obj->map_scripts_pid == attachedSid);
+    CHECK(obj->map_scripts_pid == expectedSid);
 
     // Detaching removes it again, and undo restores the linkage.
     REQUIRE(fx.controller.detachScript(obj));
@@ -192,7 +196,7 @@ TEST_CASE("attachScript and detachScript are undoable", "[undo][controller]") {
 
     REQUIRE(fx.undoStack.undo());
     CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
-    CHECK(obj->map_scripts_pid == attachedSid);
+    CHECK(obj->map_scripts_pid == expectedSid);
 }
 
 TEST_CASE("registerInventoryEdit restores inventory snapshots", "[undo][controller]") {

--- a/tests/general/test_undo_stack.cpp
+++ b/tests/general/test_undo_stack.cpp
@@ -1,0 +1,107 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+#include "util/UndoStack.h"
+
+using namespace geck;
+
+namespace {
+
+// A command that appends "undo:<desc>" / "redo:<desc>" to a shared log so tests
+// can assert exactly which closures ran and in what order.
+UndoCommand loggingCommand(const std::string& desc, std::vector<std::string>& log) {
+    UndoCommand cmd;
+    cmd.description = desc;
+    cmd.undo = [&log, desc]() { log.push_back("undo:" + desc); };
+    cmd.redo = [&log, desc]() { log.push_back("redo:" + desc); };
+    return cmd;
+}
+
+} // namespace
+
+TEST_CASE("UndoStack runs the right closures in LIFO order", "[undo]") {
+    UndoStack stack;
+    std::vector<std::string> log;
+
+    CHECK_FALSE(stack.canUndo());
+    CHECK_FALSE(stack.canRedo());
+    CHECK_FALSE(stack.undo()); // nothing to undo
+    CHECK_FALSE(stack.redo()); // nothing to redo
+
+    stack.push(loggingCommand("A", log));
+    stack.push(loggingCommand("B", log));
+
+    CHECK(stack.canUndo());
+    CHECK(stack.lastUndoLabel() == "B");
+
+    REQUIRE(stack.undo()); // B (last in)
+    REQUIRE(stack.undo()); // A
+    CHECK_FALSE(stack.undo());
+
+    CHECK(stack.canRedo());
+    CHECK(stack.lastRedoLabel() == "A");
+
+    REQUIRE(stack.redo()); // A (last undone)
+    REQUIRE(stack.redo()); // B
+    CHECK_FALSE(stack.redo());
+
+    CHECK(log == std::vector<std::string>{ "undo:B", "undo:A", "redo:A", "redo:B" });
+}
+
+TEST_CASE("UndoStack push invalidates the redo stack", "[undo]") {
+    UndoStack stack;
+    std::vector<std::string> log;
+
+    stack.push(loggingCommand("A", log));
+    REQUIRE(stack.undo());
+    CHECK(stack.canRedo());
+
+    stack.push(loggingCommand("B", log)); // a new edit drops the redo history
+    CHECK_FALSE(stack.canRedo());
+    CHECK(stack.lastRedoLabel().empty());
+}
+
+TEST_CASE("UndoStack rejects commands missing an undo or redo closure", "[undo]") {
+    UndoStack stack;
+
+    UndoCommand noUndo;
+    noUndo.description = "noUndo";
+    noUndo.redo = []() {};
+    stack.push(std::move(noUndo));
+    CHECK_FALSE(stack.canUndo());
+
+    UndoCommand noRedo;
+    noRedo.description = "noRedo";
+    noRedo.undo = []() {};
+    stack.push(std::move(noRedo));
+    CHECK_FALSE(stack.canUndo());
+}
+
+TEST_CASE("UndoStack evicts the oldest command past maxCommands", "[undo]") {
+    UndoStack stack(2);
+    std::vector<std::string> log;
+
+    stack.push(loggingCommand("A", log));
+    stack.push(loggingCommand("B", log));
+    stack.push(loggingCommand("C", log)); // evicts A (oldest)
+
+    REQUIRE(stack.undo()); // C
+    REQUIRE(stack.undo()); // B
+    CHECK_FALSE(stack.undo()); // A was evicted, not reachable
+
+    CHECK(log == std::vector<std::string>{ "undo:C", "undo:B" });
+}
+
+TEST_CASE("UndoStack clear empties both stacks", "[undo]") {
+    UndoStack stack;
+    std::vector<std::string> log;
+
+    stack.push(loggingCommand("A", log));
+    REQUIRE(stack.undo());
+    stack.clear();
+
+    CHECK_FALSE(stack.canUndo());
+    CHECK_FALSE(stack.canRedo());
+}


### PR DESCRIPTION
Adds the in-engine-mapper instance/map-editing features that Gecko lacked, all routed through `ObjectCommandController` for undo/redo. Verified against fallout2-ce; **104 tests pass** locally.

### Features
- **Object flags** (`ObjectFlagsDialog`), **per-instance light** (`LightPropertiesDialog`), **scenery destination** for stairs/ladders/elevators (`SceneryDestinationDialog`), **door/container locked/jammed** routed to the correct per-type field (`InstancePropertiesDialog`), **critter** AI-packet/team/HP + **working inventory** add/remove/quantity (`CritterPropertiesDialog`).
- **Script attach/detach** (`ScriptSelectorDialog`) and **spatial scripts** (`SpatialScriptDialog`) with engine-correct SID/OID linkage.
- **Map ops**: Clear/Copy Elevation in `MapInfoPanel`.

### Undo/redo
- All instance edits, inventory, clear/copy elevation, and script attach/detach + spatial scripts are single undoable commands; `MapObject::cloneDeep` underpins the snapshots.
- New `UndoStack` + `cloneDeep` unit tests (undo had zero coverage before).

### Infra / cleanup
- Centralized constants: `util/BuiltTile.h`, `MapScript` SID helpers + factories, `Pro::InteractionFlags`.
- `PLAN.md` refreshed: pruned implemented work, added the test-suite audit, SSL script-editing options, the patterns/generation scripting layer, an MCP-server proposal, and known limitations (incl. rectangle-only exit grids and the PRO animation-preview offset).

> Includes the CI-build fix from #22 (so this branch's CI is green); that commit drops out of this diff once #22 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)