### PR TITLE
Add Tier-1 prefab pattern format and JSON serializer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,10 @@ set(GECK_APP_SOURCES
     util/Settings.h
     util/Settings.cpp
 
+    pattern/Pattern.h
+    pattern/PatternSerializer.h
+    pattern/PatternSerializer.cpp
+
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp
 

--- a/src/pattern/Pattern.h
+++ b/src/pattern/Pattern.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace geck::pattern {
+
+/// A single object captured in a pattern, positioned by its hex offset relative to
+/// the pattern's anchor. PID and direction values are stored verbatim (engine data
+/// fidelity — the format carries no display labels).
+struct PatternObject {
+    int dxHex = 0; ///< Hex-space column offset from the anchor.
+    int dyHex = 0; ///< Hex-space row offset from the anchor.
+    uint32_t proPid = 0;
+    uint32_t frmPid = 0;
+    uint32_t direction = 0; ///< 0-5 facing; rotated by step at stamp time.
+    uint32_t flags = 0;
+};
+
+/// A floor or roof tile captured in a pattern, positioned by its tile offset
+/// relative to the anchor. Tile space is a distinct 100x100 grid from hex space —
+/// never validate one against the other's range (see CLAUDE.md).
+struct PatternTile {
+    int dxTile = 0;
+    int dyTile = 0;
+    uint16_t tileId = 0;
+};
+
+/// A reusable prefab captured from a selection: relative object and tile placements
+/// anchored at an origin hex, replayable elsewhere (optionally rotated) by the
+/// stamper. Serialized to JSON by PatternSerializer.
+struct Pattern {
+    static constexpr int CURRENT_VERSION = 1;
+
+    std::string name;
+    int version = CURRENT_VERSION;
+    int anchorHex = 0; ///< Authoring origin; object/tile offsets are relative to this.
+    int sizeHexW = 0;  ///< Bounding-box width in hexes (informational).
+    int sizeHexH = 0;  ///< Bounding-box height in hexes (informational).
+    bool rotatable = false;
+
+    std::vector<PatternObject> objects;
+    std::vector<PatternTile> floor;
+    std::vector<PatternTile> roof;
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSerializer.cpp
+++ b/src/pattern/PatternSerializer.cpp
@@ -1,0 +1,217 @@
+#include "pattern/PatternSerializer.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+
+namespace geck::pattern {
+
+namespace {
+
+    QJsonObject objectToJson(const PatternObject& obj) {
+        QJsonObject json;
+        json["dxHex"] = obj.dxHex;
+        json["dyHex"] = obj.dyHex;
+        json["proPid"] = static_cast<qint64>(obj.proPid);
+        json["frmPid"] = static_cast<qint64>(obj.frmPid);
+        json["direction"] = static_cast<qint64>(obj.direction);
+        json["flags"] = static_cast<qint64>(obj.flags);
+        return json;
+    }
+
+    QJsonObject tileToJson(const PatternTile& tile) {
+        QJsonObject json;
+        json["dxTile"] = tile.dxTile;
+        json["dyTile"] = tile.dyTile;
+        json["tileId"] = static_cast<qint64>(tile.tileId);
+        return json;
+    }
+
+    // Reads a required integer-valued field. Returns false (and sets `error`) when the
+    // field is absent or not a JSON number.
+    bool readRequiredInt(const QJsonObject& json, const QString& key, qint64& out, QString* error) {
+        const QJsonValue value = json.value(key);
+        if (!value.isDouble()) {
+            if (error) {
+                *error = QStringLiteral("missing or non-numeric field '%1'").arg(key);
+            }
+            return false;
+        }
+        out = value.toInteger();
+        return true;
+    }
+
+    bool parseObject(const QJsonValue& value, PatternObject& out, QString* error) {
+        if (!value.isObject()) {
+            if (error) {
+                *error = QStringLiteral("object entry is not a JSON object");
+            }
+            return false;
+        }
+        const QJsonObject json = value.toObject();
+
+        qint64 dxHex = 0;
+        qint64 dyHex = 0;
+        qint64 proPid = 0;
+        qint64 frmPid = 0;
+        if (!readRequiredInt(json, QStringLiteral("dxHex"), dxHex, error)
+            || !readRequiredInt(json, QStringLiteral("dyHex"), dyHex, error)
+            || !readRequiredInt(json, QStringLiteral("proPid"), proPid, error)
+            || !readRequiredInt(json, QStringLiteral("frmPid"), frmPid, error)) {
+            return false;
+        }
+
+        out.dxHex = static_cast<int>(dxHex);
+        out.dyHex = static_cast<int>(dyHex);
+        out.proPid = static_cast<uint32_t>(proPid);
+        out.frmPid = static_cast<uint32_t>(frmPid);
+        // direction and flags are optional; default to 0.
+        out.direction = static_cast<uint32_t>(json.value(QStringLiteral("direction")).toInteger(0));
+        out.flags = static_cast<uint32_t>(json.value(QStringLiteral("flags")).toInteger(0));
+        return true;
+    }
+
+    bool parseTile(const QJsonValue& value, PatternTile& out, QString* error) {
+        if (!value.isObject()) {
+            if (error) {
+                *error = QStringLiteral("tile entry is not a JSON object");
+            }
+            return false;
+        }
+        const QJsonObject json = value.toObject();
+
+        qint64 dxTile = 0;
+        qint64 dyTile = 0;
+        qint64 tileId = 0;
+        if (!readRequiredInt(json, QStringLiteral("dxTile"), dxTile, error)
+            || !readRequiredInt(json, QStringLiteral("dyTile"), dyTile, error)
+            || !readRequiredInt(json, QStringLiteral("tileId"), tileId, error)) {
+            return false;
+        }
+
+        out.dxTile = static_cast<int>(dxTile);
+        out.dyTile = static_cast<int>(dyTile);
+        out.tileId = static_cast<uint16_t>(tileId);
+        return true;
+    }
+
+    // Parses a "floor"/"roof"/"objects" array (absent => empty). Returns false on a
+    // malformed entry.
+    template <typename T, typename ParseFn>
+    bool parseArray(const QJsonObject& root, const QString& key, std::vector<T>& out, ParseFn parse, QString* error) {
+        if (!root.contains(key)) {
+            return true; // optional section
+        }
+        const QJsonValue value = root.value(key);
+        if (!value.isArray()) {
+            if (error) {
+                *error = QStringLiteral("field '%1' is not an array").arg(key);
+            }
+            return false;
+        }
+        for (const QJsonValue& entry : value.toArray()) {
+            T parsed;
+            if (!parse(entry, parsed, error)) {
+                if (error) {
+                    *error = QStringLiteral("in '%1': %2").arg(key, *error);
+                }
+                return false;
+            }
+            out.push_back(parsed);
+        }
+        return true;
+    }
+
+} // namespace
+
+QByteArray PatternSerializer::serialize(const Pattern& pattern) {
+    QJsonObject root;
+    root["name"] = QString::fromStdString(pattern.name);
+    root["version"] = pattern.version;
+    root["anchorHex"] = pattern.anchorHex;
+
+    QJsonObject size;
+    size["hexW"] = pattern.sizeHexW;
+    size["hexH"] = pattern.sizeHexH;
+    root["size"] = size;
+
+    root["rotatable"] = pattern.rotatable;
+
+    QJsonArray objects;
+    for (const PatternObject& obj : pattern.objects) {
+        objects.append(objectToJson(obj));
+    }
+    root["objects"] = objects;
+
+    QJsonArray floor;
+    for (const PatternTile& tile : pattern.floor) {
+        floor.append(tileToJson(tile));
+    }
+    root["floor"] = floor;
+
+    QJsonArray roof;
+    for (const PatternTile& tile : pattern.roof) {
+        roof.append(tileToJson(tile));
+    }
+    root["roof"] = roof;
+
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+std::optional<Pattern> PatternSerializer::deserialize(const QByteArray& data, QString* error) {
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        if (error) {
+            *error = QStringLiteral("invalid JSON: %1").arg(parseError.errorString());
+        }
+        return std::nullopt;
+    }
+    if (!doc.isObject()) {
+        if (error) {
+            *error = QStringLiteral("top-level JSON value is not an object");
+        }
+        return std::nullopt;
+    }
+    const QJsonObject root = doc.object();
+
+    qint64 version = 0;
+    if (!readRequiredInt(root, QStringLiteral("version"), version, error)) {
+        return std::nullopt;
+    }
+    if (version != Pattern::CURRENT_VERSION) {
+        if (error) {
+            *error = QStringLiteral("unsupported pattern version %1 (expected %2)")
+                         .arg(version)
+                         .arg(Pattern::CURRENT_VERSION);
+        }
+        return std::nullopt;
+    }
+
+    qint64 anchorHex = 0;
+    if (!readRequiredInt(root, QStringLiteral("anchorHex"), anchorHex, error)) {
+        return std::nullopt;
+    }
+
+    Pattern pattern;
+    pattern.version = static_cast<int>(version);
+    pattern.name = root.value(QStringLiteral("name")).toString().toStdString();
+    pattern.anchorHex = static_cast<int>(anchorHex);
+    pattern.rotatable = root.value(QStringLiteral("rotatable")).toBool(false);
+
+    const QJsonObject size = root.value(QStringLiteral("size")).toObject();
+    pattern.sizeHexW = static_cast<int>(size.value(QStringLiteral("hexW")).toInteger(0));
+    pattern.sizeHexH = static_cast<int>(size.value(QStringLiteral("hexH")).toInteger(0));
+
+    if (!parseArray(root, QStringLiteral("objects"), pattern.objects, parseObject, error)
+        || !parseArray(root, QStringLiteral("floor"), pattern.floor, parseTile, error)
+        || !parseArray(root, QStringLiteral("roof"), pattern.roof, parseTile, error)) {
+        return std::nullopt;
+    }
+
+    return pattern;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSerializer.cpp
+++ b/src/pattern/PatternSerializer.cpp
@@ -1,5 +1,7 @@
 #include "pattern/PatternSerializer.h"
 
+#include <limits>
+
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -9,6 +11,11 @@
 namespace geck::pattern {
 
 namespace {
+
+    constexpr qint64 INT32_LO = std::numeric_limits<int>::min();
+    constexpr qint64 INT32_HI = std::numeric_limits<int>::max();
+    constexpr qint64 U32_HI = std::numeric_limits<uint32_t>::max();
+    constexpr qint64 U16_HI = std::numeric_limits<uint16_t>::max();
 
     QJsonObject objectToJson(const PatternObject& obj) {
         QJsonObject json;
@@ -29,18 +36,40 @@ namespace {
         return json;
     }
 
-    // Reads a required integer-valued field. Returns false (and sets `error`) when the
-    // field is absent or not a JSON number.
-    bool readRequiredInt(const QJsonObject& json, const QString& key, qint64& out, QString* error) {
-        const QJsonValue value = json.value(key);
+    // Validates a JSON value as an integer within [lo, hi]. Rejects non-numeric values
+    // and out-of-range integers (which would otherwise wrap when narrowed to the target
+    // type), so engine IDs/directions/flags/tile-ids cannot be silently corrupted.
+    bool checkInt(const QJsonValue& value, qint64 lo, qint64 hi, const QString& key, qint64& out, QString* error) {
         if (!value.isDouble()) {
             if (error) {
                 *error = QStringLiteral("missing or non-numeric field '%1'").arg(key);
             }
             return false;
         }
-        out = value.toInteger();
+        const qint64 v = value.toInteger();
+        if (v < lo || v > hi) {
+            if (error) {
+                *error = QStringLiteral("field '%1' value %2 is out of range").arg(key).arg(v);
+            }
+            return false;
+        }
+        out = v;
         return true;
+    }
+
+    // Required integer field in [lo, hi].
+    bool readRequired(const QJsonObject& json, const QString& key, qint64 lo, qint64 hi, qint64& out, QString* error) {
+        return checkInt(json.value(key), lo, hi, key, out, error);
+    }
+
+    // Optional integer field: absent => `fallback`; present => validated against [lo, hi]
+    // (a present-but-wrong-type or out-of-range value is an error, not a default).
+    bool readOptional(const QJsonObject& json, const QString& key, qint64 lo, qint64 hi, qint64 fallback, qint64& out, QString* error) {
+        if (!json.contains(key)) {
+            out = fallback;
+            return true;
+        }
+        return checkInt(json.value(key), lo, hi, key, out, error);
     }
 
     bool parseObject(const QJsonValue& value, PatternObject& out, QString* error) {
@@ -56,10 +85,14 @@ namespace {
         qint64 dyHex = 0;
         qint64 proPid = 0;
         qint64 frmPid = 0;
-        if (!readRequiredInt(json, QStringLiteral("dxHex"), dxHex, error)
-            || !readRequiredInt(json, QStringLiteral("dyHex"), dyHex, error)
-            || !readRequiredInt(json, QStringLiteral("proPid"), proPid, error)
-            || !readRequiredInt(json, QStringLiteral("frmPid"), frmPid, error)) {
+        qint64 direction = 0;
+        qint64 flags = 0;
+        if (!readRequired(json, QStringLiteral("dxHex"), INT32_LO, INT32_HI, dxHex, error)
+            || !readRequired(json, QStringLiteral("dyHex"), INT32_LO, INT32_HI, dyHex, error)
+            || !readRequired(json, QStringLiteral("proPid"), 0, U32_HI, proPid, error)
+            || !readRequired(json, QStringLiteral("frmPid"), 0, U32_HI, frmPid, error)
+            || !readOptional(json, QStringLiteral("direction"), 0, U32_HI, 0, direction, error)
+            || !readOptional(json, QStringLiteral("flags"), 0, U32_HI, 0, flags, error)) {
             return false;
         }
 
@@ -67,9 +100,8 @@ namespace {
         out.dyHex = static_cast<int>(dyHex);
         out.proPid = static_cast<uint32_t>(proPid);
         out.frmPid = static_cast<uint32_t>(frmPid);
-        // direction and flags are optional; default to 0.
-        out.direction = static_cast<uint32_t>(json.value(QStringLiteral("direction")).toInteger(0));
-        out.flags = static_cast<uint32_t>(json.value(QStringLiteral("flags")).toInteger(0));
+        out.direction = static_cast<uint32_t>(direction);
+        out.flags = static_cast<uint32_t>(flags);
         return true;
     }
 
@@ -85,9 +117,9 @@ namespace {
         qint64 dxTile = 0;
         qint64 dyTile = 0;
         qint64 tileId = 0;
-        if (!readRequiredInt(json, QStringLiteral("dxTile"), dxTile, error)
-            || !readRequiredInt(json, QStringLiteral("dyTile"), dyTile, error)
-            || !readRequiredInt(json, QStringLiteral("tileId"), tileId, error)) {
+        if (!readRequired(json, QStringLiteral("dxTile"), INT32_LO, INT32_HI, dxTile, error)
+            || !readRequired(json, QStringLiteral("dyTile"), INT32_LO, INT32_HI, dyTile, error)
+            || !readRequired(json, QStringLiteral("tileId"), 0, U16_HI, tileId, error)) {
             return false;
         }
 
@@ -178,7 +210,7 @@ std::optional<Pattern> PatternSerializer::deserialize(const QByteArray& data, QS
     const QJsonObject root = doc.object();
 
     qint64 version = 0;
-    if (!readRequiredInt(root, QStringLiteral("version"), version, error)) {
+    if (!readRequired(root, QStringLiteral("version"), INT32_LO, INT32_HI, version, error)) {
         return std::nullopt;
     }
     if (version != Pattern::CURRENT_VERSION) {
@@ -190,20 +222,41 @@ std::optional<Pattern> PatternSerializer::deserialize(const QByteArray& data, QS
         return std::nullopt;
     }
 
+    const QJsonValue nameValue = root.value(QStringLiteral("name"));
+    if (!nameValue.isString()) {
+        if (error) {
+            *error = QStringLiteral("missing or non-string field 'name'");
+        }
+        return std::nullopt;
+    }
+
     qint64 anchorHex = 0;
-    if (!readRequiredInt(root, QStringLiteral("anchorHex"), anchorHex, error)) {
+    if (!readRequired(root, QStringLiteral("anchorHex"), INT32_LO, INT32_HI, anchorHex, error)) {
+        return std::nullopt;
+    }
+
+    const QJsonValue sizeValue = root.value(QStringLiteral("size"));
+    if (!sizeValue.isObject()) {
+        if (error) {
+            *error = QStringLiteral("missing or non-object field 'size'");
+        }
+        return std::nullopt;
+    }
+    const QJsonObject size = sizeValue.toObject();
+    qint64 hexW = 0;
+    qint64 hexH = 0;
+    if (!readRequired(size, QStringLiteral("hexW"), INT32_LO, INT32_HI, hexW, error)
+        || !readRequired(size, QStringLiteral("hexH"), INT32_LO, INT32_HI, hexH, error)) {
         return std::nullopt;
     }
 
     Pattern pattern;
     pattern.version = static_cast<int>(version);
-    pattern.name = root.value(QStringLiteral("name")).toString().toStdString();
+    pattern.name = nameValue.toString().toStdString();
     pattern.anchorHex = static_cast<int>(anchorHex);
+    pattern.sizeHexW = static_cast<int>(hexW);
+    pattern.sizeHexH = static_cast<int>(hexH);
     pattern.rotatable = root.value(QStringLiteral("rotatable")).toBool(false);
-
-    const QJsonObject size = root.value(QStringLiteral("size")).toObject();
-    pattern.sizeHexW = static_cast<int>(size.value(QStringLiteral("hexW")).toInteger(0));
-    pattern.sizeHexH = static_cast<int>(size.value(QStringLiteral("hexH")).toInteger(0));
 
     if (!parseArray(root, QStringLiteral("objects"), pattern.objects, parseObject, error)
         || !parseArray(root, QStringLiteral("floor"), pattern.floor, parseTile, error)

--- a/src/pattern/PatternSerializer.h
+++ b/src/pattern/PatternSerializer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <optional>
+
+#include <QByteArray>
+#include <QString>
+
+#include "pattern/Pattern.h"
+
+namespace geck::pattern {
+
+/// JSON (de)serialization for the Tier-1 prefab format (PLAN.md §4). PID, direction
+/// and tile-id values are preserved verbatim; the format stores no display labels.
+///
+/// Serialization is total. Deserialization is validated: it rejects malformed JSON,
+/// a missing/unsupported `version`, and entries missing required fields, returning
+/// std::nullopt and (optionally) a human-readable reason rather than a partial
+/// pattern — there is no silent fallback (engine-data-fidelity rule).
+class PatternSerializer {
+public:
+    /// Serializes a pattern to pretty-printed UTF-8 JSON bytes.
+    static QByteArray serialize(const Pattern& pattern);
+
+    /// Parses JSON bytes into a Pattern. On failure returns std::nullopt and, if
+    /// `error` is non-null, sets it to a description of the first problem found.
+    static std::optional<Pattern> deserialize(const QByteArray& data, QString* error = nullptr);
+};
+
+} // namespace geck::pattern

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(general_tests
     general/test_object_queries.cpp
     general/test_reading_dat.cpp
     general/test_reading_map.cpp
+    general/test_pattern_serializer.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_pattern_serializer.cpp
+++ b/tests/general/test_pattern_serializer.cpp
@@ -31,6 +31,31 @@ Pattern makeSamplePattern() {
     return p;
 }
 
+// Wraps an extra top-level fragment (e.g. an "objects"/"floor" array) into an
+// otherwise-minimal valid pattern document, so rejection cases differ only by the
+// part under test.
+QByteArray patternDoc(const QByteArray& extraFields) {
+    QByteArray fields = R"("name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 })";
+    if (!extraFields.isEmpty()) {
+        fields += ", " + extraFields;
+    }
+    return "{ " + fields + " }";
+}
+
+// Asserts a document is rejected. When `needle` is given, also asserts the error
+// names the offending field; otherwise just that some error was reported.
+void checkRejected(const QByteArray& doc, const char* needle = nullptr) {
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(doc, &error);
+    INFO("error: " << error.toStdString());
+    CHECK_FALSE(parsed.has_value());
+    if (needle != nullptr) {
+        CHECK(error.contains(QLatin1String(needle)));
+    } else {
+        CHECK_FALSE(error.isEmpty());
+    }
+}
+
 } // namespace
 
 TEST_CASE("PatternSerializer round-trips a pattern verbatim", "[pattern]") {
@@ -97,90 +122,35 @@ TEST_CASE("PatternSerializer parses a hand-written document", "[pattern]") {
     CHECK(parsed->roof.empty()); // omitted section defaults to empty
 }
 
-TEST_CASE("PatternSerializer rejects malformed input", "[pattern]") {
+TEST_CASE("PatternSerializer rejects malformed and out-of-spec input", "[pattern]") {
     SECTION("invalid JSON") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(QByteArray("{ not json"), &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK_FALSE(error.isEmpty());
+        checkRejected(QByteArray("{ not json"));
     }
-
-    SECTION("top-level array is rejected") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(QByteArray("[]"), &error);
-        CHECK_FALSE(parsed.has_value());
+    SECTION("top-level array is not an object") {
+        checkRejected(QByteArray("[]"));
     }
-
     SECTION("missing version") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "anchorHex": 0 })"), &error);
-        CHECK_FALSE(parsed.has_value());
+        checkRejected(QByteArray(R"({ "name": "x", "anchorHex": 0 })"));
     }
-
     SECTION("unsupported version") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "version": 99, "anchorHex": 0 })"), &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("version"));
+        checkRejected(QByteArray(R"({ "version": 99, "anchorHex": 0 })"), "version");
     }
-
+    SECTION("missing name") {
+        checkRejected(QByteArray(R"({ "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 } })"), "name");
+    }
+    SECTION("missing size") {
+        checkRejected(QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0 })"), "size");
+    }
     SECTION("object missing a required field") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
-                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1 } ] })"),
-            &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("frmPid"));
+        checkRejected(patternDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1 } ])"), "frmPid");
     }
-}
-
-TEST_CASE("PatternSerializer validates required fields, types and ranges", "[pattern]") {
-    SECTION("missing name is rejected") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 } })"), &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("name"));
+    SECTION("a negative proPid would wrap when narrowed, so it is rejected") {
+        checkRejected(patternDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": -1, "frmPid": 0 } ])"), "proPid");
     }
