### PR TITLE
Add Select-tool and Place-Exit-Grid toolbar actions

### DIFF
--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -94,8 +94,7 @@ MainWindow::MainWindow(std::shared_ptr<resource::GameResources> resources, std::
 
     // The unique_ptr owns the launcher, so it has no QObject parent (it still
     // parents its own QProcess children). `this` is only the dialog parent.
-    _gameLauncher = std::make_unique<GameLauncher>(*_resourcesShared, _settings, this,
-        [this](const QString& message) { showStatusMessage(message); }, nullptr);
+    _gameLauncher = std::make_unique<GameLauncher>(*_resourcesShared, _settings, this, [this](const QString& message) { showStatusMessage(message); }, nullptr);
 
     _externalEditorLauncher = std::make_unique<ExternalEditorLauncher>(*_resourcesShared, _settings, this);
 
@@ -610,12 +609,34 @@ void MainWindow::setupToolBar() {
 
     addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object", QKeySequence("R"));
 
+    _mainToolBar->addSeparator();
+
+    // Tool-mode group (mutually exclusive; kept in sync with the active EditorMode).
+    _selectToolAction = _mainToolBar->addAction(createIcon(":/icons/actions/select.svg"), "Select");
+    _selectToolAction->setStatusTip("Select and move objects (exits any active tool)");
+    _selectToolAction->setCheckable(true);
+    _selectToolAction->setChecked(true); // Select is the default mode
+    connect(_selectToolAction, &QAction::triggered, this, [this](bool) {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->setMode(EditorMode::Select);
+        }
+    });
+
     _markExitsAction = _mainToolBar->addAction(createIcon(":/icons/actions/door-exit.svg"), "Mark Exits");
     _markExitsAction->setStatusTip("Select exit grids to edit their properties");
     _markExitsAction->setCheckable(true);
     connect(_markExitsAction, &QAction::triggered, this, [this](bool checked) {
         if (_currentEditorWidget) {
             _currentEditorWidget->setMarkExitsMode(checked);
+        }
+    });
+
+    _placeExitGridAction = _mainToolBar->addAction(createIcon(":/icons/actions/door-exit.svg"), "Place Exit Grids");
+    _placeExitGridAction->setStatusTip("Place new exit-grid markers by clicking individual hexes");
+    _placeExitGridAction->setCheckable(true);
+    connect(_placeExitGridAction, &QAction::triggered, this, [this](bool checked) {
+        if (_currentEditorWidget) {
+            _currentEditorWidget->setExitGridPlacementMode(checked);
         }
     });
 
@@ -1001,17 +1022,14 @@ void MainWindow::connectPanelSignals() {
                 }
             });
         connect(_selectionPanel, &SelectionPanel::requestInstanceEdit,
-            this, [this](std::shared_ptr<Object> object, MapObjectInstanceState before,
-                       MapObjectInstanceState after, QString description) {
+            this, [this](std::shared_ptr<Object> object, MapObjectInstanceState before, MapObjectInstanceState after, QString description) {
                 if (!_currentEditorWidget || !object || !object->hasMapObject())
                     return;
                 _currentEditorWidget->registerInstanceEdit(object->getMapObjectPtr(),
                     before, after, description.toStdString());
             });
         connect(_selectionPanel, &SelectionPanel::requestInventoryEdit,
-            this, [this](std::shared_ptr<MapObject> container,
-                       std::vector<std::shared_ptr<MapObject>> before,
-                       std::vector<std::shared_ptr<MapObject>> after) {
+            this, [this](std::shared_ptr<MapObject> container, std::vector<std::shared_ptr<MapObject>> before, std::vector<std::shared_ptr<MapObject>> after) {
                 if (_currentEditorWidget && container)
                     _currentEditorWidget->registerInventoryEdit(container, std::move(before), std::move(after));
             });
@@ -1155,13 +1173,18 @@ void MainWindow::connectToEditorWidget() {
 
     connect(_currentEditorWidget, &EditorWidget::statusMessageRequested, this, &MainWindow::showStatusMessage);
     connect(_currentEditorWidget, &EditorWidget::statusMessageClearRequested, this, &MainWindow::clearStatusMessage);
-    // Keep the checkable Mark-Exits toolbar action in sync with the active mode
-    // (entering any other mode now exits mark-exits via EditorWidget::setMode).
+    // Keep the checkable tool-mode toolbar actions in sync with the active mode
+    // (entering any mode exits the others via EditorWidget::setMode).
     connect(_currentEditorWidget, &EditorWidget::editorModeChanged, this, [this](EditorMode mode) {
-        if (_markExitsAction) {
-            QSignalBlocker blocker(_markExitsAction);
-            _markExitsAction->setChecked(mode == EditorMode::MarkExits);
-        }
+        const auto sync = [mode](QAction* action, EditorMode actionMode) {
+            if (action) {
+                QSignalBlocker blocker(action);
+                action->setChecked(mode == actionMode);
+            }
+        };
+        sync(_selectToolAction, EditorMode::Select);
+        sync(_markExitsAction, EditorMode::MarkExits);
+        sync(_placeExitGridAction, EditorMode::PlaceExitGrid);
     });
     connect(_currentEditorWidget, &EditorWidget::hexHoverChanged, this, &MainWindow::updateHexIndexDisplay);
     connect(_currentEditorWidget, &EditorWidget::mapLoadRequested, this, [this](const std::string& mapPath) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -611,6 +611,29 @@ void MainWindow::setupToolBar() {
 
     _mainToolBar->addSeparator();
 
+    setupToolModeActions();
+
+    _mainToolBar->addSeparator();
+
+    // Layer visibility toggles (reuse View menu actions)
+    const std::array<QAction*, 9> layerVisibilityActions = {
+        _showObjectsAction,
+        _showCrittersAction,
+        _showWallsAction,
+        _showRoofsAction,
+        _showHexGridAction,
+        _showScrollBlockersAction,
+        _showWallBlockersAction,
+        _showLightOverlaysAction,
+        _showExitGridsAction,
+    };
+
+    for (QAction* action : layerVisibilityActions) {
+        _mainToolBar->addAction(action);
+    }
+}
+
+void MainWindow::setupToolModeActions() {
     // Tool-mode group (mutually exclusive; kept in sync with the active EditorMode).
     _selectToolAction = _mainToolBar->addAction(createIcon(":/icons/actions/select.svg"), "Select");
     _selectToolAction->setStatusTip("Select and move objects (exits any active tool)");
@@ -639,25 +662,18 @@ void MainWindow::setupToolBar() {
             _currentEditorWidget->setExitGridPlacementMode(checked);
         }
     });
+}
 
-    _mainToolBar->addSeparator();
-
-    // Layer visibility toggles (reuse View menu actions)
-    const std::array<QAction*, 9> layerVisibilityActions = {
-        _showObjectsAction,
-        _showCrittersAction,
-        _showWallsAction,
-        _showRoofsAction,
-        _showHexGridAction,
-        _showScrollBlockersAction,
-        _showWallBlockersAction,
-        _showLightOverlaysAction,
-        _showExitGridsAction,
+void MainWindow::syncToolModeActions(EditorMode mode) {
+    const auto sync = [mode](QAction* action, EditorMode actionMode) {
+        if (action) {
+            QSignalBlocker blocker(action);
+            action->setChecked(mode == actionMode);
+        }
     };
-
-    for (QAction* action : layerVisibilityActions) {
-        _mainToolBar->addAction(action);
-    }
+    sync(_selectToolAction, EditorMode::Select);
+    sync(_markExitsAction, EditorMode::MarkExits);
+    sync(_placeExitGridAction, EditorMode::PlaceExitGrid);
 }
 
 void MainWindow::setupDockWidgets() {
@@ -1176,16 +1192,11 @@ void MainWindow::connectToEditorWidget() {
     // Keep the checkable tool-mode toolbar actions in sync with the active mode
     // (entering any mode exits the others via EditorWidget::setMode).
     connect(_currentEditorWidget, &EditorWidget::editorModeChanged, this, [this](EditorMode mode) {
-        const auto sync = [mode](QAction* action, EditorMode actionMode) {
-            if (action) {
-                QSignalBlocker blocker(action);
-                action->setChecked(mode == actionMode);
-            }
-        };
-        sync(_selectToolAction, EditorMode::Select);
-        sync(_markExitsAction, EditorMode::MarkExits);
-        sync(_placeExitGridAction, EditorMode::PlaceExitGrid);
+        syncToolModeActions(mode);
     });
+    // The editor widget doesn't emit editorModeChanged on connect, so seed the
+    // toolbar state from its current mode (e.g. after switching maps).
+    syncToolModeActions(_currentEditorWidget->currentMode());
     connect(_currentEditorWidget, &EditorWidget::hexHoverChanged, this, &MainWindow::updateHexIndexDisplay);
     connect(_currentEditorWidget, &EditorWidget::mapLoadRequested, this, [this](const std::string& mapPath) {
         handleMapLoadRequest(mapPath, true);

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -18,6 +18,8 @@
 #include <utility>
 #include <SFML/Window/Event.hpp>
 
+#include "EditorMode.h"
+
 QT_BEGIN_NAMESPACE
 class QVBoxLayout;
 class QHBoxLayout;
@@ -120,6 +122,8 @@ private:
     void setupUI();
     void setupMenuBar();
     void setupToolBar();
+    void setupToolModeActions();
+    void syncToolModeActions(EditorMode mode);
     void setupDockWidgets();
     void setupStatusBar();
     void setupPanelsMenu();
@@ -176,7 +180,7 @@ private:
     // Toolbar
     QToolBar* _mainToolBar;
     QAction* _selectToolAction = nullptr;
-    QAction* _markExitsAction;
+    QAction* _markExitsAction = nullptr;
     QAction* _placeExitGridAction = nullptr;
     QAction* _undoAction = nullptr;
     QAction* _redoAction = nullptr;

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -175,7 +175,9 @@ private:
 
     // Toolbar
     QToolBar* _mainToolBar;
+    QAction* _selectToolAction = nullptr;
     QAction* _markExitsAction;
+    QAction* _placeExitGridAction = nullptr;
     QAction* _undoAction = nullptr;
     QAction* _redoAction = nullptr;
 


### PR DESCRIPTION
## Summary
Closes the **EditorMode UI gaps** from PLAN.md (and makes PLAN known-limitation #2 — "exit grids are rectangle-only" — addressable).

`EditorMode::PlaceExitGrid` is fully wired internally (`EditorWidget::setExitGridPlacementMode` → `InputHandler` → `ExitGridPlacementManager::placeExitGridAtPosition`), but **nothing in the UI ever entered the mode**, so per-hex exit-grid placement was unreachable — only Mark-Exits (editing existing grids) had a button. There was also no dedicated affordance to leave a tool mode back to Select.

This adds two toolbar actions, mirroring the existing Mark-Exits wiring, as a mutually-exclusive group kept in sync with the active `EditorMode` via `editorModeChanged`:
- **Select** — returns to the default select/move mode (exits any active tool). Checkable, checked by default.
- **Place Exit Grids** — enters `PlaceExitGrid` mode; clicking individual hexes places markers, enabling the engine-equivalent **non-rectangular / diagonal** exit grids that the rectangle drag-fill couldn't author.

## Implementation
- Both are checkable `QAction`s; the `editorModeChanged` handler now syncs `Select` / `Mark Exits` / `Place Exit Grids` checked-state as a radio group (`setMode` always emits, so the active tool is always reflected).
- No new internal logic — reuses `setMode(EditorMode::Select)` and `setExitGridPlacementMode(true)`.

## Verification
Full app (`gecko`) + `qt_tests` build, link, and pass. (UI behaviour itself is best eyeballed in the running editor.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)