### PR TITLE
Add Coordinates and HexagonGrid invariant tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(general_tests
     general/test_reading_lst.cpp
     general/test_reading_pal.cpp
     general/test_reading_frm.cpp
+    general/test_coordinates.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_coordinates.cpp
+++ b/tests/general/test_coordinates.cpp
@@ -1,0 +1,100 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <SFML/System/Vector2.hpp>
+
+#include "util/Coordinates.h"
+
+using namespace geck;
+
+TEST_CASE("HexPosition validity reflects the 0..39999 range", "[coordinates]") {
+    CHECK(HexPosition(0).isValid());
+    CHECK(HexPosition(HexPosition::MAX_VALUE).isValid()); // 39999
+    CHECK_FALSE(HexPosition(-1).isValid());
+    CHECK_FALSE(HexPosition(HexPosition::MAX_VALUE + 1).isValid()); // 40000
+    CHECK(HexPosition(123).value() == 123);
+}
+
+TEST_CASE("TileIndex validity reflects the 0..9999 range", "[coordinates]") {
+    CHECK(TileIndex(0).isValid());
+    CHECK(TileIndex(TileIndex::MAX_VALUE).isValid()); // 9999
+    CHECK_FALSE(TileIndex(-1).isValid());
+    CHECK_FALSE(TileIndex(TileIndex::MAX_VALUE + 1).isValid()); // 10000
+    CHECK(TileIndex(42).value() == 42);
+}
+
+TEST_CASE("HexPosition arithmetic does not clamp; isValid catches overflow", "[coordinates]") {
+    // The wrapper never clamps, so callers must validate with isValid(). The
+    // CLAUDE.md hex-vs-tile range rule depends on this staying true.
+    const auto over = HexPosition(HexPosition::MAX_VALUE) + 1;
+    CHECK(over.value() == HexPosition::MAX_VALUE + 1);
+    CHECK_FALSE(over.isValid());
+
+    const auto under = HexPosition(0) - 1;
+    CHECK(under.value() == -1);
+    CHECK_FALSE(under.isValid());
+
+    HexPosition p(10);
+    p += 5;
+    CHECK(p.value() == 15);
+    p -= 20;
+    CHECK(p.value() == -5);
+    CHECK_FALSE(p.isValid());
+}
+
+TEST_CASE("TileIndex arithmetic does not clamp", "[coordinates]") {
+    const auto over = TileIndex(TileIndex::MAX_VALUE) + 1;
+    CHECK(over.value() == TileIndex::MAX_VALUE + 1);
+    CHECK_FALSE(over.isValid());
+
+    TileIndex t(3);
+    t += 10;
+    CHECK(t.value() == 13);
+}
+
+TEST_CASE("Free validity helpers agree with the type boundaries", "[coordinates]") {
+    CHECK(isValidHexPosition(0));
+    CHECK(isValidHexPosition(HexPosition::MAX_VALUE));
+    CHECK_FALSE(isValidHexPosition(HexPosition::MAX_VALUE + 1));
+    CHECK(isValidTileIndex(TileIndex::MAX_VALUE));
+    CHECK_FALSE(isValidTileIndex(-1));
+}
+
+TEST_CASE("Elevation conversions validate and round-trip", "[coordinates]") {
+    CHECK(isValidElevation(0));
+    CHECK(isValidElevation(2));
+    CHECK_FALSE(isValidElevation(3));
+    CHECK_FALSE(isValidElevation(-1));
+    CHECK(toInt(Elevation::LEVEL_1) == 0);
+    CHECK(toInt(Elevation::LEVEL_3) == 2);
+    CHECK(toElevation(1) == Elevation::LEVEL_2);
+}
+
+TEST_CASE("CoordinateUtils::toValid* throw on out-of-range input", "[coordinates]") {
+    using namespace CoordinateUtils;
+    CHECK(toValidHexPosition(0).value() == 0);
+    CHECK(toValidHexPosition(HexPosition::MAX_VALUE).value() == HexPosition::MAX_VALUE);
+    CHECK_THROWS(toValidHexPosition(-1));
+    CHECK_THROWS(toValidHexPosition(HexPosition::MAX_VALUE + 1));
+
+    CHECK(toValidTileIndex(TileIndex::MAX_VALUE).value() == TileIndex::MAX_VALUE);
+    CHECK_THROWS(toValidTileIndex(TileIndex::MAX_VALUE + 1));
+
+    CHECK(toValidElevation(2) == Elevation::LEVEL_3);
+    CHECK_THROWS(toValidElevation(3));
+}
+
+TEST_CASE("WorldCoords and ScreenCoords arithmetic and vector round-trips", "[coordinates]") {
+    const WorldCoords w{ 1.5f, -2.0f };
+    CHECK(w.x() == 1.5f);
+    CHECK(w.y() == -2.0f);
+
+    const auto sum = w + WorldCoords(0.5f, 2.0f);
+    CHECK(sum.x() == 2.0f);
+    CHECK(sum.y() == 0.0f);
+    CHECK(WorldCoords(sf::Vector2f(3.0f, 4.0f)).toVector() == sf::Vector2f(3.0f, 4.0f));
+
+    const ScreenCoords s{ 10, 20 };
+    CHECK((s + ScreenCoords(5, -5)).x() == 15);
+    CHECK((s + ScreenCoords(5, -5)).y() == 15);
+    CHECK(s.toVector() == sf::Vector2i(10, 20));
+}

--- a/tests/general/test_hexagon_grid.cpp
+++ b/tests/general/test_hexagon_grid.cpp
@@ -46,3 +46,60 @@ TEST_CASE("HexagonGrid rectangleBorderPositions returns the outer ring", "[hex_g
                              HexagonGrid::GRID_WIDTH * 2 + 2,
                          }));
 }
