### PR TITLE
Add object_query PRO-flag tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(general_tests
     general/test_reading_frm.cpp
     general/test_coordinates.cpp
     general/test_spatial_index.cpp
+    general/test_object_queries.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_object_queries.cpp
+++ b/tests/general/test_object_queries.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -55,12 +56,16 @@ struct ProFixture {
     fs::path root;
     GameResources resources;
 
-    static constexpr uint32_t BLOCKING = 1;      // flags 0          -> blocks
-    static constexpr uint32_t NON_BLOCKING = 2;  // NoBlock flag    -> passable
-    static constexpr uint32_t SHOOT_THROUGH = 3; // ShootThrough flag
+    // walls.lst line indices (1-based), each pointing at a wall PRO crafted below.
+    static constexpr uint32_t BLOCKING = 1;      // PRO has no NoBlock flag    -> blocks
+    static constexpr uint32_t NON_BLOCKING = 2;  // PRO has the NoBlock flag    -> passable
+    static constexpr uint32_t SHOOT_THROUGH = 3; // PRO has the ShootThrough flag
 
     ProFixture() {
-        root = fs::temp_directory_path() / "geck_object_query_test";
+        // Build the tree under the build-tree scratch dir (not the world-writable
+        // system temp dir), with a unique suffix so fixtures never collide.
+        static std::atomic<int> counter{ 0 };
+        root = fs::path(GECK_TEST_TMP_DIR) / ("object_query_" + std::to_string(counter++));
         std::error_code ec;
         fs::remove_all(root, ec);
 
@@ -76,6 +81,9 @@ struct ProFixture {
         std::error_code ec;
         fs::remove_all(root, ec);
     }
+
+    ProFixture(const ProFixture&) = delete;
+    ProFixture& operator=(const ProFixture&) = delete;
 };
 
 } // namespace

--- a/tests/general/test_object_queries.cpp
+++ b/tests/general/test_object_queries.cpp
@@ -1,0 +1,116 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "editor/helper/ObjectQueries.h"
+#include "format/map/MapObject.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+#include "writer/pro/ProWriter.h"
+
+namespace fs = std::filesystem;
+using namespace geck;
+using geck::resource::GameResources;
+
+namespace {
+
+constexpr uint32_t WALL_TYPE = static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL);
+
+uint32_t wallPid(uint32_t index) {
+    return (WALL_TYPE << 24) | index;
+}
+
+void writeLine(const fs::path& path, const std::string& contents) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << contents;
+}
+
+// Writes a minimal valid WALL .pro carrying the given header flags. object_query
+// only reads header.flags, but the file must still parse as a real PRO.
+void writeWallPro(const fs::path& path, uint32_t index, uint32_t flags) {
+    fs::create_directories(path.parent_path());
+
+    Pro pro{ path }; // constructor zero-initialises the header and all data blocks
+    pro.header.PID = static_cast<int32_t>(wallPid(index));
+    pro.header.flags = flags;
+
+    ProWriter writer;
+    writer.openFile(path);
+    REQUIRE(writer.write(pro));
+}
+
+MapObject wallObject(uint32_t index) {
+    MapObject object;
+    object.pro_pid = wallPid(index);
+    return object;
+}
+
+// A temp data tree with a proto/walls list + three crafted wall PROs, mounted
+// into a GameResources so object_query resolves them through the resource stack.
+struct ProFixture {
+    fs::path root;
+    GameResources resources;
+
+    static constexpr uint32_t BLOCKING = 1;      // flags 0          -> blocks
+    static constexpr uint32_t NON_BLOCKING = 2;  // NoBlock flag    -> passable
+    static constexpr uint32_t SHOOT_THROUGH = 3; // ShootThrough flag
+
+    ProFixture() {
+        root = fs::temp_directory_path() / "geck_object_query_test";
+        std::error_code ec;
+        fs::remove_all(root, ec);
+
+        writeLine(root / "proto/walls/walls.lst", "blocking.pro\nnoblock.pro\nshoot.pro\n");
+        writeWallPro(root / "proto/walls/blocking.pro", BLOCKING, 0x00000000);
+        writeWallPro(root / "proto/walls/noblock.pro", NON_BLOCKING, 0x00000010); // NoBlock
+        writeWallPro(root / "proto/walls/shoot.pro", SHOOT_THROUGH, 0x80000000);  // ShootThrough
+
+        resources.files().addDataPath(root.string());
+    }
+
+    ~ProFixture() {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+};
+
+} // namespace
+
+TEST_CASE("object_query::blocksMovement reads the PRO NoBlock flag", "[object_query]") {
+    ProFixture fx;
+
+    // No NoBlock flag -> the object blocks movement (and is a wall blocker).
+    const auto blocking = wallObject(ProFixture::BLOCKING);
+    CHECK(object_query::blocksMovement(blocking, fx.resources));
+    CHECK(object_query::isWallBlocker(blocking, fx.resources));
+
+    // NoBlock flag set -> passable.
+    const auto passable = wallObject(ProFixture::NON_BLOCKING);
+    CHECK_FALSE(object_query::blocksMovement(passable, fx.resources));
+    CHECK_FALSE(object_query::isWallBlocker(passable, fx.resources));
+}
+
+TEST_CASE("object_query::isShootThroughWallBlocker reads the PRO ShootThrough flag", "[object_query]") {
+    ProFixture fx;
+
+    const auto shootThrough = wallObject(ProFixture::SHOOT_THROUGH);
+    CHECK(object_query::isShootThroughWallBlocker(shootThrough, fx.resources));
+    // ShootThrough does not imply NoBlock, so it still blocks movement.
+    CHECK(object_query::blocksMovement(shootThrough, fx.resources));
+
+    const auto plain = wallObject(ProFixture::BLOCKING);
+    CHECK_FALSE(object_query::isShootThroughWallBlocker(plain, fx.resources));
+}
+
+TEST_CASE("object_query treats an unresolvable PRO as non-blocking", "[object_query]") {
+    ProFixture fx;
+
+    // Index 99 is past the end of walls.lst, so the PRO cannot be resolved.
+    const auto unknown = wallObject(99);
+    CHECK_FALSE(object_query::blocksMovement(unknown, fx.resources));
+    CHECK_FALSE(object_query::isShootThroughWallBlocker(unknown, fx.resources));
+}