-
-    SECTION("missing size is rejected") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0 })"), &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("size"));
-    }
-
-    SECTION("a negative proPid is rejected (would wrap when narrowed)") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
-                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": -1, "frmPid": 0 } ] })"),
-            &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("proPid"));
-    }
-
     SECTION("a tileId above 65535 is rejected") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
-                "floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 70000 } ] })"),
-            &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("tileId"));
+        checkRejected(patternDoc(R"("floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 70000 } ])"), "tileId");
     }
-
     SECTION("a present-but-non-numeric direction is rejected, not defaulted") {
-        QString error;
-        const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
-                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": "north" } ] })"),
-            &error);
-        CHECK_FALSE(parsed.has_value());
-        CHECK(error.contains("direction"));
+        checkRejected(patternDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": "north" } ])"), "direction");
     }
 }

--- a/tests/general/test_pattern_serializer.cpp
+++ b/tests/general/test_pattern_serializer.cpp
@@ -41,8 +41,8 @@ TEST_CASE("PatternSerializer round-trips a pattern verbatim", "[pattern]") {
 
     QString error;
     const auto parsed = PatternSerializer::deserialize(json, &error);
+    INFO("error: " << error.toStdString()); // shown if the REQUIRE below fails
     REQUIRE(parsed.has_value());
-    INFO("error: " << error.toStdString());
 
     CHECK(parsed->name == original.name);
     CHECK(parsed->version == original.version);
@@ -129,10 +129,58 @@ TEST_CASE("PatternSerializer rejects malformed input", "[pattern]") {
     SECTION("object missing a required field") {
         QString error;
         const auto parsed = PatternSerializer::deserialize(
-            QByteArray(R"({ "version": 1, "anchorHex": 0,
+            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
                 "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1 } ] })"),
             &error);
         CHECK_FALSE(parsed.has_value());
         CHECK(error.contains("frmPid"));
+    }
+}
+
+TEST_CASE("PatternSerializer validates required fields, types and ranges", "[pattern]") {
+    SECTION("missing name is rejected") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 } })"), &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("name"));
+    }
+
+    SECTION("missing size is rejected") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0 })"), &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("size"));
+    }
+
+    SECTION("a negative proPid is rejected (would wrap when narrowed)") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
+                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": -1, "frmPid": 0 } ] })"),
+            &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("proPid"));
+    }
+
+    SECTION("a tileId above 65535 is rejected") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
+                "floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 70000 } ] })"),
+            &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("tileId"));
+    }
+
+    SECTION("a present-but-non-numeric direction is rejected, not defaulted") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "name": "x", "version": 1, "anchorHex": 0, "size": { "hexW": 1, "hexH": 1 },
+                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": "north" } ] })"),
+            &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("direction"));
     }
 }

