### PR TITLE
Add undo batching to ObjectCommandController

### DIFF
--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -798,7 +798,66 @@ bool ObjectCommandController::addSpatialScript(uint32_t programIndex, int tile, 
 }
 
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {
+    if (!cmd.undo || !cmd.redo) {
+        return false;
+    }
+    if (_batchDepth > 0) {
+        // Buffer for collapse in endBatch(); the edit itself was already applied by
+        // the register*() caller, so we do not run redo here.
+        _batchedCommands.push_back(std::move(cmd));
+        return true;
+    }
     _undoStack.push(std::move(cmd));
+    if (_onStackChanged) {
+        _onStackChanged();
+    }
+    return true;
+}
+
+void ObjectCommandController::beginBatch(const std::string& description) {
+    if (_batchDepth == 0) {
+        _batchDescription = description;
+        _batchedCommands.clear();
+    }
+    ++_batchDepth;
+}
+
+bool ObjectCommandController::endBatch() {
+    if (_batchDepth == 0) {
+        return false; // Unbalanced endBatch(); nothing to close.
+    }
+
+    --_batchDepth;
+    if (_batchDepth > 0) {
+        return false; // Inner nested close; defer the flush to the outermost endBatch().
+    }
+
+    if (_batchedCommands.empty()) {
+        _batchDescription.clear();
+        return false; // Nothing was recorded during the batch.
+    }
+
+    // Collapse the buffered commands into one entry: redo replays forward, undo
+    // reverts in reverse. Both closures share one command list via shared_ptr so the
+    // batch is stored once and survives repeated undo/redo cycles.
+    auto commands = std::make_shared<std::vector<UndoCommand>>(std::move(_batchedCommands));
+    _batchedCommands.clear(); // restore to a known-empty state after the move
+
+    UndoCommand combined;
+    combined.description = std::move(_batchDescription);
+    _batchDescription.clear();
+    combined.redo = [commands]() {
+        for (const auto& cmd : *commands) {
+            cmd.redo();
+        }
+    };
+    combined.undo = [commands]() {
+        for (auto it = commands->rbegin(); it != commands->rend(); ++it) {
+            it->undo();
+        }
+    };
+
+    _undoStack.push(std::move(combined));
     if (_onStackChanged) {
         _onStackChanged();
     }

--- a/src/ui/editing/ObjectCommandController.cpp
+++ b/src/ui/editing/ObjectCommandController.cpp
@@ -857,11 +857,9 @@ bool ObjectCommandController::endBatch() {
         }
     };
 
-    _undoStack.push(std::move(combined));
-    if (_onStackChanged) {
-        _onStackChanged();
-    }
-    return true;
+    // _batchDepth is now 0, so this pushes (rather than buffers) through the single
+    // funnel that owns the undo stack and its stack-changed notification.
+    return pushCommand(std::move(combined));
 }
 
 } // namespace geck

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -209,7 +209,17 @@ public:
         : _controller(controller) {
         _controller.beginBatch(description);
     }
-    ~ScopedUndoBatch() { _controller.endBatch(); }
+    ~ScopedUndoBatch() {
+        // endBatch() allocates (make_shared / std::function), so it can throw. A
+        // throwing destructor during stack unwinding would std::terminate — which
+        // would defeat the whole point of flushing safely when a scope exits via an
+        // exception — so swallow any failure here. The edits were already applied;
+        // at worst their batched undo record is dropped.
+        try {
+            _controller.endBatch();
+        } catch (...) { // NOLINT(bugprone-empty-catch)
+        }
+    }
 
     ScopedUndoBatch(const ScopedUndoBatch&) = delete;
     ScopedUndoBatch& operator=(const ScopedUndoBatch&) = delete;

--- a/src/ui/editing/ObjectCommandController.h
+++ b/src/ui/editing/ObjectCommandController.h
@@ -76,7 +76,28 @@ public:
 
     /// Pushes a command onto the shared undo stack and notifies (the single owner
     /// of "a command was recorded"). All register*() helpers funnel through here.
+    /// While a batch is open (see beginBatch), commands are buffered instead of
+    /// pushed so the whole batch lands as a single undo entry.
     bool pushCommand(UndoCommand cmd);
