### PR TITLE
Add MSG and GAM reader edge-case tests

### DIFF
--- a/tests/general/test_reading_gam.cpp
+++ b/tests/general/test_reading_gam.cpp
@@ -1,8 +1,18 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
 #include "format/gam/Gam.h"
 #include "reader/gam/GamReader.h"
 #include "support/Fixtures.h"
+
+namespace {
+std::vector<uint8_t> gamBytes(std::string_view s) {
+    return std::vector<uint8_t>(s.begin(), s.end());
+}
+} // namespace
 
 TEST_CASE("Parse .gam file", "[gam]") {
     geck::GamReader gam_reader{};
@@ -14,4 +24,40 @@ TEST_CASE("Parse .gam file", "[gam]") {
         REQUIRE(gam_file->mvarValue(index) == index + 1);
         REQUIRE(gam_file->gvarValue(index) == vars_count - index);
     }
+}
+
+TEST_CASE("GamReader parses gvars and mvars, skipping comments and blanks", "[gam]") {
+    geck::GamReader reader;
+    auto gam = reader.openFile("inline.gam", gamBytes("GAME_GLOBAL_VARS:\n"
+                                                      "// a comment\n"
+                                                      "GVAR_FOO := 5 ;\n"
+                                                      "\n"
+                                                      "GVAR_BAR := 10 ;\n"
+                                                      "MAP_GLOBAL_VARS:\n"
+                                                      "MVAR_BAZ := 7 ;\n"));
+
+    REQUIRE(gam != nullptr);
+    CHECK(gam->gvarValue("GVAR_FOO") == 5);
+    CHECK(gam->gvarValue("GVAR_BAR") == 10);
+    CHECK(gam->mvarValue("MVAR_BAZ") == 7);
+    // Variables keep their file order.
+    CHECK(gam->gvarKey(0) == "GVAR_FOO");
+    CHECK(gam->gvarValue(1) == 10);
+    CHECK(gam->mvarValue(0) == 7);
+}
+
+TEST_CASE("GamReader rejects an empty file", "[gam]") {
+    geck::GamReader reader;
+    REQUIRE_THROWS(reader.openFile("empty.gam", std::vector<uint8_t>{}));
+}
+
+TEST_CASE("GamReader rejects a file with no GVARS/MVARS sections", "[gam]") {
+    geck::GamReader reader;
+    REQUIRE_THROWS(reader.openFile("bad.gam", gamBytes("SOME_KEY := 1 ;\n")));
+}
+
+TEST_CASE("GamReader rejects a variable declared outside any section", "[gam]") {
+    geck::GamReader reader;
+    // The section marker is present, but a variable precedes it.
+    REQUIRE_THROWS(reader.openFile("bad.gam", gamBytes("GVAR_X := 1 ;\nGAME_GLOBAL_VARS:\n")));
 }

--- a/tests/general/test_reading_msg.cpp
+++ b/tests/general/test_reading_msg.cpp
@@ -1,11 +1,21 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
 #include "format/msg/Msg.h"
 #include "reader/msg/MsgReader.h"
 #include "support/Fixtures.h"
 
 using Catch::Matchers::Equals;
+
+namespace {
+std::vector<uint8_t> msgBytes(std::string_view s) {
+    return std::vector<uint8_t>(s.begin(), s.end());
+}
+} // namespace
 
 TEST_CASE("Parse .msg file", "[msg]") {
     geck::MsgReader msg_reader{};
@@ -21,4 +31,39 @@ TEST_CASE("Parse .msg file", "[msg]") {
     // FIXME: bug in CMBATAI2.MSG in messages #1382 and #32020 where we need to handle missing '}'
     // REQUIRE_THAT(msg_file->message(1382).text, Equals("My eyes, bitch!"));
     // REQUIRE_THAT(msg_file->message(32020).text, Equals("Ow, my arm!"));
+}
+
+TEST_CASE("MsgReader parses id, audio and text from inline content", "[msg]") {
+    geck::MsgReader reader;
+    auto msg = reader.openFile("inline.msg", msgBytes("{100}{snd.acm}{Hello}\n{200}{}{World}\n"));
+
+    REQUIRE(msg != nullptr);
+    CHECK(msg->message(100).id == 100);
+    CHECK(msg->message(100).audio == "snd.acm");
+    CHECK(msg->message(100).text == "Hello");
+    CHECK(msg->message(200).audio.empty());
+    CHECK(msg->message(200).text == "World");
+}
+
+TEST_CASE("MsgReader returns an empty message for an unknown id", "[msg]") {
+    geck::MsgReader reader;
+    auto msg = reader.openFile("inline.msg", msgBytes("{1}{}{Only}\n"));
+
+    REQUIRE(msg != nullptr);
+    const auto& missing = msg->message(999);
+    CHECK(missing.id == 0);
+    CHECK(missing.text.empty());
+}
+
+TEST_CASE("MsgReader keeps the last entry for a duplicate id", "[msg]") {
+    geck::MsgReader reader;
+    auto msg = reader.openFile("inline.msg", msgBytes("{5}{}{First}\n{5}{}{Second}\n"));
+
+    REQUIRE(msg != nullptr);
+    CHECK(msg->message(5).text == "Second");
+}
+
+TEST_CASE("MsgReader rejects an empty file", "[msg]") {
+    geck::MsgReader reader;
+    REQUIRE_THROWS(reader.openFile("empty.msg", std::vector<uint8_t>{}));
 }


### PR DESCRIPTION
## Summary
Implements PLAN.md test-suite **P2 #6** — negative/edge-case coverage for the MSG and GAM readers (the existing tests only assert happy-path lookups).

## Coverage (in-memory crafted content via `openFile(path, data)`)
**MSG**
- Inline `{id}{audio}{text}` parsing (id/audio/text fields).
- An unknown id returns an empty message (`{0,"",""}`).
- Last-write-wins for a duplicate id.
- Empty-file rejection.

**GAM**
- Parses `gvars`/`mvars` while skipping `//` comments and blank lines, preserving file order.
- Rejects an empty file, a file missing the `GVARS`/`MVARS` sections, and a variable declared outside any section.

## Notes
- Appended to the existing `test_reading_msg.cpp` / `test_reading_gam.cpp` (no CMake change).
- MSG fixtures are newline-separated because the reader's `.*` regex groups don't cross newlines (real `.msg` files are line-based).
- Tests only; no production code changed. (The reader FIXME for the missing-`}` `CMBATAI2.MSG` case is left as-is — a real parser limitation, not in scope here.)

## Verification
All tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)