+
+TEST_CASE("HexagonGrid position<->coordinates round-trip over the whole grid", "[hex_grid]") {
+    HexagonGrid grid;
+
+    // Row-major mapping: position = y * GRID_WIDTH + x.
+    REQUIRE(grid.coordinatesForPosition(0).has_value());
+    CHECK(grid.coordinatesForPosition(0)->x == 0);
+    CHECK(grid.coordinatesForPosition(0)->y == 0);
+    CHECK(grid.coordinatesForPosition(HexagonGrid::GRID_WIDTH + 1)->x == 1);
+    CHECK(grid.coordinatesForPosition(HexagonGrid::GRID_WIDTH + 1)->y == 1);
+    CHECK(grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT - 1)->x == HexagonGrid::GRID_WIDTH - 1);
+    CHECK(grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT - 1)->y == HexagonGrid::GRID_HEIGHT - 1);
+
+    // Every position converts to coordinates and back to the same position.
+    for (int position = 0; position < HexagonGrid::POSITION_COUNT; ++position) {
+        const auto coords = grid.coordinatesForPosition(position);
+        REQUIRE(coords.has_value());
+        const auto roundTripped = grid.positionForCoordinates(coords->x, coords->y);
+        REQUIRE(roundTripped.has_value());
+        REQUIRE(*roundTripped == position);
+    }
+}
+
+TEST_CASE("HexagonGrid rejects out-of-range positions and coordinates", "[hex_grid]") {
+    HexagonGrid grid;
+
+    CHECK_FALSE(grid.coordinatesForPosition(-1).has_value());
+    CHECK_FALSE(grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT).has_value());
+    CHECK_FALSE(grid.tileIndexForPosition(HexagonGrid::POSITION_COUNT).has_value());
+    CHECK_FALSE(grid.getHexByPosition(HexagonGrid::POSITION_COUNT).has_value());
+
+    CHECK_FALSE(grid.positionForCoordinates(-1, 0).has_value());
+    CHECK_FALSE(grid.positionForCoordinates(HexagonGrid::GRID_WIDTH, 0).has_value());
+    CHECK_FALSE(grid.positionForCoordinates(0, HexagonGrid::GRID_HEIGHT).has_value());
+}
+
+TEST_CASE("HexagonGrid positionAt resolves a screen point to the hex sitting there", "[hex_grid]") {
+    HexagonGrid grid;
+
+    // A hex's own logical (x, y) must resolve back to a hex at that exact point
+    // (nearest-hex stability), independent of any coordinate ties.
+    for (int position : { 0, 1, HexagonGrid::GRID_WIDTH, 12345, HexagonGrid::POSITION_COUNT - 1 }) {
+        const auto hex = grid.getHexByPosition(static_cast<uint32_t>(position));
+        REQUIRE(hex.has_value());
+        const Hex& h = hex->get();
+
+        const uint32_t found = grid.positionAt(static_cast<uint32_t>(h.x()), static_cast<uint32_t>(h.y()));
+        REQUIRE(found != Hex::HEX_OUT_OF_MAP);
+        const auto foundHex = grid.getHexByPosition(found);
+        REQUIRE(foundHex.has_value());
+        CHECK(foundHex->get().x() == h.x());
+        CHECK(foundHex->get().y() == h.y());
+    }
+
+    // A point far outside the grid resolves to no hex.
+    CHECK(grid.positionAt(100000, 100000) == Hex::HEX_OUT_OF_MAP);
+}