--- a/tests/general/test_pattern_serializer.cpp
+++ b/tests/general/test_pattern_serializer.cpp
@@ -1,0 +1,138 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <QByteArray>
+#include <QString>
+
+#include "pattern/Pattern.h"
+#include "pattern/PatternSerializer.h"
+
+using namespace geck::pattern;
+
+namespace {
+
+Pattern makeSamplePattern() {
+    Pattern p;
+    p.name = "small_tent";
+    p.version = 1;
+    p.anchorHex = 19998;
+    p.sizeHexW = 6;
+    p.sizeHexH = 5;
+    p.rotatable = true;
+
+    // PIDs chosen to exceed 2^24 so the round-trip proves no precision loss.
+    p.objects.push_back(PatternObject{ 0, 0, 33555201u, 16777345u, 0u, 0u });
+    p.objects.push_back(PatternObject{ 2, 0, 33555201u, 16777345u, 2u, 0x10u });
+    // Negative offsets must survive (objects can sit "before" the anchor).
+    p.objects.push_back(PatternObject{ -3, -1, 33554435u, 16777220u, 5u, 0u });
+
+    p.floor.push_back(PatternTile{ 0, 0, 271 });
+    p.floor.push_back(PatternTile{ 1, 0, 271 });
+    p.roof.push_back(PatternTile{ 0, 0, 4096 });
+    return p;
+}
+
+} // namespace
+
+TEST_CASE("PatternSerializer round-trips a pattern verbatim", "[pattern]") {
+    const Pattern original = makeSamplePattern();
+
+    const QByteArray json = PatternSerializer::serialize(original);
+    REQUIRE_FALSE(json.isEmpty());
+
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(json, &error);
+    REQUIRE(parsed.has_value());
+    INFO("error: " << error.toStdString());
+
+    CHECK(parsed->name == original.name);
+    CHECK(parsed->version == original.version);
+    CHECK(parsed->anchorHex == original.anchorHex);
+    CHECK(parsed->sizeHexW == original.sizeHexW);
+    CHECK(parsed->sizeHexH == original.sizeHexH);
+    CHECK(parsed->rotatable == original.rotatable);
+
+    REQUIRE(parsed->objects.size() == original.objects.size());
+    for (size_t i = 0; i < original.objects.size(); ++i) {
+        const auto& a = original.objects[i];
+        const auto& b = parsed->objects[i];
+        CHECK(b.dxHex == a.dxHex);
+        CHECK(b.dyHex == a.dyHex);
+        CHECK(b.proPid == a.proPid); // verbatim engine PID, no precision loss
+        CHECK(b.frmPid == a.frmPid);
+        CHECK(b.direction == a.direction);
+        CHECK(b.flags == a.flags);
+    }
+
+    REQUIRE(parsed->floor.size() == 2);
+    CHECK(parsed->floor[1].dxTile == 1);
+    CHECK(parsed->floor[1].tileId == 271);
+    REQUIRE(parsed->roof.size() == 1);
+    CHECK(parsed->roof[0].tileId == 4096);
+}
+
+TEST_CASE("PatternSerializer parses a hand-written document", "[pattern]") {
+    const QByteArray doc = R"({
+        "name": "two_walls",
+        "version": 1,
+        "anchorHex": 12345,
+        "size": { "hexW": 3, "hexH": 1 },
+        "rotatable": false,
+        "objects": [
+            { "dxHex": 0, "dyHex": 0, "proPid": 33555201, "frmPid": 16777345, "direction": 1, "flags": 0 }
+        ],
+        "floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 100 } ]
+    })";
+
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(doc, &error);
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->name == "two_walls");
+    CHECK(parsed->anchorHex == 12345);
+    CHECK(parsed->sizeHexW == 3);
+    CHECK_FALSE(parsed->rotatable);
+    REQUIRE(parsed->objects.size() == 1);
+    CHECK(parsed->objects[0].proPid == 33555201u);
+    CHECK(parsed->objects[0].direction == 1u);
+    REQUIRE(parsed->floor.size() == 1);
+    CHECK(parsed->roof.empty()); // omitted section defaults to empty
+}
+
+TEST_CASE("PatternSerializer rejects malformed input", "[pattern]") {
+    SECTION("invalid JSON") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(QByteArray("{ not json"), &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK_FALSE(error.isEmpty());
+    }
+
+    SECTION("top-level array is rejected") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(QByteArray("[]"), &error);
+        CHECK_FALSE(parsed.has_value());
+    }
+
+    SECTION("missing version") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "name": "x", "anchorHex": 0 })"), &error);
+        CHECK_FALSE(parsed.has_value());
+    }
+
+    SECTION("unsupported version") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "version": 99, "anchorHex": 0 })"), &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("version"));
+    }
+
+    SECTION("object missing a required field") {
+        QString error;
+        const auto parsed = PatternSerializer::deserialize(
+            QByteArray(R"({ "version": 1, "anchorHex": 0,
+                "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1 } ] })"),
+            &error);
+        CHECK_FALSE(parsed.has_value());
+        CHECK(error.contains("frmPid"));
+    }
+}


