### PR TITLE
Add raw DatReader tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(general_tests
     general/test_coordinates.cpp
     general/test_spatial_index.cpp
     general/test_object_queries.cpp
+    general/test_reading_dat.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_reading_dat.cpp
+++ b/tests/general/test_reading_dat.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <filesystem>
+
+#include "format/dat/Dat.h"
+#include "format/dat/DatEntry.h"
+#include "reader/dat/DatReader.h"
+#include "support/Fixtures.h"
+
+using namespace geck;
+
+namespace {
+
+// f2_res.dat (the Fallout2-CE hi-res resource archive) is a valid DAT2 with 178
+// zlib-compressed entries (also pinned by the vfspp-based qt test).
+constexpr size_t F2_RES_ENTRY_COUNT = 178;
+
+const DatEntry* findBySuffix(const Dat& dat, const std::string& suffix) {
+    for (const auto& [name, entry] : dat.getEntries()) {
+        if (name.size() >= suffix.size()
+            && name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0) {
+            return entry.get();
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+TEST_CASE("DatReader parses the f2_res.dat entry table", "[dat]") {
+    DatReader reader;
+    const auto dat = reader.openFile(geck::test::dataPath("f2_res.dat"));
+
+    REQUIRE(dat != nullptr);
+    CHECK(dat->getEntries().size() == F2_RES_ENTRY_COUNT);
+}
+
+TEST_CASE("DatReader normalizes names and reads entry metadata", "[dat]") {
+    const size_t fileSize = std::filesystem::file_size(geck::test::dataPath("f2_res.dat"));
+
+    DatReader reader;
+    const auto dat = reader.openFile(geck::test::dataPath("f2_res.dat"));
+    REQUIRE(dat != nullptr);
+
+    // Names are normalized to lowercase, forward-slash, and key the entry map.
+    const DatEntry* entry = findBySuffix(*dat, "hr_alltlk.frm");
+    REQUIRE(entry != nullptr);
+    CHECK(entry->getFilename() == "art/intrface/hr_alltlk.frm");
+    CHECK(entry->getCompressed());
+    CHECK(entry->getDecompressedSize() > 0);
+    CHECK(entry->getPackedSize() > 0);
+    CHECK(entry->getOffset() < fileSize);
+
+    // Every entry has a normalized name keying itself and an in-bounds offset.
+    for (const auto& [name, e] : dat->getEntries()) {
+        CHECK_FALSE(name.empty());
+        CHECK(name == e->getFilename());
+        CHECK(name.find('\\') == std::string::npos);
+        CHECK(e->getOffset() < fileSize);
+    }
+}
+
+TEST_CASE("DatReader rejects a file too small to be a DAT archive", "[dat]") {
+    DatReader reader;
+    REQUIRE_THROWS(reader.openFile("tiny.dat", std::vector<uint8_t>{ 1, 2, 3, 4 }));
+}

--- a/tests/general/test_reading_dat.cpp
+++ b/tests/general/test_reading_dat.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
-#include <string>
-#include <vector>
-
 #include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "format/dat/Dat.h"
 #include "format/dat/DatEntry.h"
@@ -19,10 +19,9 @@ namespace {
 // zlib-compressed entries (also pinned by the vfspp-based qt test).
 constexpr size_t F2_RES_ENTRY_COUNT = 178;
 
-const DatEntry* findBySuffix(const Dat& dat, const std::string& suffix) {
+const DatEntry* findBySuffix(const Dat& dat, std::string_view suffix) {
     for (const auto& [name, entry] : dat.getEntries()) {
-        if (name.size() >= suffix.size()
-            && name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        if (std::string_view(name).ends_with(suffix)) {
             return entry.get();
         }
     }


### PR DESCRIPTION
## Summary
Implements PLAN.md test-suite **P2 #2** — a pure `DatReader` test in `general_tests` (the existing DAT coverage only exercises the vfspp `DataFileSystem` path in `qt_tests`).

## Coverage
Parses the `f2_res.dat` fixture directly through `DatReader`:
- The DAT2 entry table has **178 entries** (matching the vfspp-based count).
- Filenames are normalized to **lowercase, forward-slash** and key their own entries (no `\` remains; `name == entry.getFilename()`).
- A known entry (`art/intrface/hr_alltlk.frm`) reads correct metadata: compressed flag, non-zero packed/decompressed sizes, in-bounds offset.
- A file too small to hold a DAT2 footer is rejected.

## Notes
- Uses the `openFile(path)` overload: `DatReader` is little-endian, and the `openFile(path, data)` overload doesn't propagate the reader's endianness to the StreamBuffer (a latent quirk worth a separate look) — the path overload does.
- Tests only; no production code changed.

## Verification
All tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)