### PR TITLE
Add shared test-support headers; make fixtures cwd-independent

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,8 +35,15 @@ add_executable(qt_tests
     qt/test_dat_archive.cpp
 )
 
+# Shared, header-only test support (fixtures, temp files, builders, stub provider).
+# Included as "support/<Header>.h"; fixtures resolve via GECK_TEST_DATA_DIR.
+add_library(test_support INTERFACE)
+target_include_directories(test_support INTERFACE ${CMAKE_SOURCE_DIR}/tests)
+target_link_libraries(test_support INTERFACE Catch2::Catch2)
+
 target_link_libraries(general_tests PRIVATE
     Catch2::Catch2WithMain
+    test_support
     gecko::spdlog
     gecko::app
     vault
@@ -47,15 +54,25 @@ target_include_directories(general_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src
 )
 
+target_compile_definitions(general_tests PRIVATE
+    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
+)
+
 target_link_libraries(performance_tests PRIVATE
     Catch2::Catch2WithMain
+    test_support
     gecko::spdlog
     vault
     SFML::System SFML::Graphics
 )
 
+target_compile_definitions(performance_tests PRIVATE
+    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
+)
+
 target_link_libraries(qt_tests PRIVATE
     Catch2::Catch2
+    test_support
     Qt6::Test
     gecko::app
 )
@@ -107,18 +124,8 @@ if(WIN32)
     )
 endif()
 