+
+    /// Opens an undo batch: subsequent register*()/pushCommand() calls buffer their
+    /// commands instead of pushing them, and endBatch() collapses the whole run into
+    /// ONE UndoStack entry (replayed/reverted as a unit). This keeps multi-edit
+    /// operations — area paste, prefab stamp, procedural fill — from blowing the
+    /// UndoStack's command cap and forcing one Ctrl-Z per hex. Batches nest: only the
+    /// outermost endBatch() flushes, and the outermost description is the one used.
+    /// The individual edits are still applied immediately by the register*() calls;
+    /// the batch only governs how they are recorded for undo/redo.
+    void beginBatch(const std::string& description);
+
+    /// Closes the batch opened by the matching beginBatch(). On the outermost close,
+    /// buffered commands are collapsed into a single UndoCommand and pushed (one
+    /// stack-changed notification). Returns true iff a command was pushed (false for
+    /// an empty batch, an inner nested close, or an unbalanced call).
+    bool endBatch();
+
+    /// True while at least one beginBatch() is open.
+    bool isBatching() const { return _batchDepth > 0; }
 
     bool registerObjectPlacement(const std::shared_ptr<MapObject>& mapObject, const std::shared_ptr<Object>& object);
     bool registerObjectDeletion(const std::vector<std::pair<std::shared_ptr<MapObject>, std::shared_ptr<Object>>>& removedObjects);
@@ -170,6 +191,33 @@ private:
     std::function<int()> _getCurrentElevation;
     std::function<void(int, bool, int)> _updateTileSprite;
     std::function<void()> _reloadTiles;
+
+    // Undo-batch state. While _batchDepth > 0, pushCommand() appends to
+    // _batchedCommands instead of touching _undoStack; endBatch() collapses them.
+    int _batchDepth = 0;
+    std::string _batchDescription;
+    std::vector<UndoCommand> _batchedCommands;
+};
+
+/// RAII guard that opens an undo batch for its lifetime: collapses every edit made
+/// within the scope into a single undo entry, and flushes even if the scope exits
+/// via an exception (e.g. a sandboxed script aborting mid-generation). Prefer this
+/// over manual beginBatch()/endBatch() at call sites.
+class ScopedUndoBatch {
+public:
+    ScopedUndoBatch(ObjectCommandController& controller, const std::string& description)
+        : _controller(controller) {
+        _controller.beginBatch(description);
+    }
+    ~ScopedUndoBatch() { _controller.endBatch(); }
+
+    ScopedUndoBatch(const ScopedUndoBatch&) = delete;
+    ScopedUndoBatch& operator=(const ScopedUndoBatch&) = delete;
+    ScopedUndoBatch(ScopedUndoBatch&&) = delete;
+    ScopedUndoBatch& operator=(ScopedUndoBatch&&) = delete;
+
+private:
+    ObjectCommandController& _controller;
 };
 
 } // namespace geck