--- a/tests/general/test_object_queries.cpp
+++ b/tests/general/test_object_queries.cpp
@@ -50,6 +50,12 @@ MapObject wallObject(uint32_t index) {
     return object;
 }
 
+// Unique-per-call suffix so concurrently-constructed fixtures never collide.
+int nextFixtureId() {
+    static std::atomic counter{ 0 };
+    return counter++;
+}
+
 // A temp data tree with a proto/walls list + three crafted wall PROs, mounted
 // into a GameResources so object_query resolves them through the resource stack.
 struct ProFixture {
@@ -61,11 +67,10 @@ struct ProFixture {
     static constexpr uint32_t NON_BLOCKING = 2;  // PRO has the NoBlock flag    -> passable
     static constexpr uint32_t SHOOT_THROUGH = 3; // PRO has the ShootThrough flag
 
-    ProFixture() {
-        // Build the tree under the build-tree scratch dir (not the world-writable
-        // system temp dir), with a unique suffix so fixtures never collide.
-        static std::atomic<int> counter{ 0 };
-        root = fs::path(GECK_TEST_TMP_DIR) / ("object_query_" + std::to_string(counter++));
+    // Build the tree under the build-tree scratch dir (not the world-writable
+    // system temp dir), with a unique suffix so fixtures never collide.
+    ProFixture()
+        : root(fs::path(GECK_TEST_TMP_DIR) / ("object_query_" + std::to_string(nextFixtureId()))) {
         std::error_code ec;
         fs::remove_all(root, ec);
 


### PR DESCRIPTION
## Summary
Implements PLAN.md test-suite **P2 #10** — `object_query` movement/blocker queries that read PRO flags through the resource stack.

## Coverage
Mounts a temp `proto/walls` tree (a `walls.lst` + three crafted wall PROs) into a `GameResources`, mirroring the `test_frm_resolver` fixture pattern, and exercises the full resolve path (`pro_pid` → `ProHelper::basePath` → VFS → `ProReader`):
- `blocksMovement` / `isWallBlocker` — true when the PRO lacks the `NoBlock` flag, false when it's set.
- `isShootThroughWallBlocker` — reads the `ShootThrough` flag; confirms it doesn't imply non-blocking.
- An unresolvable PRO (index past the list) is treated as non-blocking (the nullptr fallback).

## Notes
- Lives in `general_tests` (not qt_tests): `GameResources` is Qt-free, as the existing `test_frm_resolver` already demonstrates.
- WALL PROs are used because object_query only reads `header.flags` — a minimal wall `.pro` (zero-initialized + flags) parses cleanly.
- Tests only; no production code changed.

## Verification
All **147 tests pass** (was 144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)