-# Copy test data to both the executable directory and the test working directory
-add_custom_command(
-    TARGET general_tests POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tests/data $<TARGET_FILE_DIR:general_tests>/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tests/data ${CMAKE_CURRENT_BINARY_DIR}/data
-)
-
-add_custom_command(
-    TARGET performance_tests POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tests/data $<TARGET_FILE_DIR:performance_tests>/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tests/data ${CMAKE_CURRENT_BINARY_DIR}/data
-)
+# general_tests / performance_tests resolve fixtures by absolute path
+# (GECK_TEST_DATA_DIR via test_support), so no tests/data copy is needed for them.
 
 add_custom_command(
     TARGET qt_tests POST_BUILD

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(qt_tests
 add_library(test_support INTERFACE)
 target_include_directories(test_support INTERFACE ${CMAKE_SOURCE_DIR}/tests)
 target_link_libraries(test_support INTERFACE Catch2::Catch2)
+target_compile_definitions(test_support INTERFACE
+    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
+    GECK_TEST_TMP_DIR="${CMAKE_BINARY_DIR}/test-tmp"
+)
 
 target_link_libraries(general_tests PRIVATE
     Catch2::Catch2WithMain
@@ -54,10 +58,6 @@ target_include_directories(general_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_compile_definitions(general_tests PRIVATE
-    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
-)
-
 target_link_libraries(performance_tests PRIVATE
     Catch2::Catch2WithMain
     test_support
@@ -66,19 +66,11 @@ target_link_libraries(performance_tests PRIVATE
     SFML::System SFML::Graphics
 )
 
-target_compile_definitions(performance_tests PRIVATE
-    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
-)
-
 target_link_libraries(qt_tests PRIVATE
     Catch2::Catch2
     test_support
     Qt6::Test
     gecko::app
-)
-
-target_compile_definitions(qt_tests PRIVATE
-    GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
 )
 
 target_include_directories(qt_tests PRIVATE

--- a/tests/general/test_map_roundtrip.cpp
+++ b/tests/general/test_map_roundtrip.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
-#include <map>
 #include <memory>
 
 #include "format/map/Map.h"
@@ -10,94 +10,12 @@
 #include "format/pro/Pro.h"
 #include "reader/map/MapReader.h"
 #include "writer/map/MapWriter.h"
+#include "support/MapObjectBuilder.h"
+#include "support/ProStubProvider.h"
+#include "support/TempFile.h"
 
 using namespace geck;
-
-namespace {
-
-// Stub PRO provider. Only ITEM/SCENERY objects dereference their Pro during
-// (de)serialization (for objectSubtypeId()); walls/critters/misc do not. So a
-// minimal in-memory Pro carrying just the subtype is enough, and the whole
-// round-trip needs no .map or .pro fixture on disk.
-struct StubProvider {
-    std::map<uint32_t, std::unique_ptr<Pro>> pros;
-
-    void addItem(uint32_t pid, Pro::ITEM_TYPE t) { set(pid, static_cast<unsigned int>(t)); }
-    void addScenery(uint32_t pid, Pro::SCENERY_TYPE t) { set(pid, static_cast<unsigned int>(t)); }
-
-    void set(uint32_t pid, unsigned int subtype) {
-        auto pro = std::make_unique<Pro>(std::filesystem::path("stub"));
-        pro->setObjectSubtypeId(subtype);
-        pros[pid] = std::move(pro);
-    }
-
-    Pro* load(uint32_t pid) const {
-        auto it = pros.find(pid);
-        return it != pros.end() ? it->second.get() : nullptr;
-    }
-};
-
-uint32_t pidOf(Pro::OBJECT_TYPE type, uint32_t index) {
-    return (static_cast<uint32_t>(type) << 24) | index;
-}
-
-std::filesystem::path tempMapPath() {
-    auto path = std::filesystem::temp_directory_path() / "geck_map_roundtrip.map";
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
-    return path;
-}
-
-// Fills every serialized base field with a distinctive seed-derived value, so a
-// field-order or width bug anywhere in the 22-field block is caught for each
-// object type. pro_pid / elevation / inventory are set by the caller.
-void fillBase(MapObject& o, int32_t seed) {
-    o.unknown0 = static_cast<uint32_t>(seed * 100 + 1);
-    o.position = seed * 100 + 2;
-    o.x = static_cast<uint32_t>(seed * 100 + 3);
-    o.y = static_cast<uint32_t>(seed * 100 + 4);
-    o.sx = -(seed * 100 + 5);
-    o.sy = -(seed * 100 + 6);
-    o.frame_number = static_cast<uint32_t>(seed * 100 + 7);
-    o.direction = static_cast<uint32_t>(seed % 6);
-    o.frm_pid = static_cast<uint32_t>(seed * 100 + 9);
-    o.flags = static_cast<uint32_t>(seed * 100 + 10);
-    o.critter_index = seed * 100 + 11;
-    o.light_radius = static_cast<uint32_t>(seed % 9);
-    o.light_intensity = static_cast<uint32_t>(seed * 100 + 13);
-    o.outline_color = static_cast<uint32_t>(seed % 256);
-    o.map_scripts_pid = seed * 100 + 15;
-    o.script_id = seed * 100 + 16;
-    o.max_inventory_size = static_cast<uint32_t>(seed * 100 + 17);
-    o.unknown10 = static_cast<uint32_t>(seed * 100 + 18);
-    o.unknown11 = static_cast<uint32_t>(seed * 100 + 19);
-}
-
-void checkBase(const MapObject& got, const MapObject& want) {
-    CHECK(got.unknown0 == want.unknown0);
-    CHECK(got.position == want.position);
-    CHECK(got.x == want.x);
-    CHECK(got.y == want.y);
-    CHECK(got.sx == want.sx);
-    CHECK(got.sy == want.sy);
-    CHECK(got.frame_number == want.frame_number);
-    CHECK(got.direction == want.direction);
-    CHECK(got.frm_pid == want.frm_pid);
-    CHECK(got.flags == want.flags);
-    CHECK(got.elevation == want.elevation);
-    CHECK(got.pro_pid == want.pro_pid);
-    CHECK(got.critter_index == want.critter_index);
-    CHECK(got.light_radius == want.light_radius);
-    CHECK(got.light_intensity == want.light_intensity);
-    CHECK(got.outline_color == want.outline_color);
-    CHECK(got.map_scripts_pid == want.map_scripts_pid);
-    CHECK(got.script_id == want.script_id);
-    CHECK(got.max_inventory_size == want.max_inventory_size);
-    CHECK(got.unknown10 == want.unknown10);
-    CHECK(got.unknown11 == want.unknown11);
-}
-
-} // namespace
+using namespace geck::test;
 
 // MapWriter/MapReader symmetry guard. Builds one object of every type and item/
 // scenery subtype that has a distinct serialization path (plus a nested inventory
@@ -181,7 +99,8 @@ TEST_CASE("MAP round-trip preserves all object types and inventory", "[map][roun
 
     const size_t objectCount = objects.size();
 
-    const auto path = tempMapPath();
+    TempFile mapFile{ "geck_map_roundtrip_alltypes", ".map" };
+    const auto& path = mapFile.path();
     {
         MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
         writer.openFile(path);
@@ -248,9 +167,6 @@ TEST_CASE("MAP round-trip preserves all object types and inventory", "[map][roun
     CHECK(gotExit.exit_position == exitGrid->exit_position);
     CHECK(gotExit.exit_elevation == exitGrid->exit_elevation);
     CHECK(gotExit.exit_orientation == exitGrid->exit_orientation);
-
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
 }
 
 // MapObject::cloneDeep underpins the inventory and copy-elevation undo commands,
@@ -315,7 +231,8 @@ TEST_CASE("MAP single-enabled-elevation map keeps engine 3-block object framing"
 
     const size_t objectCount = objects.size();
 
-    const auto path = tempMapPath();
+    TempFile mapFile{ "geck_map_roundtrip_single_elev", ".map" };
+    const auto& path = mapFile.path();
     {
         MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
         writer.openFile(path);
@@ -340,9 +257,6 @@ TEST_CASE("MAP single-enabled-elevation map keeps engine 3-block object framing"
     CHECK(result.tiles.count(0) == 1);
     CHECK(result.tiles.count(1) == 0);
     CHECK(result.tiles.count(2) == 0);
-
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
 }
 
 // A non-exit-grid MISC object must not serialize the 4 trailing exit fields:
@@ -378,11 +292,10 @@ TEST_CASE("MAP non-exit MISC object writes no trailing exit data", "[map][roundt
         return reader.openFile(p);
     };
 
-    const auto exitPath = std::filesystem::temp_directory_path() / "geck_misc_exit.map";
-    const auto plainPath = std::filesystem::temp_directory_path() / "geck_misc_plain.map";
-    std::error_code ec;
-    std::filesystem::remove(exitPath, ec);
-    std::filesystem::remove(plainPath, ec);
+    TempFile exitFile{ "geck_misc_exit", ".map" };
+    TempFile plainFile{ "geck_misc_plain", ".map" };
+    const auto& exitPath = exitFile.path();
+    const auto& plainPath = plainFile.path();
 
     writeMap(buildSingleMisc(16), exitPath); // exit grid -> 4 trailing fields
     writeMap(buildSingleMisc(5), plainPath); // ordinary MISC -> none
@@ -413,7 +326,4 @@ TEST_CASE("MAP non-exit MISC object writes no trailing exit data", "[map][roundt
     CHECK(exitObj.exit_position == 902);
     CHECK(exitObj.exit_elevation == 903);
     CHECK(exitObj.exit_orientation == 904);
-
-    std::filesystem::remove(exitPath, ec);
-    std::filesystem::remove(plainPath, ec);
 }

--- a/tests/general/test_pro_roundtrip.cpp
+++ b/tests/general/test_pro_roundtrip.cpp
@@ -2,34 +2,15 @@
 
 #include <cstdint>
 #include <filesystem>
-#include <fstream>
-#include <vector>
 
 #include "format/pro/Pro.h"
 #include "reader/pro/ProReader.h"
 #include "writer/pro/ProWriter.h"
+#include "support/Fixtures.h"
+#include "support/ProBuilder.h"
+#include "support/TempFile.h"
 
-namespace {
-
-// Read an entire file into a byte vector for byte-for-byte comparisons.
-std::vector<uint8_t> readAllBytes(const std::filesystem::path& path) {
-    std::ifstream stream{ path.string(), std::ios::binary };
-    REQUIRE(stream.is_open());
-    return std::vector<uint8_t>(std::istreambuf_iterator<char>(stream),
-        std::istreambuf_iterator<char>());
-}
-
-// Build a unique temp path inside the test working directory so the existing
-// tests/data copy rules are untouched and parallel runs do not collide.
-std::filesystem::path makeTempProPath(const std::string& stem) {
-    auto dir = std::filesystem::temp_directory_path();
-    auto path = dir / (stem + ".pro");
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
-    return path;
-}
-
-} // namespace
+using namespace geck::test;
 
 // ---------------------------------------------------------------------------
 // Level 1: generic read -> write -> read integrity using the shipped fixture.
@@ -37,7 +18,7 @@ std::filesystem::path makeTempProPath(const std::string& stem) {
 // re-parsed produces identical state AND identical on-disk bytes.
 // ---------------------------------------------------------------------------
 TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]") {
-    const std::filesystem::path fixture = "data/test_item_drug_radx.pro";
+    const std::filesystem::path fixture = dataPath("test_item_drug_radx.pro");
 
     geck::ProReader reader{};
     auto original = reader.openFile(fixture);
@@ -45,7 +26,8 @@ TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]"
     REQUIRE(original->type() == geck::Pro::OBJECT_TYPE::ITEM);
     REQUIRE(original->itemType() == geck::Pro::ITEM_TYPE::DRUG);
 
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_drug");
+    TempFile tmpFile{ "test_pro_roundtrip_drug", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     {
         geck::ProWriter writer{};
@@ -101,9 +83,6 @@ TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]"
     REQUIRE(reparsed->drugData.addictionRate == original->drugData.addictionRate);
     REQUIRE(reparsed->drugData.addictionEffect == original->drugData.addictionEffect);
     REQUIRE(reparsed->drugData.addictionOnset == original->drugData.addictionOnset);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 // ---------------------------------------------------------------------------
@@ -118,7 +97,8 @@ TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]"
 // 0 and the test FAILS; against the fix they round-trip and the test PASSES.
 // ---------------------------------------------------------------------------
 TEST_CASE("PRO wall round-trip preserves flagsExt and SID (WP-1.1)", "[pro][roundtrip][wall]") {
-    const std::filesystem::path tempPath = makeTempProPath("test_pro_roundtrip_wall");
+    TempFile tmpFile{ "test_pro_roundtrip_wall", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     // PID type nibble == 3 selects OBJECT_TYPE::WALL. The remaining bits are
     // an arbitrary but distinctive prototype index, preserved verbatim.
@@ -166,9 +146,6 @@ TEST_CASE("PRO wall round-trip preserves flagsExt and SID (WP-1.1)", "[pro][roun
     REQUIRE(reparsed->commonItemData.flagsExt == SENTINEL_FLAGS_EXT);
     REQUIRE(reparsed->commonItemData.SID == SENTINEL_SID);
     REQUIRE(reparsed->wallData.materialId == SENTINEL_MATERIAL);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 // ---------------------------------------------------------------------------
@@ -178,24 +155,10 @@ TEST_CASE("PRO wall round-trip preserves flagsExt and SID (WP-1.1)", "[pro][roun
 // flagsExt/SID prefix that the reader reads (writeCritterData/writeSceneryData
 // previously omitted them, corrupting saved critter/scenery prototypes).
 // ---------------------------------------------------------------------------
-namespace {
-
-geck::Pro roundTrip(const geck::Pro& original, const std::filesystem::path& tempPath) {
-    {
-        geck::ProWriter writer{};
-        writer.openFile(tempPath);
-        REQUIRE(writer.write(original));
-    }
-    geck::ProReader reader{};
-    auto reparsed = reader.openFile(tempPath);
-    REQUIRE(reparsed != nullptr);
-    return *reparsed;
-}
-
-} // namespace
 
 TEST_CASE("PRO critter round-trip preserves the common header and stats", "[pro][roundtrip][critter]") {
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_critter");
+    TempFile tmpFile{ "test_pro_roundtrip_critter", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     geck::Pro critter{ tempPath };
     critter.header.PID = static_cast<int32_t>(
@@ -213,7 +176,8 @@ TEST_CASE("PRO critter round-trip preserves the common header and stats", "[pro]
     c.aiPacket = 701;
     c.teamNumber = 702;
     c.flags = 703;
-    for (int i = 0; i < geck::Pro::SPECIAL_STATS_COUNT; ++i) c.specialStats[i] = 10 + i;
+    for (int i = 0; i < geck::Pro::SPECIAL_STATS_COUNT; ++i)
+        c.specialStats[i] = 10 + i;
     c.maxHitPoints = 50;
     c.experienceForKill = 999;
     c.killType = 3;
@@ -222,7 +186,7 @@ TEST_CASE("PRO critter round-trip preserves the common header and stats", "[pro]
 
     REQUIRE(critter.type() == geck::Pro::OBJECT_TYPE::CRITTER);
 
-    const geck::Pro got = roundTrip(critter, tempPath);
+    const geck::Pro got = proRoundTrip(critter, tempPath);
 
     REQUIRE(got.type() == geck::Pro::OBJECT_TYPE::CRITTER);
     REQUIRE(got.header.PID == critter.header.PID);
@@ -236,13 +200,11 @@ TEST_CASE("PRO critter round-trip preserves the common header and stats", "[pro]
     REQUIRE(got.critterData.experienceForKill == 999);
     REQUIRE(got.critterData.killType == 3);
     REQUIRE(got.critterData.damageType == 2);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 TEST_CASE("PRO scenery round-trip preserves the common header and subtype data", "[pro][roundtrip][scenery]") {
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_scenery");
+    TempFile tmpFile{ "test_pro_roundtrip_scenery", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     geck::Pro scenery{ tempPath };
     scenery.header.PID = static_cast<int32_t>(
@@ -260,7 +222,7 @@ TEST_CASE("PRO scenery round-trip preserves the common header and subtype data",
 
     REQUIRE(scenery.type() == geck::Pro::OBJECT_TYPE::SCENERY);
 
-    const geck::Pro got = roundTrip(scenery, tempPath);
+    const geck::Pro got = proRoundTrip(scenery, tempPath);
 
     REQUIRE(got.type() == geck::Pro::OBJECT_TYPE::SCENERY);
     REQUIRE(got.objectSubtypeId() == static_cast<unsigned int>(geck::Pro::SCENERY_TYPE::STAIRS));
@@ -270,13 +232,11 @@ TEST_CASE("PRO scenery round-trip preserves the common header and subtype data",
     REQUIRE(got.sceneryData.soundId == 9);
     REQUIRE(got.sceneryData.stairsData.destTile == 12345);
     REQUIRE(got.sceneryData.stairsData.destElevation == 2);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 TEST_CASE("PRO weapon round-trip preserves the optional weaponFlags field", "[pro][roundtrip][weapon]") {
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_weapon");
+    TempFile tmpFile{ "test_pro_roundtrip_weapon", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     geck::Pro weapon{ tempPath };
     weapon.header.PID = static_cast<int32_t>(
@@ -295,7 +255,7 @@ TEST_CASE("PRO weapon round-trip preserves the optional weaponFlags field", "[pr
     weapon.weaponData.soundId = 4;
     weapon.weaponData.weaponFlags = 0x00000001; // energy-weapon bit; optional trailing field
 
-    const geck::Pro got = roundTrip(weapon, tempPath);
+    const geck::Pro got = proRoundTrip(weapon, tempPath);
 
     REQUIRE(got.itemType() == geck::Pro::ITEM_TYPE::WEAPON);
     REQUIRE(got.commonItemData.flagsExt == 0x11112222u);
@@ -306,13 +266,11 @@ TEST_CASE("PRO weapon round-trip preserves the optional weaponFlags field", "[pr
     REQUIRE(got.weaponData.ammoPID == 0x00000029);
     REQUIRE(got.weaponData.ammoCapacity == 30);
     REQUIRE(got.weaponData.weaponFlags == 0x00000001u);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 TEST_CASE("PRO container round-trip preserves item subtype data", "[pro][roundtrip][item]") {
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_container");
+    TempFile tmpFile{ "test_pro_roundtrip_container", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     geck::Pro container{ tempPath };
     container.header.PID = static_cast<int32_t>(
@@ -324,7 +282,7 @@ TEST_CASE("PRO container round-trip preserves item subtype data", "[pro][roundtr
     container.containerData.maxSize = 100;
     container.containerData.flags = 0x0Au;
 
-    const geck::Pro got = roundTrip(container, tempPath);
+    const geck::Pro got = proRoundTrip(container, tempPath);
 
     REQUIRE(got.itemType() == geck::Pro::ITEM_TYPE::CONTAINER);
     REQUIRE(got.commonItemData.flagsExt == 0x44445555u);
@@ -332,13 +290,11 @@ TEST_CASE("PRO container round-trip preserves item subtype data", "[pro][roundtr
     REQUIRE(got.commonItemData.materialId == 2);
     REQUIRE(got.containerData.maxSize == 100);
     REQUIRE(got.containerData.flags == 0x0Au);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }
 
 TEST_CASE("PRO tile round-trip omits the common header prefix", "[pro][roundtrip][tile]") {
-    const auto tempPath = makeTempProPath("test_pro_roundtrip_tile");
+    TempFile tmpFile{ "test_pro_roundtrip_tile", ".pro" };
+    const auto& tempPath = tmpFile.path();
 
     // TILE (and MISC) are the types WITHOUT the flagsExt/SID prefix.
     geck::Pro tile{ tempPath };
@@ -348,14 +304,11 @@ TEST_CASE("PRO tile round-trip omits the common header prefix", "[pro][roundtrip
     tile.header.flags = 0x00000002;
     tile.tileData.materialId = 3;
 
-    const geck::Pro got = roundTrip(tile, tempPath);
+    const geck::Pro got = proRoundTrip(tile, tempPath);
 
     REQUIRE(got.type() == geck::Pro::OBJECT_TYPE::TILE);
     REQUIRE(got.header.PID == tile.header.PID);
     REQUIRE(got.header.message_id == 321);
     REQUIRE(got.header.flags == 0x00000002);
     REQUIRE(got.tileData.materialId == 3);
-
-    std::error_code ec;
-    std::filesystem::remove(tempPath, ec);
 }

--- a/tests/general/test_reading_gam.cpp
+++ b/tests/general/test_reading_gam.cpp
@@ -2,10 +2,11 @@
 
 #include "format/gam/Gam.h"
 #include "reader/gam/GamReader.h"
+#include "support/Fixtures.h"
 
 TEST_CASE("Parse .gam file", "[gam]") {
     geck::GamReader gam_reader{};
-    auto gam_file = gam_reader.openFile("data/test.gam");
+    auto gam_file = gam_reader.openFile(geck::test::dataPath("test.gam"));
 
     constexpr int vars_count = 10;
 

--- a/tests/general/test_reading_msg.cpp
+++ b/tests/general/test_reading_msg.cpp
@@ -3,12 +3,13 @@
 
 #include "format/msg/Msg.h"
 #include "reader/msg/MsgReader.h"
+#include "support/Fixtures.h"
 
 using Catch::Matchers::Equals;
 
 TEST_CASE("Parse .msg file", "[msg]") {
     geck::MsgReader msg_reader{};
-    auto msg_file = msg_reader.openFile("data/test.msg");
+    auto msg_file = msg_reader.openFile(geck::test::dataPath("test.msg"));
 
     REQUIRE_THAT(msg_file->message(6500).text, Equals("Mutant"));
     REQUIRE(msg_file->message(6500).id == 6500);

--- a/tests/general/test_reading_pro_drug.cpp
+++ b/tests/general/test_reading_pro_drug.cpp
@@ -2,10 +2,11 @@
 
 #include "format/pro/Pro.h"
 #include "reader/pro/ProReader.h"
+#include "support/Fixtures.h"
 
 TEST_CASE("Parse .pro drug file", "[pro]") {
     geck::ProReader pro_reader{};
-    auto pro_file = pro_reader.openFile("data/test_item_drug_radx.pro");
+    auto pro_file = pro_reader.openFile(geck::test::dataPath("test_item_drug_radx.pro"));
 
     // Verify it's an item type
     REQUIRE(pro_file->type() == geck::Pro::OBJECT_TYPE::ITEM);

--- a/tests/performance/test_reader_performance.cpp
+++ b/tests/performance/test_reader_performance.cpp
@@ -13,6 +13,7 @@
 #include "reader/msg/MsgReader.h"
 #include "reader/lst/LstReader.h"
 #include "reader/ReaderDiagnostics.h"
+#include "support/Fixtures.h"
 
 // Include format classes for complete type definitions
 #include "format/dat/Dat.h"
@@ -208,20 +209,20 @@ TEST_CASE("FrmReader Performance", "[performance][frm]") {
 
 TEST_CASE("GamReader Performance", "[performance][gam]") {
     // Test with actual GAM file if available
-    if (std::filesystem::exists("data/test.gam")) {
+    if (std::filesystem::exists(geck::test::dataPath("test.gam"))) {
         BENCHMARK("GamReader - Real File") {
             geck::GamReader reader;
-            return reader.openFile("data/test.gam");
+            return reader.openFile(geck::test::dataPath("test.gam"));
         };
     }
 }
 
 TEST_CASE("MsgReader Performance", "[performance][msg]") {
     // Test with actual MSG file if available
-    if (std::filesystem::exists("data/test.msg")) {
+    if (std::filesystem::exists(geck::test::dataPath("test.msg"))) {
         BENCHMARK("MsgReader - Real File") {
             geck::MsgReader reader;
-            return reader.openFile("data/test.msg");
+            return reader.openFile(geck::test::dataPath("test.msg"));
         };
     }
 }

--- a/tests/support/Fixtures.h
+++ b/tests/support/Fixtures.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+// GECK_TEST_DATA_DIR is injected per test target via target_compile_definitions
+// and points at the in-source tests/data tree. Resolving fixtures by absolute
+// path makes tests independent of the working directory (running the binary
+// directly, from a debugger, or an IDE no longer silently fails to find data).
+#ifndef GECK_TEST_DATA_DIR
+#error "GECK_TEST_DATA_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+namespace geck::test {
+
+/// Absolute path to the in-source tests/data directory.
+inline std::filesystem::path dataDir() {
+    return std::filesystem::path(GECK_TEST_DATA_DIR);
+}
+
+/// Absolute path to a fixture file under tests/data.
+inline std::filesystem::path dataPath(const std::string& name) {
+    return dataDir() / name;
+}
+
+} // namespace geck::test

--- a/tests/support/MapObjectBuilder.h
+++ b/tests/support/MapObjectBuilder.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+#include "format/map/MapObject.h"
+
+namespace geck::test {
+
+/// Fills every serialized base field with a distinctive seed-derived value, so a
+/// field-order or width bug anywhere in the 22-field base block is caught for
+/// each object type. pro_pid / elevation / inventory are set by the caller.
+inline void fillBase(MapObject& o, int32_t seed) {
+    o.unknown0 = static_cast<uint32_t>(seed * 100 + 1);
+    o.position = seed * 100 + 2;
+    o.x = static_cast<uint32_t>(seed * 100 + 3);
+    o.y = static_cast<uint32_t>(seed * 100 + 4);
+    o.sx = -(seed * 100 + 5);
+    o.sy = -(seed * 100 + 6);
+    o.frame_number = static_cast<uint32_t>(seed * 100 + 7);
+    o.direction = static_cast<uint32_t>(seed % 6);
+    o.frm_pid = static_cast<uint32_t>(seed * 100 + 9);
+    o.flags = static_cast<uint32_t>(seed * 100 + 10);
+    o.critter_index = seed * 100 + 11;
+    o.light_radius = static_cast<uint32_t>(seed % 9);
+    o.light_intensity = static_cast<uint32_t>(seed * 100 + 13);
+    o.outline_color = static_cast<uint32_t>(seed % 256);
+    o.map_scripts_pid = seed * 100 + 15;
+    o.script_id = seed * 100 + 16;
+    o.max_inventory_size = static_cast<uint32_t>(seed * 100 + 17);
+    o.unknown10 = static_cast<uint32_t>(seed * 100 + 18);
+    o.unknown11 = static_cast<uint32_t>(seed * 100 + 19);
+}
+
+/// Asserts that every serialized base field of `got` matches `want`.
+inline void checkBase(const MapObject& got, const MapObject& want) {
+    CHECK(got.unknown0 == want.unknown0);
+    CHECK(got.position == want.position);
+    CHECK(got.x == want.x);
+    CHECK(got.y == want.y);
+    CHECK(got.sx == want.sx);
+    CHECK(got.sy == want.sy);
+    CHECK(got.frame_number == want.frame_number);
+    CHECK(got.direction == want.direction);
+    CHECK(got.frm_pid == want.frm_pid);
+    CHECK(got.flags == want.flags);
+    CHECK(got.elevation == want.elevation);
+    CHECK(got.pro_pid == want.pro_pid);
+    CHECK(got.critter_index == want.critter_index);
+    CHECK(got.light_radius == want.light_radius);
+    CHECK(got.light_intensity == want.light_intensity);
+    CHECK(got.outline_color == want.outline_color);
+    CHECK(got.map_scripts_pid == want.map_scripts_pid);
+    CHECK(got.script_id == want.script_id);
+    CHECK(got.max_inventory_size == want.max_inventory_size);
+    CHECK(got.unknown10 == want.unknown10);
+    CHECK(got.unknown11 == want.unknown11);
+}
+
+} // namespace geck::test

--- a/tests/support/ProBuilder.h
+++ b/tests/support/ProBuilder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+#include "format/pro/Pro.h"
+#include "reader/pro/ProReader.h"
+#include "writer/pro/ProWriter.h"
+
+namespace geck::test {
+
+/// Writes a Pro to `tempPath`, reads it back, and returns the reparsed copy.
+/// Collapses the write-then-read block every PRO round-trip case repeats.
+inline geck::Pro proRoundTrip(const geck::Pro& original, const std::filesystem::path& tempPath) {
+    {
+        geck::ProWriter writer{};
+        writer.openFile(tempPath);
+        REQUIRE(writer.write(original));
+    } // writer destructor closes/flushes the stream before we read it back
+
+    geck::ProReader reader{};
+    auto reparsed = reader.openFile(tempPath);
+    REQUIRE(reparsed != nullptr);
+    return *reparsed;
+}
+
+} // namespace geck::test

--- a/tests/support/ProStubProvider.h
+++ b/tests/support/ProStubProvider.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <memory>
+
+#include "format/pro/Pro.h"
+
+namespace geck::test {
+
+/// Builds a PID from an object type (high byte) and a per-type index, matching
+/// the engine's `(type << 24) | index` layout. The MapReader/MapWriter and the
+/// PRO suites all need this to fabricate typed objects without a .pro on disk.
+inline uint32_t pidOf(Pro::OBJECT_TYPE type, uint32_t index) {
+    return (static_cast<uint32_t>(type) << 24) | index;
+}
+
+/// In-memory PRO provider for MapReader/MapWriter. Only ITEM/SCENERY objects
+/// dereference their Pro during (de)serialization (for objectSubtypeId());
+/// walls/critters/misc do not. A minimal Pro carrying just the subtype is
+/// therefore enough, and a whole map round-trip needs no .map or .pro fixture.
+struct StubProvider {
+    std::map<uint32_t, std::unique_ptr<Pro>> pros;
+
+    void addItem(uint32_t pid, Pro::ITEM_TYPE t) { set(pid, static_cast<unsigned int>(t)); }
+    void addScenery(uint32_t pid, Pro::SCENERY_TYPE t) { set(pid, static_cast<unsigned int>(t)); }
+
+    void set(uint32_t pid, unsigned int subtype) {
+        auto pro = std::make_unique<Pro>(std::filesystem::path("stub"));
+        pro->setObjectSubtypeId(subtype);
+        pros[pid] = std::move(pro);
+    }
+
+    Pro* load(uint32_t pid) const {
+        auto it = pros.find(pid);
+        return it != pros.end() ? it->second.get() : nullptr;
+    }
+};
+
+} // namespace geck::test

--- a/tests/support/TempFile.h
+++ b/tests/support/TempFile.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace geck::test {
+
+/// RAII temp file path under the system temp directory. Removes any stale file
+/// of the same name on construction and unlinks on destruction, replacing the
+/// hand-written `temp_directory_path() / name` + `std::error_code; remove(...)`
+/// scaffolding repeated across the round-trip suites.
+class TempFile {
+public:
+    TempFile(const std::string& stem, const std::string& extension) {
+        _path = std::filesystem::temp_directory_path() / (stem + extension);
+        remove();
+    }
+
+    ~TempFile() { remove(); }
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    const std::filesystem::path& path() const { return _path; }
+    operator const std::filesystem::path&() const { return _path; }
+
+private:
+    void remove() {
+        std::error_code ec;
+        std::filesystem::remove(_path, ec);
+    }
+
+    std::filesystem::path _path;
+};
+
+/// Reads an entire file into a byte vector for byte-for-byte comparisons.
+inline std::vector<uint8_t> readAllBytes(const std::filesystem::path& path) {
+    std::ifstream stream{ path.string(), std::ios::binary };
+    REQUIRE(stream.is_open());
+    return std::vector<uint8_t>(std::istreambuf_iterator<char>(stream),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace geck::test

--- a/tests/support/TempFile.h
+++ b/tests/support/TempFile.h
@@ -9,16 +9,27 @@
 #include <string>
 #include <vector>
 
+// GECK_TEST_TMP_DIR is injected per test target (a directory inside the build
+// tree). Writing scratch files there instead of the shared, world-writable
+// system temp directory keeps test artifacts contained and avoids using a
+// predictable name in a public directory.
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
 namespace geck::test {
 
-/// RAII temp file path under the system temp directory. Removes any stale file
+/// RAII scratch file under the build-tree temp directory. Removes any stale file
 /// of the same name on construction and unlinks on destruction, replacing the
-/// hand-written `temp_directory_path() / name` + `std::error_code; remove(...)`
-/// scaffolding repeated across the round-trip suites.
+/// hand-written temp-path + `std::error_code; remove(...)` scaffolding repeated
+/// across the round-trip suites.
 class TempFile {
 public:
     TempFile(const std::string& stem, const std::string& extension) {
-        _path = std::filesystem::temp_directory_path() / (stem + extension);
+        const std::filesystem::path dir{ GECK_TEST_TMP_DIR };
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        _path = dir / (stem + extension);
         remove();
     }
 
@@ -28,10 +39,9 @@ public:
     TempFile& operator=(const TempFile&) = delete;
 
     const std::filesystem::path& path() const { return _path; }
-    operator const std::filesystem::path&() const { return _path; }
 
 private:
-    void remove() {
+    void remove() const {
         std::error_code ec;
         std::filesystem::remove(_path, ec);
     }

--- a/tests/support/TempFile.h
+++ b/tests/support/TempFile.h
@@ -51,7 +51,7 @@ private:
 
 /// Reads an entire file into a byte vector for byte-for-byte comparisons.
 inline std::vector<uint8_t> readAllBytes(const std::filesystem::path& path) {
-    std::ifstream stream{ path.string(), std::ios::binary };
+    std::ifstream stream{ path, std::ios::binary };
     REQUIRE(stream.is_open());
     return std::vector<uint8_t>(std::istreambuf_iterator<char>(stream),
         std::istreambuf_iterator<char>());


### PR DESCRIPTION
## Summary
Implements PLAN.md test-suite **P0 (shared support header)** + **P1 (robust fixtures)**.

### P1 — fixtures resolve by absolute path
- `tests/support/Fixtures.h` exposes `geck::test::dataDir()`/`dataPath(name)` backed by a `GECK_TEST_DATA_DIR` compile definition, now set for `general_tests` and `performance_tests` (qt_tests already had it).
- All bare `"data/…"` fixture literals are routed through `dataPath()`.
- Tests are now working-directory independent — running a binary directly, from a debugger, or an IDE no longer silently fails to find fixtures (the gotcha where `./build/general_tests` from the repo root failed). The redundant `copy_directory tests/data` POST_BUILD steps for general/performance are dropped.

### P0 — shared, header-only support library
A `test_support` INTERFACE target (include root = `tests/`) linked into all three executables, promoting the helpers previously duplicated across the round-trip suites:
- `TempFile.h` — RAII temp-file path (auto-cleanup) + `readAllBytes`.
- `ProStubProvider.h` — `StubProvider` + `pidOf`.
- `MapObjectBuilder.h` — `fillBase` / `checkBase`.
- `ProBuilder.h` — `proRoundTrip`.

Both `test_map_roundtrip` and `test_pro_roundtrip` are migrated onto these as the proof, removing the per-test temp-path + `std::error_code; remove(...)` boilerplate (−126 lines in the migrated files).

## Verification
- All **118 tests pass**.
- Proven cwd-independent: running `general_tests` from `/tmp` passes the gam/msg/pro/map suites (517 assertions) that previously needed the build dir's copied `data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)