--- a/tests/general/test_hexagon_grid.cpp
+++ b/tests/general/test_hexagon_grid.cpp
@@ -51,13 +51,20 @@ TEST_CASE("HexagonGrid position<->coordinates round-trip over the whole grid", "
     HexagonGrid grid;
 
     // Row-major mapping: position = y * GRID_WIDTH + x.
-    REQUIRE(grid.coordinatesForPosition(0).has_value());
-    CHECK(grid.coordinatesForPosition(0)->x == 0);
-    CHECK(grid.coordinatesForPosition(0)->y == 0);
-    CHECK(grid.coordinatesForPosition(HexagonGrid::GRID_WIDTH + 1)->x == 1);
-    CHECK(grid.coordinatesForPosition(HexagonGrid::GRID_WIDTH + 1)->y == 1);
-    CHECK(grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT - 1)->x == HexagonGrid::GRID_WIDTH - 1);
-    CHECK(grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT - 1)->y == HexagonGrid::GRID_HEIGHT - 1);
+    const auto origin = grid.coordinatesForPosition(0);
+    REQUIRE(origin.has_value());
+    CHECK(origin->x == 0);
+    CHECK(origin->y == 0);
+
+    const auto oneOne = grid.coordinatesForPosition(HexagonGrid::GRID_WIDTH + 1);
+    REQUIRE(oneOne.has_value());
+    CHECK(oneOne->x == 1);
+    CHECK(oneOne->y == 1);
+
+    const auto last = grid.coordinatesForPosition(HexagonGrid::POSITION_COUNT - 1);
+    REQUIRE(last.has_value());
+    CHECK(last->x == HexagonGrid::GRID_WIDTH - 1);
+    CHECK(last->y == HexagonGrid::GRID_HEIGHT - 1);
 
     // Every position converts to coordinates and back to the same position.
     for (int position = 0; position < HexagonGrid::POSITION_COUNT; ++position) {


### PR DESCRIPTION
## Summary
Implements PLAN.md test-suite **P2 #7/#8** — coverage for the project's most safety-critical math (the CLAUDE.md "never validate hex against the tile range" rule lives or dies here).

### Coordinates (`test_coordinates.cpp`, new)
- `HexPosition` (0–39999) and `TileIndex` (0–9999) `isValid()` boundaries.
- **Non-clamping arithmetic**: the wrappers never clamp, so out-of-range `+`/`-`/`+=`/`-=` is caught by `isValid()` rather than silently corrected — the invariant the range rule depends on.
- Free validity helpers (`isValidHexPosition`/`isValidTileIndex`), `Elevation` conversions, `CoordinateUtils::toValid*` throwing on out-of-range input, and `WorldCoords`/`ScreenCoords` arithmetic + vector round-trips.

### HexagonGrid (`test_hexagon_grid.cpp`, extended)
- Exhaustive `coordinatesForPosition` ↔ `positionForCoordinates` round-trip over **all 40,000 positions**.
- Out-of-range positions/coordinates return `nullopt` (`coordinatesForPosition`, `positionForCoordinates`, `tileIndexForPosition`, `getHexByPosition`).
- `positionAt` resolves a hex's own logical point back to a hex sitting there (nearest-hex stability, robust to coordinate ties), and a far point resolves to `HEX_OUT_OF_MAP`.

## Notes
- Tests only; no production code changed.
- Verified the PLAN's "operator clamping" assumption against the real code — the operators intentionally don't clamp, so the tests assert that actual contract.

## Verification
All **139 tests pass** (was 128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)