--- a/tests/general/test_object_command_controller.cpp
+++ b/tests/general/test_object_command_controller.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "editor/HexagonGrid.h"
@@ -219,4 +220,131 @@ TEST_CASE("registerInventoryEdit restores inventory snapshots", "[undo][controll
     REQUIRE(fx.undoStack.redo());
     REQUIRE(container->inventory.size() == 1);
     CHECK(container->inventory.front()->pro_pid == 1234u);
+}
+
+namespace {
+// Records an undoable flags edit on a fresh object (applied immediately) so batch
+// tests have observable, independent state to assert on.
+std::shared_ptr<MapObject> editFlags(ObjectCommandController& controller, uint32_t flags) {
+    auto obj = std::make_shared<MapObject>();
+    MapObjectInstanceState before;
+    MapObjectInstanceState after;
+    after.flags = flags;
+    controller.registerInstanceEdit(obj, before, after, "Edit Flags");
+    return obj;
+}
+} // namespace
+
+TEST_CASE("beginBatch/endBatch collapse many edits into one undo entry", "[undo][controller][batch]") {
+    ControllerFixture fx;
+
+    fx.controller.beginBatch("Batch edit");
+    CHECK(fx.controller.isBatching());
+
+    auto o1 = editFlags(fx.controller, 0x01);
+    auto o2 = editFlags(fx.controller, 0x02);
+    auto o3 = editFlags(fx.controller, 0x04);
+
+    // Each edit is applied immediately, but nothing is on the stack mid-batch.
+    CHECK(o1->flags == 0x01u);
+    CHECK(o2->flags == 0x02u);
+    CHECK(o3->flags == 0x04u);
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    CHECK(fx.controller.endBatch());
+    CHECK_FALSE(fx.controller.isBatching());
+    CHECK(fx.undoStack.lastUndoLabel() == "Batch edit");
+
+    // A single undo reverts ALL three edits, and the stack then holds nothing else
+    // (proving the batch is one entry, not three).
+    REQUIRE(fx.undoStack.undo());
+    CHECK(o1->flags == 0u);
+    CHECK(o2->flags == 0u);
+    CHECK(o3->flags == 0u);
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    // A single redo re-applies the whole batch.
+    REQUIRE(fx.undoStack.redo());
+    CHECK(o1->flags == 0x01u);
+    CHECK(o2->flags == 0x02u);
+    CHECK(o3->flags == 0x04u);
+}
+
+TEST_CASE("an empty batch records nothing", "[undo][controller][batch]") {
+    ControllerFixture fx;
+
+    fx.controller.beginBatch("Nothing happens");
+    CHECK_FALSE(fx.controller.endBatch()); // false: nothing was recorded
+    CHECK_FALSE(fx.controller.isBatching());
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("an unbalanced endBatch is a no-op", "[undo][controller][batch]") {
+    ControllerFixture fx;
+    CHECK_FALSE(fx.controller.endBatch());
+    CHECK_FALSE(fx.controller.isBatching());
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("nested batches flush once at the outermost endBatch", "[undo][controller][batch]") {
+    ControllerFixture fx;
+
+    fx.controller.beginBatch("Outer");
+    auto o1 = editFlags(fx.controller, 0x01);
+
+    fx.controller.beginBatch("Inner");
+    auto o2 = editFlags(fx.controller, 0x02);
+    CHECK_FALSE(fx.controller.endBatch()); // inner close defers the flush
+    CHECK(fx.controller.isBatching());     // still inside the outer batch
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    auto o3 = editFlags(fx.controller, 0x04);
+    CHECK(fx.controller.endBatch()); // outer close flushes one combined command
+    CHECK_FALSE(fx.controller.isBatching());
+
+    // One undo reverts all three edits across both nesting levels.
+    REQUIRE(fx.undoStack.undo());
+    CHECK(o1->flags == 0u);
+    CHECK(o2->flags == 0u);
+    CHECK(o3->flags == 0u);
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("ScopedUndoBatch flushes on scope exit, even via an exception", "[undo][controller][batch]") {
+    ControllerFixture fx;
+    std::shared_ptr<MapObject> o1;
+    std::shared_ptr<MapObject> o2;
+
+    SECTION("normal scope exit collapses to one entry") {
+        {
+            ScopedUndoBatch batch(fx.controller, "Scoped");
+            o1 = editFlags(fx.controller, 0x01);
+            o2 = editFlags(fx.controller, 0x02);
+            CHECK(fx.controller.isBatching());
+        }
+        CHECK_FALSE(fx.controller.isBatching());
+
+        REQUIRE(fx.undoStack.undo());
+        CHECK(o1->flags == 0u);
+        CHECK(o2->flags == 0u);
+        CHECK_FALSE(fx.undoStack.canUndo());
+    }
+
+    SECTION("an exception mid-batch still flushes the buffered edits as one entry") {
+        try {
+            ScopedUndoBatch batch(fx.controller, "Aborted");
+            o1 = editFlags(fx.controller, 0x01);
+            o2 = editFlags(fx.controller, 0x02);
+            throw std::runtime_error("simulated script abort");
+        } catch (const std::runtime_error&) {
+            // The guard's destructor ran during unwinding and flushed the batch.
+        }
+
+        CHECK_FALSE(fx.controller.isBatching());
+        CHECK(fx.undoStack.canUndo());
+        REQUIRE(fx.undoStack.undo());
+        CHECK(o1->flags == 0u);
+        CHECK(o2->flags == 0u);
+        CHECK_FALSE(fx.undoStack.canUndo());
+    }
 }


### PR DESCRIPTION
Foundation for collapsing multi-edit operations into a single undo step (PLAN.md §6 "Critical constraint — batch into ONE undo command", §8 sequencing step 1).

## Problem
Every `register*()` call funnels through `pushCommand()` and lands as its own `UndoStack` entry. `UndoStack` is a flat list with a hard command cap (default 100), so any multi-object operation — area paste, the future prefab stamp / procedural fill — would (a) blow the cap and silently evict earlier history, and (b) force one Ctrl-Z per edit. `registerTileEdit` already takes a *vector* of changes; this generalizes that model to every operation.

## Change
- `beginBatch(description)` / `endBatch()` on `ObjectCommandController`: while a batch is open, `pushCommand()` buffers commands instead of pushing them; `endBatch()` collapses the whole run into **one** `UndoCommand` whose `redo` replays forward and `undo` reverts in reverse.
- Batches **nest** — only the outermost `endBatch()` flushes, and the outermost description is used.
- `ScopedUndoBatch` RAII guard flushes on scope exit **including via an exception**, so a sandboxed script aborting mid-generation still records one clean entry.
- The edits are still applied immediately by the `register*()` calls; batching only governs how they're recorded. `pushCommand()` remains the single funnel — `_undoStack` / `_onStackChanged` are touched nowhere else — so this batches *every* operation with no per-call changes.

## Tests (`test_object_command_controller.cpp`, headless)
- Many edits inside a batch → **one** undo entry; a single undo reverts all, single redo re-applies all.
- Empty batch records nothing; unbalanced `endBatch()` is a no-op.
- Nested batches flush once at the outermost close.
- `ScopedUndoBatch` collapses on normal scope exit **and** when the scope unwinds via an exception.

Full suite green (156 cases); 45 assertions across the 5 new batch cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)