### PR TITLE
Add hex-grid cube geometry and 60-degree rotation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,6 +396,7 @@ add_library(gecko_core STATIC
     editor/Object.cpp
     editor/HexagonGrid.h
     editor/HexagonGrid.cpp
+    editor/HexGeometry.h
     editor/Hex.h
     editor/Hex.cpp
     editor/helper/ObjectQueries.h

--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "HexagonGrid.h"
+
+#include <optional>
+
+// Fallout 2 hex-grid geometry: cube coordinates and 60-degree rotation.
+//
+// Positions are numbered row-major, position = row * WIDTH + col, over a WIDTH x HEIGHT
+// grid (matches HexagonGrid). The grid uses a column-offset ("even-q") layout, so
+// neighbour deltas in position space are parity-dependent (fallout2-ce src/tile.cc,
+// `_dir_tile[parity][direction]`). Converting to cube coordinates removes that parity
+// dependence and turns rotation into a simple, exact integer operation.
+//
+// Because the layout is offset-based, rotating a *relative* offset is only well-defined
+// once it is resolved against an absolute pivot — hence the primitives here work on
+// absolute positions (0 .. WIDTH*HEIGHT-1), not bare (dx, dy) deltas.
+namespace geck::hexgrid {
+
+inline constexpr int WIDTH = HexagonGrid::GRID_WIDTH;
+inline constexpr int HEIGHT = HexagonGrid::GRID_HEIGHT;
+
+struct Cube {
+    int x = 0;
+    int y = 0;
+    int z = 0;
+    constexpr bool operator==(const Cube&) const = default;
+};
+
+constexpr Cube operator+(const Cube& a, const Cube& b) { return { a.x + b.x, a.y + b.y, a.z + b.z }; }
+constexpr Cube operator-(const Cube& a, const Cube& b) { return { a.x - b.x, a.y - b.y, a.z - b.z }; }
+
+constexpr int columnOf(int position) { return position % WIDTH; }
+constexpr int rowOf(int position) { return position / WIDTH; }
+
+struct ColRow {
+    int col = 0;
+    int row = 0;
+    constexpr bool operator==(const ColRow&) const = default;
+};
+
+// even-q offset (col, row) -> cube. `col + (col & 1)` is always even, so the division is
+// exact even for negative col, making the conversion invertible over all integers (the
+// rotated intermediate values routinely fall outside [0, WIDTH/HEIGHT)).
+constexpr Cube offsetToCube(int col, int row) {
+    const int x = col;
+    const int z = row - (col + (col & 1)) / 2;
+    return { x, -x - z, z };
+}
+
+constexpr ColRow cubeToOffset(const Cube& c) {
+    return { c.x, c.z + (c.x + (c.x & 1)) / 2 };
+}
+
+constexpr Cube cubeOfPosition(int position) {
+    return offsetToCube(columnOf(position), rowOf(position));
+}
+
+// Rotate a cube vector by `steps` 60-degree increments. One +step advances the Fallout 2
+// direction index by one (validated against `_dir_tile` in the tests); +3 is a 180-degree
+// point reflection and +6 is the identity. Negative steps rotate the other way.
+constexpr Cube rotate(const Cube& c, int steps) {
+    int s = steps % 6;
+    if (s < 0) {
+        s += 6;
+    }
+    Cube r = c;
+    for (int i = 0; i < s; ++i) {
+        r = { -r.y, -r.z, -r.x };
+    }
+    return r;
+}
+
+// Unit cube vector pointing along Fallout 2 hex direction d (0..5).
+constexpr Cube directionCube(int d) { return rotate(Cube{ -1, 1, 0 }, d); }
+
+// `direction` rotated by `steps`, normalised to 0..5 (mirrors the object-facing rotation
+// `(direction + steps) % 6`).
+constexpr int rotateDirection(int direction, int steps) {
+    int d = (direction + steps) % 6;
+    if (d < 0) {
+        d += 6;
+    }
+    return d;
+}
+
+// Map `position` — authored relative to `fromAnchor` — to where it lands when the pattern
+// is stamped at `toAnchor` rotated by `steps`. Returns std::nullopt if the result falls
+// outside the grid. With fromAnchor == toAnchor this is an in-place rotation about a pivot.
+inline std::optional<int> stamp(int position, int fromAnchor, int toAnchor, int steps) {
+    const Cube rel = cubeOfPosition(position) - cubeOfPosition(fromAnchor);
+    const ColRow placed = cubeToOffset(cubeOfPosition(toAnchor) + rotate(rel, steps));
+    if (placed.col < 0 || placed.col >= WIDTH || placed.row < 0 || placed.row >= HEIGHT) {
+        return std::nullopt;
+    }
+    return placed.row * WIDTH + placed.col;
+}
+
+// Rotate `position` by `steps` 60-degree increments about `pivot`.
+inline std::optional<int> rotateAround(int position, int pivot, int steps) {
+    return stamp(position, pivot, pivot, steps);
+}
+
+} // namespace geck::hexgrid

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(general_tests
     general/test_object_queries.cpp
     general/test_reading_dat.cpp
     general/test_reading_map.cpp
+    general/test_hex_geometry.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_hex_geometry.cpp
+++ b/tests/general/test_hex_geometry.cpp
@@ -1,0 +1,135 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+
+#include "editor/HexGeometry.h"
+
+using namespace geck::hexgrid;
+
+namespace {
+
+// Ground-truth neighbour deltas (in position space) from fallout2-ce src/tile.cc
+// `_dir_tile[parity][direction]`, with the engine's hex-grid width of 200:
+//   _dir_tile[0] = { -1, W-1, W, W+1, 1, -W }   (even column)
+//   _dir_tile[1] = { -W-1, -1, W, 1, 1-W, -W }  (odd column)
+// These are the single-step neighbour offsets the engine walks in tileGetTileInDirection.
+constexpr std::array<std::array<int, 6>, 2> ENGINE_DIR_TILE = { {
+    { -1, WIDTH - 1, WIDTH, WIDTH + 1, 1, -WIDTH },
+    { -WIDTH - 1, -1, WIDTH, 1, 1 - WIDTH, -WIDTH },
+} };
+
+// Steps one hex from `position` along direction `d` using the cube model under test.
+int stepInDirection(int position, int d) {
+    const ColRow next = cubeToOffset(cubeOfPosition(position) + directionCube(d));
+    return next.row * WIDTH + next.col;
+}
+
+} // namespace
+
+TEST_CASE("offset<->cube round-trips over the grid", "[hex_geometry]") {
+    for (int row = 0; row < HEIGHT; row += 7) {
+        for (int col = 0; col < WIDTH; col += 5) {
+            const Cube cube = offsetToCube(col, row);
+            CHECK(cube.x + cube.y + cube.z == 0); // cube invariant
+            const ColRow back = cubeToOffset(cube);
+            CHECK(back == ColRow{ col, row });
+        }
+    }
+}
+
+TEST_CASE("cube direction steps match the fallout2-ce _dir_tile table", "[hex_geometry]") {
+    // An even and an odd column away from the edges so neighbours stay on-grid.
+    const int evenColPos = 40 * WIDTH + 10; // col 10 (even)
+    const int oddColPos = 40 * WIDTH + 11;  // col 11 (odd)
+
+    for (int d = 0; d < 6; ++d) {
+        INFO("direction " << d);
+        CHECK(stepInDirection(evenColPos, d) - evenColPos == ENGINE_DIR_TILE[0][d]);
+        CHECK(stepInDirection(oddColPos, d) - oddColPos == ENGINE_DIR_TILE[1][d]);
+    }
+}
+
+TEST_CASE("cube rotation has the expected algebraic properties", "[hex_geometry]") {
+    const Cube sample{ 3, -5, 2 };
+
+    SECTION("six steps is the identity and full multiples too") {
+        CHECK(rotate(sample, 6) == sample);
+        CHECK(rotate(sample, 0) == sample);
+        CHECK(rotate(sample, 12) == sample);
+        CHECK(rotate(sample, -6) == sample);
+    }
+
+    SECTION("three steps is a 180-degree point reflection") {
+        CHECK(rotate(sample, 3) == Cube{ -sample.x, -sample.y, -sample.z });
+    }
+
+    SECTION("negative steps invert positive steps") {
+        CHECK(rotate(rotate(sample, 2), -2) == sample);
+        CHECK(rotate(sample, -1) == rotate(sample, 5));
+    }
+
+    SECTION("rotating one direction by k yields the (d+k) direction") {
+        for (int d = 0; d < 6; ++d) {
+            for (int k = 0; k < 6; ++k) {
+                CHECK(rotate(directionCube(d), k) == directionCube((d + k) % 6));
+            }
+        }
+    }
+}
+
+TEST_CASE("rotateDirection wraps facings into 0..5", "[hex_geometry]") {
+    CHECK(rotateDirection(0, 1) == 1);
+    CHECK(rotateDirection(5, 1) == 0);
+    CHECK(rotateDirection(4, 3) == 1);
+    CHECK(rotateDirection(0, -1) == 5);
+    CHECK(rotateDirection(2, 6) == 2);
+}
+
+TEST_CASE("rotateAround moves a neighbour to the rotated neighbour", "[hex_geometry]") {
+    const int pivot = 100 * WIDTH + 100; // well inside the grid
+
+    // A neighbour in direction d, rotated by k steps about the pivot, must land on the
+    // neighbour in direction (d+k)%6 — the engine-consistent definition of rotation.
+    for (int d = 0; d < 6; ++d) {
+        const int neighbour = stepInDirection(pivot, d);
+        for (int k = 0; k < 6; ++k) {
+            const auto rotated = rotateAround(neighbour, pivot, k);
+            REQUIRE(rotated.has_value());
+            const int expected = stepInDirection(pivot, (d + k) % 6);
+            INFO("d=" << d << " k=" << k);
+            CHECK(*rotated == expected);
+        }
+    }
+}
+
+TEST_CASE("rotateAround is identity for full revolutions and zero", "[hex_geometry]") {
+    const int pivot = 100 * WIDTH + 100;
+    const int pos = 100 * WIDTH + 103;
+    CHECK(rotateAround(pos, pivot, 0) == pos);
+    CHECK(rotateAround(pos, pivot, 6) == pos);
+    CHECK(rotateAround(pos, pivot, -6) == pos);
+}
+
+TEST_CASE("stamp translates a pattern offset to the target anchor", "[hex_geometry]") {
+    const int fromAnchor = 50 * WIDTH + 50;
+    const int toAnchor = 120 * WIDTH + 80;
+
+    // With no rotation, stamping reproduces the same offset around the new anchor.
+    const int authored = stepInDirection(fromAnchor, 2); // one hex SE of the authoring anchor
+    const auto placed = stamp(authored, fromAnchor, toAnchor, 0);
+    REQUIRE(placed.has_value());
+    CHECK(*placed == stepInDirection(toAnchor, 2));
+
+    // The anchor itself always maps onto the target anchor, at any rotation.
+    for (int k = 0; k < 6; ++k) {
+        CHECK(stamp(fromAnchor, fromAnchor, toAnchor, k) == toAnchor);
+    }
+}
+
+TEST_CASE("stamp reports positions that rotate off the grid", "[hex_geometry]") {
+    // A hex on the top row rotated 180 degrees about a pivot near the top edge lands
+    // above the grid -> nullopt rather than a wrapped, bogus position.
+    const int pivot = 0 * WIDTH + 100;     // top edge
+    const int neighbour = 1 * WIDTH + 100; // one row down
+    CHECK_FALSE(rotateAround(neighbour, pivot, 3).has_value());
+}


### PR DESCRIPTION
Second slice of the prefab feature (PLAN.md §4) — the engine-matched hex rotation the stamper (next PR) needs. Independent of the format PR (#38); lives in `gecko_core`, Qt-free and headless.

## The subtlety
Fallout 2's hex grid is a **column-offset (even-q)** layout: neighbour deltas in position space are *parity-dependent* (`fallout2-ce/src/tile.cc` `_dir_tile[parity][direction]`). That means rotating a bare `(dx, dy)` offset is ill-defined without an absolute pivot. `HexGeometry` instead converts positions to **cube coordinates**, where a 60° rotation is an exact, parity-free integer op, and exposes primitives that work on **absolute positions**:
- `offsetToCube` / `cubeToOffset` (exact even-division, invertible over all integers)
- `rotate(cube, steps)`, `directionCube(d)`, `rotateDirection(dir, steps)`
- `stamp(pos, fromAnchor, toAnchor, steps)` and `rotateAround(pos, pivot, steps)` → `std::optional<int>` (nullopt when the result rotates off-grid)

## Engine fidelity
The headline test asserts that stepping one hex via the cube model reproduces the engine's `_dir_tile` neighbour offsets — for **both** column parities and **all six** directions. So the geometry matches fallout2-ce by construction, not by guess. Derivation: an even-q offset→cube conversion is the one that reproduces those deltas.

## Tests (2464 assertions, 8 cases, headless)
- offset↔cube round-trips across the grid (+ cube `x+y+z==0` invariant)
- `_dir_tile` engine match (both parities, all directions)
- rotation algebra: 6 steps = identity, 3 = 180° point reflection, negative inverts, `rotate(directionCube(d), k) == directionCube((d+k)%6)`
- `rotateAround` maps a direction-`d` neighbour to the direction-`(d+k)` neighbour; identity for full revolutions
- `stamp` translates an offset to a new anchor and maps the anchor onto itself at any rotation
- off-grid rotation returns `nullopt` instead of a wrapped/bogus position

## Next
PR-3 `PatternStamper` replays a `Pattern` (#38) through `ObjectCommandController` as one `ScopedUndoBatch`, using `stamp()` for positions and `rotateDirection()` for facings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)