### PR DESCRIPTION
First slice of the prefab/pattern feature (PLAN.md §4). Self-contained: data model + JSON I/O + tests. No rotation, stamping, or UI yet — those are the next slices.

## What
- `pattern::Pattern` — a prefab captured from a selection: relative **object** offsets in hex space and **floor/roof tile** offsets in tile space, anchored at an origin hex (the two coordinate systems are kept distinct per CLAUDE.md).
- `PatternSerializer` — `serialize()` to pretty JSON and `deserialize()` back, with `proPid`/`frmPid`/`direction`/`flags`/`tileId` preserved **verbatim** (engine-data fidelity, no display labels).
- Deserialization is validated, not best-effort: malformed JSON, a missing/unsupported `version`, a non-object top level, or an entry missing a required field all return `std::nullopt` + a reason — no silent partial pattern.

## Why QJson
The codebase already serializes `Settings` with Qt's JSON, and the prefab system is inherently Qt-side (it will route stamping through `ObjectCommandController`). Reusing QJson avoids a new third-party dependency.

## Tests (`test_pattern_serializer.cpp`, headless)
- Round-trips a sample pattern verbatim, including >2^24 PIDs (proves no precision loss) and negative offsets.
- Parses a hand-written document; an omitted `roof` section defaults to empty.
- Rejects: invalid JSON, a top-level array, missing `version`, unsupported `version`, and an object missing `frmPid`.

## Next slices
1. `rotateHexOffset` (engine-matched hex rotation) in `gecko_core` + tests
2. `PatternStamper` — replay a pattern through `ObjectCommandController` as one undo batch (`ScopedUndoBatch`)
3. UI — "Save selection as pattern" + stamp drag-drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)