### PR TITLE
Add prefab patterns: capture, stamp, and a thumbnail browser

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,201 +1,13 @@
 # Improvement Backlog
 
-## Test-suite audit & refactor plan
+## Test-suite audit & refactor plan — DONE
 
-Audit of `tests/` (22 source files, ~117 `TEST_CASE`s across `general_tests`,
-`performance_tests`, `qt_tests`). The format round-trip coverage (PRO all-types,
-MAP all-object-types + engine-framing regressions) is genuinely strong; the gaps
-are in (a) the other binary formats, (b) editor/coordinate invariants, and (c)
-duplicated scaffolding plus a fragile fixture-path setup. Items are ordered by
-value/effort.
-
-### P0 — Shared test-support header (highest leverage, unblocks everything below)
-
-Create `tests/support/` with a small, header-only support library linked into all
-three executables. The two round-trip suites already re-derive the same helpers;
-new format tests would copy them a third and fourth time.
-
-- **`tests/support/Fixtures.h`** — one function `geck::test::dataDir()` /
-  `dataPath(name)` that resolves fixtures from a compile-time
-  `GECK_TEST_DATA_DIR` (see P1). Replaces the bare `"data/test.gam"` string
-  literal repeated in `test_reading_gam.cpp`, `test_reading_msg.cpp`,
-  `test_reading_pro_drug.cpp`, `test_pro_roundtrip.cpp`, and the `"data/…"` calls
-  inside `test_reader_performance.cpp`.
-- **`tests/support/TempFile.h`** — RAII `TempFile{stem, ".pro"}` that picks a
-  unique path under `temp_directory_path()`, removes any stale copy on
-  construction, and unlinks on destruction. This collapses the near-identical
-  `makeTempProPath()` (test_pro_roundtrip.cpp:24) and `tempMapPath()`
-  (test_map_roundtrip.cpp:44) plus the hand-written `std::error_code ec;
-  std::filesystem::remove(...)` cleanup that appears at the end of **every**
-  round-trip `TEST_CASE` (10+ copies). Also folds in `readAllBytes()`
-  (test_pro_roundtrip.cpp:15) for byte-for-byte comparisons.
-- **`tests/support/ProStubProvider.h`** — promote `StubProvider` from
-  test_map_roundtrip.cpp (the in-memory `pid -> Pro` map with `addItem` /
-  `addScenery` / `set` / `load`) and the free `pidOf(OBJECT_TYPE, index)` helper.
-  These are exactly the provider callbacks `MapReader`/`MapWriter` take, so any
-  future MAP or object-query test needs them. Keep `StubProvider` returning raw
-  subtype-only `Pro`s (the only thing (de)serialization dereferences).
-- **`tests/support/MapObjectBuilder.h`** — promote `fillBase()` / `checkBase()`
-  (test_map_roundtrip.cpp:54/76) and the local `add(proPid, seed)` lambda into a
-  reusable builder/asserter over the 22-field base block. This is the single
-  biggest duplicated block and is needed verbatim by the MAP fixture test (P2)
-  and any editor/selection test that fabricates objects.
-- **`tests/support/ProBuilder.h`** — the `roundTrip(Pro, path)` helper
-  (test_pro_roundtrip.cpp:183) plus thin constructors that set a PID with the
-  correct type nibble (`(type<<24)|index`), currently re-spelled in every PRO
-  `TEST_CASE`.
-
-Wire it up in `tests/CMakeLists.txt` as
-`add_library(test_support INTERFACE)` with
-`target_include_directories(test_support INTERFACE ${CMAKE_SOURCE_DIR}/tests)`,
-and link it into `general_tests`, `performance_tests`, `qt_tests`. Migrate the two
-existing round-trip suites onto it in the same change to prove the API.
-
-### P1 — Make fixture loading robust (fixes the ctest-only gotcha)
-
-**Problem:** `general_tests` / `performance_tests` load fixtures via bare relative
-paths (`reader.openFile("data/test.gam")`). These only resolve because
-`catch_discover_tests` runs each test with its working directory defaulting to
-`$<TARGET_FILE_DIR>` (the build dir, where the post-build `copy_directory` rule
-drops `data/`). Running the executable directly from any other cwd
-(`./build/general_tests`, a debugger, an IDE) silently fails to find fixtures.
-Only `qt_tests` does this correctly, via the `GECK_TEST_DATA_DIR` compile
-definition (tests/CMakeLists.txt:60-62).
-
-**Fix:**
-1. Add `target_compile_definitions(general_tests PRIVATE
-   GECK_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data")` (and the same for
-   `performance_tests`). Point fixtures at the source tree so no copy step is
-   needed for *reading*.
-2. Route all fixture access through `test::dataPath()` (P0). Delete the bare
-   `"data/…"` literals.
-3. Once fixtures resolve by absolute path, the per-target
-   `copy_directory tests/data` POST_BUILD commands (tests/CMakeLists.txt:108-118)
-   become dead weight — drop them (keep only what `qt_tests` still needs for the
-   `resources/` copy).
-4. Add a `set_tests_properties(... PROPERTIES WORKING_DIRECTORY ...)` is then
-   unnecessary; document in `AGENTS.md` that fixtures are absolute and tests are
-   cwd-independent.
-
-### P2 — Highest-value missing tests (format round-trips & editor invariants)
-
-Format fidelity is the project's core promise; these are the untested formats and
-the load-bearing editor math.
-
-**Formats / readers / writers (priority order):**
-
-1. **FRM round-trip + correctness** — `FrmReader` is exercised only for *timing*
-   in `test_reader_performance.cpp` (in-memory buffer, no assertions on decoded
-   frames). No correctness test exists, and there is **no `FrmWriter`** — confirm
-   whether FRM is read-only; if so, add a read-correctness test against a small
-   real `.frm` fixture (frame count, dimensions, per-direction offsets, pixel-0
-   sanity). `new tests/general/test_reading_frm.cpp`.
-2. **DAT reader correctness in `general_tests`** — `DatReader` is only touched by
-   `test_dat_archive.cpp` in the **qt** suite (because it pulls the resource
-   stack), exercising the vfspp path. Add a pure-`vault` test for the raw
-   `DatReader` (entry table parse, compressed vs stored entries, file extraction
-   bytes) using the existing `tests/data/f2_res.dat` fixture. Belongs in
-   `general_tests` (no Qt needed). `new tests/general/test_reading_dat.cpp`.
-3. **LST reader** — `LstReader` (used everywhere for proto/script list lookups)
-   has zero coverage. Add a trivial fixture test: line parsing, comment/whitespace
-   trimming, 1-based vs 0-based indexing, CRLF handling.
-   `new tests/general/test_reading_lst.cpp`.
-4. **PAL reader** — `PalReader` untested. Small, deterministic: 256-entry palette,
-   6-bit→8-bit channel scaling, the cycling/animation indices. Pairs well with a
-   `ColorUtils` test. `new tests/general/test_reading_pal.cpp`.
-5. **MAP read from a real fixture** — the MAP round-trip is fully synthetic (no
-   `.map` on disk). Add one small real `.map` fixture and assert header +
-   representative objects/tiles parse, to catch reader assumptions the synthetic
-   path can't (real elevation flags, real script sections, tile blocks).
-   Reuses the P0 `StubProvider`. Extend `test_map_roundtrip.cpp` or
-   `new tests/general/test_reading_map.cpp`.
-6. **MSG / GAM negative + edge cases** — current tests assert a few happy-path
-   lookups. Add: missing message id, the documented unclosed-`}` recovery
-   (test_reading_msg.cpp has a `FIXME` for messages #1382/#32020 — turn it into a
-   real expectation or an xfail), empty file, duplicate ids.
-
-**Editor / selection / util invariants (priority order):**
-
-7. **`Coordinates.h` round-trips & clamping** — `HexPosition` (0–39999),
-   `TileIndex` (0–9999), and the world/screen/hex conversions are the project's
-   most safety-critical math (the CLAUDE.md "never validate hex against
-   TILES_PER_ELEVATION" rule lives or dies here). Test `isValid()` boundaries,
-   `operator+/-` clamping at the 39999/9999 edges, and world→hex→world stability.
-   `new tests/general/test_coordinates.cpp`.
-8. **`HexagonGrid` invariants** — only 2 `TEST_CASE`s today. Add:
-   `positionForCoordinates`↔`coordinatesForPosition` round-trip over the whole
-   grid, `containsPosition` boundary, `tileIndexForPosition` mapping
-   (200×200 hex ↔ 100×100 tile), and `rectangleBorderPositions` for a known rect.
-9. **`UndoStack`** — pure, deterministic, zero deps, currently untested. Test
-   push/undo/redo ordering, redo-stack invalidation on new push, the
-   `_maxCommands` eviction (oldest dropped), `lastUndo/RedoLabel`, and the
-   reject-on-missing-undo/redo guard (UndoStack.h:26). High value because every
-   instance-edit feature in this very PLAN routes through it.
-10. **`object_query` (ObjectQueries.h)** — `blocksMovement` /
-    `isWallBlocker` / `isShootThroughWallBlocker` read PRO flags and gate
-    movement/rendering. Testable with the P0 `StubProvider` supplying flag bits;
-    no Qt needed (but needs `GameResources`, so likely a `qt_tests` resident).
-11. **`SpatialIndex` / `TileSpatialIndex`** — query-correctness (point/area/radius
-    membership, no duplicates across cells, update/remove consistency). Pure
-    geometry over SFML rects; belongs in `general_tests`.
-
-### P3 — Structure & categorization cleanup
-
-The 3-executable split (general = pure C++ logic, performance = Catch2 benchmarks,
-qt = needs `gecko::app` + `Qt6::Test`) is sound and the boundary is mostly clean.
-Issues:
-
-- **Naming is inconsistent.** Two conventions coexist: `test_reading_<fmt>.cpp`
-  (gam/msg/pro_drug) vs `test_<fmt>_roundtrip.cpp` (pro/map) vs
-  `test_<subject>.cpp` (everything else). Pick one. Recommend
-  `test_<subject>.cpp` for unit/logic and reserve `_roundtrip` as a meaningful
-  suffix; rename `test_reading_gam/msg/pro_drug` → `test_gam/test_msg/test_pro`
-  (and fold `test_reading_pro_drug` into the PRO suite, since `test_pro_roundtrip`
-  already owns the drug fixture). This also de-confuses "reading" tests that
-  actually only read vs the round-trip ones.
-- **`test_reading_pro_drug.cpp` is redundant.** Its single happy-path drug parse
-  is a strict subset of `test_pro_roundtrip.cpp`'s Level-1 case (same fixture).
-  Merge and delete.
-- **No tag-based categorization.** Catch2 tags exist (`[map]`, `[pro]`,
-  `[selection_state]`, …) but `ctest` can't filter by them (AGENTS/CLAUDE both
-  note "no ctest label registration"). Low priority, but `catch_discover_tests`
-  supports `TEST_PREFIX`/`PROPERTIES LABELS` — consider emitting one ctest label
-  per top-level area so `ctest -L format` works.
-- **`test_selection_system.cpp` is a 1631-line, 24-`TEST_CASE` monolith** (a third
-  of all test LOC). It mixes `SelectionState`, tile/hex coordinate conversions,
-  selection-mode enums, and "original" position-conversion cases. Split into
-  `test_selection_state.cpp`, `test_tile_hex_conversion.cpp` (overlaps
-  `test_tile_utils.cpp` — consolidate), and fold the coordinate cases into the new
-  `test_coordinates.cpp` (P2#7). Several of its coordinate `SECTION`s duplicate
-  `test_tile_utils.cpp` and `test_selection_system.cpp` itself.
-- **Misplacement check:** `test_data_path_resolution.cpp` and
-  `test_game_data_path_resolver.cpp` are near-siblings split across qt/general by
-  whether they touch `DataFileSystem`. That's defensible, but verify the general
-  one doesn't transitively need Qt; if it links cleanly it's correctly placed.
-
-### P4 — Other duplication to retire (after P0 lands)
-
-- The **writer-then-reader block** `{ Writer w; w.openFile(p); REQUIRE(w.write(x)); }`
-  immediately followed by `Reader r; auto back = r.openFile(p);` appears in every
-  round-trip case in both PRO and MAP suites. The P0 `roundTrip()` /
-  `MapRoundTrip()` helpers cover PRO and inline MAP; add a `mapRoundTrip(MapFile,
-  StubProvider&)` to fully retire it.
-- The **`pidOf` / type-nibble PID construction**
-  (`(static_cast<uint32_t>(type) << 24) | index`) is hand-inlined in ~8 places
-  across both suites with slightly different casts — centralize in P0.
-- **Per-test temp-path + `std::error_code ec; remove(...)` cleanup** — fully
-  removed by `TempFile` RAII (P0).
-
-### Suggested sequencing
-
-1. **P0 + P1 together** (shared support header + robust fixtures; migrate the two
-   existing round-trip suites onto them as the proof). Net LOC should *drop*.
-2. **P2 formats** (FRM, DAT-in-general, LST, PAL, real-MAP fixture) — each is a
-   small file that reuses P0.
-3. **P2 invariants** (Coordinates, HexagonGrid, UndoStack first — pure & zero-dep;
-   then object_query, SpatialIndex).
-4. **P3 restructure** (renames, split the selection monolith, merge the redundant
-   drug test) — purely mechanical once P0 helpers exist.
+The P0–P4 plan landed: a shared `tests/support/` header + robust build-tree fixtures,
+the missing format round-trips and editor/coordinate-invariant tests, and the
+selection-monolith split. `general_tests`, `performance_tests` and `qt_tests` now cover
+the binary formats, coordinate/hex geometry, selection, undo + command-controller, and the
+pattern/prefab code. Any remaining test gaps are tracked inline with the features that need
+them.
 
 ## Architecture backlog (remaining)
 
@@ -215,30 +27,6 @@ Issues:
 *(Done since this backlog was first written: the four-library CMake split with per-target
 includes + `cmake/dependencies.cmake`; the `ProEditorDialog` breakup into `ui/widgets/pro/`
 — now 367 lines; and removal of the macOS `post-build-test.sh`.)*
-
-## Known tool-mode (EditorMode) UI gaps
-
-These surfaced while building the `EditorMode` state machine (`EditorWidget::setMode`,
-`src/ui/core/EditorMode.h`). The state machine itself is correct — these are missing
-UI affordances, not regressions:
-
-- **No "Select tool" affordance to exit a tool mode.** Once in tile painting (or
-  Mark-Exits / Set-Player-Position), the only way back to plain Select is Escape /
-  right-click cancel (or deselecting the tile in the palette). The "Selection mode"
-  toolbar button (`_selectionModeAction`) only changes the *selection type*
-  (`SelectionMode`: All/Objects/Tiles/…), **not** the tool mode (`EditorMode`), so
-  clicking it does not exit painting. Fix: add a dedicated Select-tool toolbar/menu
-  action that calls `EditorWidget::setMode(EditorMode::Select)` (and consider having
-  the selection-type dropdown also drop the active tool mode). Pre-existing.
-
-- **Exit-grid *placement* mode has no UI trigger.** `EditorMode::PlaceExitGrid` /
-  `setExitGridPlacementMode(true)` is fully wired internally (InputHandler's
-  `onExitGridPlacement` callback at `EditorWidget.cpp` → `ExitGridPlacementManager`),
-  but nothing in the UI ever enters the mode, so exit-grid placement is unreachable.
-  Only Mark-Exits (editing existing exit grids) has a button. Fix: add a toolbar/menu
-  action to enter `PlaceExitGrid`. Pre-existing / incomplete feature.
-
----
 
 ## Done — engine MAP compatibility & instance/map editing
 
@@ -392,9 +180,21 @@ Adopt **C as the core**, structured so **B** falls out for free and **A** remain
 
 # Scripting & Automation Layer (Patterns / Prefabs + Procedural Generation)
 
-> Status: design proposal. Grounded in `src/format/map/Map.h`, `MapObject.h`,
-> `src/editor/HexagonGrid.h` / `Hex.h`, `src/format/map/Tile.h`,
-> `src/ui/editing/ObjectCommandController.h`, and `src/util/UndoStack.h`.
+> Status: **Tier-1 prefabs implemented**; Tier-2 scripting still a design proposal.
+> Grounded in `src/format/map/Map.h`, `MapObject.h`, `src/editor/HexagonGrid.h` / `Hex.h`,
+> `src/format/map/Tile.h`, `src/ui/editing/ObjectCommandController.h`, and `src/util/UndoStack.h`.
+>
+> **Implemented (`src/pattern/`):** the prefab format + JSON serializer, hex cube geometry
+> (`src/editor/HexGeometry.h`), `PatternStamper` (place a variant as one undo entry, with
+> a parity-snap so floor/roof tiles stay locked to the objects), `PatternBuilder` (capture a
+> selection), the `ObjectCommandController` undo-batching, and the UI (Save Selection as
+> Pattern, Stamp Pattern mode with a ghost preview, default library folder). Remaining:
+> the pattern **browser** (cached on-the-fly thumbnails + folders), and the Tier-2 work.
+>
+> **Important correction to §4 below:** orientation is **not** done by geometric rotation —
+> F2 object art is direction-specific, so a pattern stores one or more **pre-authored
+> orientation variants** that the editor cycles through. The `rotatable` / rotate-at-stamp
+> design in §4/§9 was superseded by the variant-set model.
 
 ## 1. Goals & two use cases
 
@@ -602,10 +402,61 @@ the user to press Ctrl-Z thousands of times. Therefore:
 
 ## 9. Open questions
 
-- Hex rotation correctness on the F2 odd/even-row layout (needs golden tests).
+- ~~Hex rotation correctness~~ — moot: no geometric rotation (variant-set model); the cube
+  geometry is validated against fallout2-ce's `_dir_tile`. The remaining geometry choice was
+  the stamp parity-snap (tiles vs objects), now resolved.
 - Multi-elevation prefabs (store/stamp across the 3 `ELEVATION_COUNT` slots?).
 - Collision policy on stamp (overwrite vs skip vs error when target hexes are occupied).
-- Whether to lift `UndoStack::maxCommands` or rely solely on batching (batching is enough).
+- Scripts in patterns (object scripts via `programIndex`; spatial scripts) — deferred; see
+  the script-model notes (programIndex is portable, SID/OID re-allocated at stamp).
+- Tile-id range: the format stores `uint16` but `Tile` masks to 12 bits (`& 0x0FFF`); decide
+  whether to cap `tileId` at 4095 in the format.
+
+---
+
+# Map loader panel with thumbnail previews
+
+> Status: planned. A visual map picker that lists available maps as rendered thumbnails
+> with their names, so a designer browses maps by sight instead of by filename. Replaces /
+> augments the plain "Open Map" file dialog and the text-only file browser.
+
+## What it is
+A dockable panel (or a dialog reachable from the Welcome screen / File menu) showing a grid
+of map thumbnails + names, with a larger preview of the highlighted map. Double-click (or an
+"Open" button) loads the map. Optional: a search/filter box and a folder/source grouping
+(vanilla `master.dat` maps vs user/filesystem maps).
+
+## Where maps come from
+Enumerate `*.map` under `maps/` across the mounted VFS (`master.dat`/`critter.dat` + any
+mounted DATs) plus filesystem data paths — the same surface `FileBrowserPanel` /
+`DataFileSystem` already walk, so reuse that enumeration rather than re-scanning.
+
+## Thumbnails — reuse the pattern compositor
+A map thumbnail is "render this map to an image, scaled to fit". This is the **same offscreen
+compositor + disk cache** being built for the Tier-1 pattern browser (§4-5 above): generalize
+it to "render a set of tiles + objects to an `sf::RenderTexture`, read back to a `QImage`",
+and both patterns and maps feed it. Differences for maps:
+- A map render is **much heavier** than a prefab (up to `TILES_PER_ELEVATION` floor/roof
+  tiles + all objects on the default elevation), and producing it means **loading the map**
+  (`MapLoader` parse + FRM/tile resolution). So the **disk cache is mandatory**, keyed by map
+  path + size/mtime, with **lazy** (visible-cell-only) and **background** generation — never
+  block the UI loading dozens of maps up front.
+- Decide the thumbnail's elevation (default 0) and whether to include objects/critters or just
+  the tile layer (tiles alone are cheaper and already give a recognizable silhouette).
+
+## Reuse / dependencies
+- **Offscreen thumbnail compositor + disk cache** — shared with the pattern browser; build it
+  generic from the start (it's the prerequisite for both).
+- **Headless/offscreen map render path** — the current renderer is tied to the live editor
+  view; the same generalization the pattern thumbnails need (render to an arbitrary target)
+  applies here. Ties into the WP-9 "UI-free render" seam.
+- **Grid + folder view widgets** — shared with the pattern browser's grid.
+
+## Rough effort
+M–L. The grid/panel UI is S–M; the heavy/risky part is the offscreen map render + cache
+(shared with patterns) and keeping browsing responsive over a large map set (lazy + background
++ persisted cache). Sequence **after** the pattern thumbnail compositor exists, since it
+provides the rendering+cache foundation this reuses.
 
 ---
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,8 @@ set(GECK_APP_SOURCES
     ui/rendering/MapSpriteLoader.cpp
     ui/rendering/RenderingEngine.h
     ui/rendering/RenderingEngine.cpp
+    ui/rendering/ThumbnailRenderer.h
+    ui/rendering/ThumbnailRenderer.cpp
     ui/editing/ObjectCommandController.h
     ui/editing/ObjectCommandController.cpp
     ui/input/InputHandler.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ set(GECK_APP_SOURCES
     pattern/Pattern.h
     pattern/PatternSerializer.h
     pattern/PatternSerializer.cpp
+    pattern/PatternStamper.h
+    pattern/PatternStamper.cpp
 
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,8 @@ set(GECK_APP_SOURCES
     ui/dialogs/SpatialScriptDialog.cpp
     ui/dialogs/AboutDialog.h
     ui/dialogs/AboutDialog.cpp
+    ui/dialogs/PatternBrowserDialog.h
+    ui/dialogs/PatternBrowserDialog.cpp
 
     # Qt6 UI Widgets
     ui/widgets/SFMLWidget.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ set(GECK_APP_SOURCES
     pattern/PatternSerializer.cpp
     pattern/PatternStamper.h
     pattern/PatternStamper.cpp
+    pattern/PatternBuilder.h
+    pattern/PatternBuilder.cpp
 
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -400,6 +400,7 @@ add_library(gecko_core STATIC
     editor/Object.cpp
     editor/HexagonGrid.h
     editor/HexagonGrid.cpp
+    editor/HexGeometry.h
     editor/Hex.h
     editor/Hex.cpp
     editor/helper/ObjectQueries.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,10 @@ set(GECK_APP_SOURCES
     util/Settings.h
     util/Settings.cpp
 
+    pattern/Pattern.h
+    pattern/PatternSerializer.h
+    pattern/PatternSerializer.cpp
+
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,10 @@ set(GECK_APP_SOURCES
     pattern/PatternBuilder.cpp
     pattern/PatternLibrary.h
     pattern/PatternLibrary.cpp
+    pattern/PatternSprite.h
+    pattern/PatternSprite.cpp
+    pattern/PatternThumbnail.h
+    pattern/PatternThumbnail.cpp
 
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,8 @@ set(GECK_APP_SOURCES
     pattern/PatternStamper.cpp
     pattern/PatternBuilder.h
     pattern/PatternBuilder.cpp
+    pattern/PatternLibrary.h
+    pattern/PatternLibrary.cpp
 
     util/ExternalEditorLauncher.h
     util/ExternalEditorLauncher.cpp

--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "HexagonGrid.h"
+
+#include <optional>
+
+// Fallout 2 hex-grid geometry: cube coordinates and shape-preserving translation.
+//
+// Positions are numbered row-major, position = row * WIDTH + col, over a WIDTH x HEIGHT
+// grid (matches HexagonGrid). The grid uses a column-offset ("even-q") layout, so
+// neighbour deltas in position space are parity-dependent (fallout2-ce src/tile.cc,
+// `_dir_tile[parity][direction]`). Converting to cube coordinates removes that parity
+// dependence, so translating a captured shape from one anchor to another (the stamp
+// operation) preserves its layout even when the anchors have different column parity.
+namespace geck::hexgrid {
+
+inline constexpr int WIDTH = HexagonGrid::GRID_WIDTH;
+inline constexpr int HEIGHT = HexagonGrid::GRID_HEIGHT;
+
+struct Cube {
+    int x = 0;
+    int y = 0;
+    int z = 0;
+    constexpr bool operator==(const Cube&) const = default;
+};
+
+constexpr Cube operator+(const Cube& a, const Cube& b) { return { a.x + b.x, a.y + b.y, a.z + b.z }; }
+constexpr Cube operator-(const Cube& a, const Cube& b) { return { a.x - b.x, a.y - b.y, a.z - b.z }; }
+
+constexpr int columnOf(int position) { return position % WIDTH; }
+constexpr int rowOf(int position) { return position / WIDTH; }
+
+struct ColRow {
+    int col = 0;
+    int row = 0;
+    constexpr bool operator==(const ColRow&) const = default;
+};
+
+// even-q offset (col, row) -> cube. `col + (col & 1)` is always even, so the division is
+// exact even for negative col, making the conversion invertible over all integers (a
+// translated intermediate value can fall outside [0, WIDTH/HEIGHT)).
+constexpr Cube offsetToCube(int col, int row) {
+    const int x = col;
+    const int z = row - (col + (col & 1)) / 2;
+    return { x, -x - z, z };
+}
+
+constexpr ColRow cubeToOffset(const Cube& c) {
+    return { c.x, c.z + (c.x + (c.x & 1)) / 2 };
+}
+
+constexpr Cube cubeOfPosition(int position) {
+    return offsetToCube(columnOf(position), rowOf(position));
+}
+
+// Map `position` — authored relative to `fromAnchor` — to where it lands when the shape
+// is stamped at `toAnchor`. Translation happens in cube space so the shape is preserved
+// regardless of the two anchors' column parity. Returns std::nullopt if the result falls
+// outside the grid.
+inline std::optional<int> translate(int position, int fromAnchor, int toAnchor) {
+    const Cube placed = cubeOfPosition(toAnchor) + (cubeOfPosition(position) - cubeOfPosition(fromAnchor));
+    const ColRow cr = cubeToOffset(placed);
+    if (cr.col < 0 || cr.col >= WIDTH || cr.row < 0 || cr.row >= HEIGHT) {
+        return std::nullopt;
+    }
+    return cr.row * WIDTH + cr.col;
+}
+
+} // namespace geck::hexgrid

--- a/src/pattern/Pattern.h
+++ b/src/pattern/Pattern.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace geck::pattern {
+
+/// A single object captured in a pattern variant, positioned by its hex offset
+/// relative to the variant's anchor. PID and direction values are stored verbatim
+/// (engine data fidelity — the format carries no display labels).
+struct PatternObject {
+    int dxHex = 0; ///< Hex-space column offset from the anchor.
+    int dyHex = 0; ///< Hex-space row offset from the anchor.
+    uint32_t proPid = 0;
+    uint32_t frmPid = 0;
+    uint32_t direction = 0; ///< Stored verbatim; matches the authored sprite.
+    uint32_t flags = 0;
+};
+
+/// A floor or roof tile captured in a pattern variant, positioned by its tile offset
+/// relative to the anchor. Tile space is a distinct 100x100 grid from hex space —
+/// never validate one against the other's range (see CLAUDE.md).
+struct PatternTile {
+    int dxTile = 0;
+    int dyTile = 0;
+    uint16_t tileId = 0;
+};
+
+/// One authored orientation of a pattern (e.g. "entrance west"). Fallout 2 object art
+/// is direction-specific — a wall facing NE is a different PRO/FRM than one facing NW —
+/// so orientations are pre-authored variants rather than computed by rotation. Stamping
+/// places a variant verbatim, translated from its anchor to the target hex.
+struct PatternVariant {
+    std::string label;
+    int anchorHex = 0; ///< Authoring origin; object/tile offsets are relative to this.
+    std::vector<PatternObject> objects;
+    std::vector<PatternTile> floor;
+    std::vector<PatternTile> roof;
+};
+
+/// A reusable prefab captured from a selection, holding one or more orientation
+/// variants the editor cycles through at stamp time. Serialized to JSON by
+/// PatternSerializer.
+struct Pattern {
+    static constexpr int CURRENT_VERSION = 1;
+
+    std::string name;
+    int version = CURRENT_VERSION;
+    std::vector<PatternVariant> variants; ///< At least one.
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternBuilder.cpp
+++ b/src/pattern/PatternBuilder.cpp
@@ -1,0 +1,103 @@
+#include "pattern/PatternBuilder.h"
+
+#include "editor/HexGeometry.h"
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/Tile.h"
+#include "selection/SelectionState.h"
+#include "util/TileUtils.h"
+
+namespace geck::pattern {
+
+PatternVariant PatternBuilder::buildVariant(
+    const std::vector<const MapObject*>& objects,
+    const std::vector<TileSelection>& floorTiles,
+    const std::vector<TileSelection>& roofTiles,
+    int anchorHex,
+    const std::string& label) {
+    using namespace geck::hexgrid;
+
+    PatternVariant variant;
+    variant.label = label;
+    variant.anchorHex = anchorHex;
+
+    const int anchorCol = columnOf(anchorHex);
+    const int anchorRow = rowOf(anchorHex);
+    for (const MapObject* obj : objects) {
+        if (obj == nullptr) {
+            continue;
+        }
+        variant.objects.push_back(PatternObject{
+            columnOf(obj->position) - anchorCol,
+            rowOf(obj->position) - anchorRow,
+            obj->pro_pid,
+            obj->frm_pid,
+            obj->direction,
+            obj->flags });
+    }
+
+    // Tile offsets are relative to the anchor's tile (the tile containing the anchor hex).
+    const int anchorTileCol = anchorCol / 2;
+    const int anchorTileRow = anchorRow / 2;
+    const auto addTiles = [&](const std::vector<TileSelection>& src, std::vector<PatternTile>& dst) {
+        for (const auto& [tileIndex, tileId] : src) {
+            const int col = tileIndex % HexagonGrid::TILE_GRID_WIDTH;
+            const int row = tileIndex / HexagonGrid::TILE_GRID_WIDTH;
+            dst.push_back(PatternTile{ col - anchorTileCol, row - anchorTileRow, tileId });
+        }
+    };
+    addTiles(floorTiles, variant.floor);
+    addTiles(roofTiles, variant.roof);
+
+    return variant;
+}
+
+std::optional<Pattern> PatternBuilder::fromSelection(const selection::SelectionState& selection,
+    Map& map, int elevation, const std::string& name) {
+    std::vector<const MapObject*> objects;
+    for (const auto& object : selection.getObjects()) {
+        if (object && object->hasMapObject()) {
+            objects.push_back(object->getMapObjectPtr().get());
+        }
+    }
+
+    const auto& tilesByElevation = map.getMapFile().tiles;
+    const auto elevationIt = tilesByElevation.find(elevation);
+    const auto readTiles = [&](const std::vector<int>& indices, bool isRoof) {
+        std::vector<TileSelection> out;
+        out.reserve(indices.size());
+        for (int index : indices) {
+            uint16_t tileId = 0;
+            if (elevationIt != tilesByElevation.end() && index >= 0
+                && index < static_cast<int>(elevationIt->second.size())) {
+                tileId = isRoof ? elevationIt->second[index].getRoof() : elevationIt->second[index].getFloor();
+            }
+            out.emplace_back(index, tileId);
+        }
+        return out;
+    };
+    const std::vector<TileSelection> floorTiles = readTiles(selection.getFloorTileIndices(), false);
+    const std::vector<TileSelection> roofTiles = readTiles(selection.getRoofTileIndices(), true);
+
+    if (objects.empty() && floorTiles.empty() && roofTiles.empty()) {
+        return std::nullopt;
+    }
+
+    int anchorHex = 0;
+    if (!objects.empty()) {
+        anchorHex = objects.front()->position;
+    } else if (!floorTiles.empty()) {
+        anchorHex = tileIndexToHexIndex(floorTiles.front().first);
+    } else {
+        anchorHex = tileIndexToHexIndex(roofTiles.front().first);
+    }
+
+    Pattern pattern;
+    pattern.name = name;
+    pattern.variants.push_back(buildVariant(objects, floorTiles, roofTiles, anchorHex, "default"));
+    return pattern;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternBuilder.h
+++ b/src/pattern/PatternBuilder.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pattern/Pattern.h"
+
+namespace geck {
+struct MapObject;
+class Map;
+namespace selection {
+    class SelectionState;
+}
+} // namespace geck
+
+namespace geck::pattern {
+
+/// Captures a selection into a pattern (the inverse of PatternStamper). Object hexes and
+/// tile indices become offsets relative to an anchor hex, so the result can be stamped
+/// elsewhere. The capture is verbatim (engine IDs preserved); orientation variants are
+/// authored by capturing the same prefab in different facings.
+class PatternBuilder {
+public:
+    using TileSelection = std::pair<int, uint16_t>; ///< (tile index in tile space, tile id)
+
+    /// Build one variant from selected objects and tiles, as offsets from `anchorHex`.
+    /// Pure — no map/resource access (tile ids are supplied by the caller).
+    static PatternVariant buildVariant(
+        const std::vector<const MapObject*>& objects,
+        const std::vector<TileSelection>& floorTiles,
+        const std::vector<TileSelection>& roofTiles,
+        int anchorHex,
+        const std::string& label);
+
+    /// Build a single-variant pattern from a live selection: extract objects, read the
+    /// selected tiles' ids from the map's `elevation`, and derive an anchor (the first
+    /// object's hex, else the first floor/roof tile's hex). Returns std::nullopt when the
+    /// selection has neither objects nor tiles.
+    static std::optional<Pattern> fromSelection(const selection::SelectionState& selection,
+        Map& map,
+        int elevation,
+        const std::string& name);
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternLibrary.cpp
+++ b/src/pattern/PatternLibrary.cpp
@@ -1,0 +1,16 @@
+#include "pattern/PatternLibrary.h"
+
+#include <QDir>
+#include <QStandardPaths>
+
+namespace geck::pattern {
+
+QString PatternLibrary::rootDir() {
+    // Mirror Settings' location convention: <ConfigLocation>/gecko/<...>.
+    const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    const QString patternsPath = QDir(configPath).filePath(QStringLiteral("gecko/patterns"));
+    QDir().mkpath(patternsPath);
+    return patternsPath;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternLibrary.h
+++ b/src/pattern/PatternLibrary.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QString>
+
+namespace geck::pattern {
+
+/// Locates the user's pattern library on disk. Patterns live alongside the app's
+/// settings, under <ConfigLocation>/gecko/patterns, and may be organised into
+/// subfolders. The browser and the save/load dialogs default to this location.
+class PatternLibrary {
+public:
+    /// The pattern library root, created on first use. Returns an absolute path.
+    static QString rootDir();
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSerializer.cpp
+++ b/src/pattern/PatternSerializer.cpp
@@ -15,7 +15,8 @@ namespace {
     constexpr qint64 INT32_LO = std::numeric_limits<int>::min();
     constexpr qint64 INT32_HI = std::numeric_limits<int>::max();
     constexpr qint64 U32_HI = std::numeric_limits<uint32_t>::max();
-    constexpr qint64 U16_HI = std::numeric_limits<uint16_t>::max();
+    constexpr qint64 DIRECTION_HI = 5;    // Fallout 2 hex facings are 0..5.
+    constexpr qint64 TILE_ID_HI = 0x0FFF; // Engine tile ids are 12-bit (Tile masks & 0x0FFF).
 
     QJsonObject objectToJson(const PatternObject& obj) {
         QJsonObject json;
@@ -110,7 +111,7 @@ namespace {
             || !readRequired(json, QStringLiteral("dyHex"), INT32_LO, INT32_HI, dyHex, error)
             || !readRequired(json, QStringLiteral("proPid"), 0, U32_HI, proPid, error)
             || !readRequired(json, QStringLiteral("frmPid"), 0, U32_HI, frmPid, error)
-            || !readOptional(json, QStringLiteral("direction"), 0, U32_HI, 0, direction, error)
+            || !readOptional(json, QStringLiteral("direction"), 0, DIRECTION_HI, 0, direction, error)
             || !readOptional(json, QStringLiteral("flags"), 0, U32_HI, 0, flags, error)) {
             return false;
         }
@@ -138,7 +139,7 @@ namespace {
         qint64 tileId = 0;
         if (!readRequired(json, QStringLiteral("dxTile"), INT32_LO, INT32_HI, dxTile, error)
             || !readRequired(json, QStringLiteral("dyTile"), INT32_LO, INT32_HI, dyTile, error)
-            || !readRequired(json, QStringLiteral("tileId"), 0, U16_HI, tileId, error)) {
+            || !readRequired(json, QStringLiteral("tileId"), 0, TILE_ID_HI, tileId, error)) {
             return false;
         }
 

--- a/src/pattern/PatternSerializer.cpp
+++ b/src/pattern/PatternSerializer.cpp
@@ -1,0 +1,279 @@
+#include "pattern/PatternSerializer.h"
+
+#include <limits>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+
+namespace geck::pattern {
+
+namespace {
+
+    constexpr qint64 INT32_LO = std::numeric_limits<int>::min();
+    constexpr qint64 INT32_HI = std::numeric_limits<int>::max();
+    constexpr qint64 U32_HI = std::numeric_limits<uint32_t>::max();
+    constexpr qint64 U16_HI = std::numeric_limits<uint16_t>::max();
+
+    QJsonObject objectToJson(const PatternObject& obj) {
+        QJsonObject json;
+        json["dxHex"] = obj.dxHex;
+        json["dyHex"] = obj.dyHex;
+        json["proPid"] = static_cast<qint64>(obj.proPid);
+        json["frmPid"] = static_cast<qint64>(obj.frmPid);
+        json["direction"] = static_cast<qint64>(obj.direction);
+        json["flags"] = static_cast<qint64>(obj.flags);
+        return json;
+    }
+
+    QJsonObject tileToJson(const PatternTile& tile) {
+        QJsonObject json;
+        json["dxTile"] = tile.dxTile;
+        json["dyTile"] = tile.dyTile;
+        json["tileId"] = static_cast<qint64>(tile.tileId);
+        return json;
+    }
+
+    template <typename T, typename ToJson>
+    QJsonArray arrayToJson(const std::vector<T>& items, ToJson toJson) {
+        QJsonArray out;
+        for (const T& item : items) {
+            out.append(toJson(item));
+        }
+        return out;
+    }
+
+    QJsonObject variantToJson(const PatternVariant& variant) {
+        QJsonObject json;
+        json["label"] = QString::fromStdString(variant.label);
+        json["anchorHex"] = variant.anchorHex;
+        json["objects"] = arrayToJson(variant.objects, objectToJson);
+        json["floor"] = arrayToJson(variant.floor, tileToJson);
+        json["roof"] = arrayToJson(variant.roof, tileToJson);
+        return json;
+    }
+
+    // Validates a JSON value as an integer within [lo, hi]. Rejects non-numeric values
+    // and out-of-range integers (which would otherwise wrap when narrowed to the target
+    // type), so engine IDs/directions/flags/tile-ids cannot be silently corrupted.
+    bool checkInt(const QJsonValue& value, qint64 lo, qint64 hi, const QString& key, qint64& out, QString* error) {
+        if (!value.isDouble()) {
+            if (error) {
+                *error = QStringLiteral("missing or non-numeric field '%1'").arg(key);
+            }
+            return false;
+        }
+        const qint64 v = value.toInteger();
+        if (v < lo || v > hi) {
+            if (error) {
+                *error = QStringLiteral("field '%1' value %2 is out of range").arg(key).arg(v);
+            }
+            return false;
+        }
+        out = v;
+        return true;
+    }
+
+    // Required integer field in [lo, hi].
+    bool readRequired(const QJsonObject& json, const QString& key, qint64 lo, qint64 hi, qint64& out, QString* error) {
+        return checkInt(json.value(key), lo, hi, key, out, error);
+    }
+
+    // Optional integer field: absent => `fallback`; present => validated against [lo, hi]
+    // (a present-but-wrong-type or out-of-range value is an error, not a default).
+    bool readOptional(const QJsonObject& json, const QString& key, qint64 lo, qint64 hi, qint64 fallback, qint64& out, QString* error) {
+        if (!json.contains(key)) {
+            out = fallback;
+            return true;
+        }
+        return checkInt(json.value(key), lo, hi, key, out, error);
+    }
+
+    bool parseObject(const QJsonValue& value, PatternObject& out, QString* error) {
+        if (!value.isObject()) {
+            if (error) {
+                *error = QStringLiteral("object entry is not a JSON object");
+            }
+            return false;
+        }
+        const QJsonObject json = value.toObject();
+
+        qint64 dxHex = 0;
+        qint64 dyHex = 0;
+        qint64 proPid = 0;
+        qint64 frmPid = 0;
+        qint64 direction = 0;
+        qint64 flags = 0;
+        if (!readRequired(json, QStringLiteral("dxHex"), INT32_LO, INT32_HI, dxHex, error)
+            || !readRequired(json, QStringLiteral("dyHex"), INT32_LO, INT32_HI, dyHex, error)
+            || !readRequired(json, QStringLiteral("proPid"), 0, U32_HI, proPid, error)
+            || !readRequired(json, QStringLiteral("frmPid"), 0, U32_HI, frmPid, error)
+            || !readOptional(json, QStringLiteral("direction"), 0, U32_HI, 0, direction, error)
+            || !readOptional(json, QStringLiteral("flags"), 0, U32_HI, 0, flags, error)) {
+            return false;
+        }
+
+        out.dxHex = static_cast<int>(dxHex);
+        out.dyHex = static_cast<int>(dyHex);
+        out.proPid = static_cast<uint32_t>(proPid);
+        out.frmPid = static_cast<uint32_t>(frmPid);
+        out.direction = static_cast<uint32_t>(direction);
+        out.flags = static_cast<uint32_t>(flags);
+        return true;
+    }
+
+    bool parseTile(const QJsonValue& value, PatternTile& out, QString* error) {
+        if (!value.isObject()) {
+            if (error) {
+                *error = QStringLiteral("tile entry is not a JSON object");
+            }
+            return false;
+        }
+        const QJsonObject json = value.toObject();
+
+        qint64 dxTile = 0;
+        qint64 dyTile = 0;
+        qint64 tileId = 0;
+        if (!readRequired(json, QStringLiteral("dxTile"), INT32_LO, INT32_HI, dxTile, error)
+            || !readRequired(json, QStringLiteral("dyTile"), INT32_LO, INT32_HI, dyTile, error)
+            || !readRequired(json, QStringLiteral("tileId"), 0, U16_HI, tileId, error)) {
+            return false;
+        }
+
+        out.dxTile = static_cast<int>(dxTile);
+        out.dyTile = static_cast<int>(dyTile);
+        out.tileId = static_cast<uint16_t>(tileId);
+        return true;
+    }
+
+    // Parses an "objects"/"floor"/"roof" array (absent => empty). Returns false on a
+    // malformed entry.
+    template <typename T, typename ParseFn>
+    bool parseArray(const QJsonObject& root, const QString& key, std::vector<T>& out, ParseFn parse, QString* error) {
+        if (!root.contains(key)) {
+            return true; // optional section
+        }
+        const QJsonValue value = root.value(key);
+        if (!value.isArray()) {
+            if (error) {
+                *error = QStringLiteral("field '%1' is not an array").arg(key);
+            }
+            return false;
+        }
+        for (const QJsonValue& entry : value.toArray()) {
+            T parsed;
+            if (!parse(entry, parsed, error)) {
+                if (error) {
+                    *error = QStringLiteral("in '%1': %2").arg(key, *error);
+                }
+                return false;
+            }
+            out.push_back(parsed);
+        }
+        return true;
+    }
+
+    bool parseVariant(const QJsonValue& value, PatternVariant& out, QString* error) {
+        if (!value.isObject()) {
+            if (error) {
+                *error = QStringLiteral("variant entry is not a JSON object");
+            }
+            return false;
+        }
+        const QJsonObject json = value.toObject();
+
+        qint64 anchorHex = 0;
+        if (!readRequired(json, QStringLiteral("anchorHex"), INT32_LO, INT32_HI, anchorHex, error)) {
+            return false;
+        }
+        out.anchorHex = static_cast<int>(anchorHex);
+        out.label = json.value(QStringLiteral("label")).toString().toStdString();
+
+        return parseArray(json, QStringLiteral("objects"), out.objects, parseObject, error)
+            && parseArray(json, QStringLiteral("floor"), out.floor, parseTile, error)
+            && parseArray(json, QStringLiteral("roof"), out.roof, parseTile, error);
+    }
+
+} // namespace
+
+QByteArray PatternSerializer::serialize(const Pattern& pattern) {
+    QJsonObject root;
+    root["name"] = QString::fromStdString(pattern.name);
+    root["version"] = pattern.version;
+    root["variants"] = arrayToJson(pattern.variants, variantToJson);
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+std::optional<Pattern> PatternSerializer::deserialize(const QByteArray& data, QString* error) {
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        if (error) {
+            *error = QStringLiteral("invalid JSON: %1").arg(parseError.errorString());
+        }
+        return std::nullopt;
+    }
+    if (!doc.isObject()) {
+        if (error) {
+            *error = QStringLiteral("top-level JSON value is not an object");
+        }
+        return std::nullopt;
+    }
+    const QJsonObject root = doc.object();
+
+    qint64 version = 0;
+    if (!readRequired(root, QStringLiteral("version"), INT32_LO, INT32_HI, version, error)) {
+        return std::nullopt;
+    }
+    if (version != Pattern::CURRENT_VERSION) {
+        if (error) {
+            *error = QStringLiteral("unsupported pattern version %1 (expected %2)")
+                         .arg(version)
+                         .arg(Pattern::CURRENT_VERSION);
+        }
+        return std::nullopt;
+    }
+
+    const QJsonValue nameValue = root.value(QStringLiteral("name"));
+    if (!nameValue.isString()) {
+        if (error) {
+            *error = QStringLiteral("missing or non-string field 'name'");
+        }
+        return std::nullopt;
+    }
+
+    const QJsonValue variantsValue = root.value(QStringLiteral("variants"));
+    if (!variantsValue.isArray()) {
+        if (error) {
+            *error = QStringLiteral("missing or non-array field 'variants'");
+        }
+        return std::nullopt;
+    }
+    const QJsonArray variantsArray = variantsValue.toArray();
+    if (variantsArray.isEmpty()) {
+        if (error) {
+            *error = QStringLiteral("a pattern must have at least one variant");
+        }
+        return std::nullopt;
+    }
+
+    Pattern pattern;
+    pattern.version = static_cast<int>(version);
+    pattern.name = nameValue.toString().toStdString();
+    for (const QJsonValue& entry : variantsArray) {
+        PatternVariant variant;
+        if (!parseVariant(entry, variant, error)) {
+            if (error) {
+                *error = QStringLiteral("in 'variants': %1").arg(*error);
+            }
+            return std::nullopt;
+        }
+        pattern.variants.push_back(std::move(variant));
+    }
+
+    return pattern;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSerializer.h
+++ b/src/pattern/PatternSerializer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <optional>
+
+#include <QByteArray>
+#include <QString>
+
+#include "pattern/Pattern.h"
+
+namespace geck::pattern {
+
+/// JSON (de)serialization for the Tier-1 prefab format (PLAN.md §4). PID, direction
+/// and tile-id values are preserved verbatim; the format stores no display labels.
+///
+/// Serialization is total. Deserialization is validated: it rejects malformed JSON,
+/// a missing/unsupported `version`, and entries missing required fields, returning
+/// std::nullopt and (optionally) a human-readable reason rather than a partial
+/// pattern — there is no silent fallback (engine-data-fidelity rule).
+class PatternSerializer {
+public:
+    /// Serializes a pattern to pretty-printed UTF-8 JSON bytes.
+    static QByteArray serialize(const Pattern& pattern);
+
+    /// Parses JSON bytes into a Pattern. On failure returns std::nullopt and, if
+    /// `error` is non-null, sets it to a description of the first problem found.
+    static std::optional<Pattern> deserialize(const QByteArray& data, QString* error = nullptr);
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSerializer.h
+++ b/src/pattern/PatternSerializer.h
@@ -9,8 +9,8 @@
 
 namespace geck::pattern {
 
-/// JSON (de)serialization for the Tier-1 prefab format (PLAN.md §4). PID, direction
-/// and tile-id values are preserved verbatim; the format stores no display labels.
+/// JSON (de)serialization for the prefab pattern format. PID, direction and tile-id
+/// values are preserved verbatim; the format stores no display labels.
 ///
 /// Serialization is total. Deserialization is validated: it rejects malformed JSON,
 /// a missing/unsupported `version`, and entries missing required fields, returning

--- a/src/pattern/PatternSprite.cpp
+++ b/src/pattern/PatternSprite.cpp
@@ -1,0 +1,49 @@
+#include "pattern/PatternSprite.h"
+
+#include <string>
+
+#include <SFML/Graphics.hpp>
+#include <spdlog/spdlog.h>
+
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/frm/Frm.h"
+#include "resource/GameResources.h"
+
+namespace geck::pattern {
+
+std::shared_ptr<Object> buildSpriteObject(resource::GameResources& resources,
+    const HexagonGrid& hexgrid, uint32_t frmPid, int hex, uint32_t direction) {
+    const Frm* frm = nullptr;
+    std::string frmPath;
+    try {
+        frmPath = resources.frmResolver().resolve(frmPid);
+        if (!frmPath.empty()) {
+            frm = resources.repository().load<Frm>(frmPath);
+        }
+    } catch (const std::exception& e) {
+        spdlog::warn("buildSpriteObject: FRM resolve/load failed for fid {}: {}", frmPid, e.what());
+    }
+
+    // Object requires valid art (it draws a sprite); without a resolvable FRM there is
+    // nothing to build, so the caller skips this entry.
+    if (frm == nullptr) {
+        return nullptr;
+    }
+
+    try {
+        auto object = std::make_shared<Object>(frm);
+        sf::Sprite sprite{ resources.textures().get(frmPath) };
+        object->setSprite(std::move(sprite));
+        object->setDirection(static_cast<ObjectDirection>(direction));
+        if (auto h = hexgrid.getHexByPosition(static_cast<uint32_t>(hex)); h.has_value()) {
+            object->setHexPosition(h->get());
+        }
+        return object;
+    } catch (const std::exception& e) {
+        spdlog::warn("buildSpriteObject: failed to build object for fid {}: {}", frmPid, e.what());
+        return nullptr;
+    }
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSprite.cpp
+++ b/src/pattern/PatternSprite.cpp
@@ -8,7 +8,10 @@
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
 #include "format/frm/Frm.h"
+#include "format/lst/Lst.h"
+#include "format/map/Map.h"
 #include "resource/GameResources.h"
+#include "util/TileUtils.h"
 
 namespace geck::pattern {
 
@@ -43,6 +46,27 @@ std::shared_ptr<Object> buildSpriteObject(resource::GameResources& resources,
     } catch (const std::exception& e) {
         spdlog::warn("buildSpriteObject: failed to build object for fid {}: {}", frmPid, e.what());
         return nullptr;
+    }
+}
+
+std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
+    int tileIndex, bool isRoof, uint16_t tileId) {
+    if (tileId == static_cast<uint16_t>(Map::EMPTY_TILE)) {
+        return std::nullopt;
+    }
+    const auto* tileList = resources.repository().find<Lst>("art/tiles/tiles.lst");
+    if (tileList == nullptr || tileId >= tileList->list().size()) {
+        return std::nullopt;
+    }
+    try {
+        const std::string tilePath = "art/tiles/" + tileList->list()[tileId];
+        sf::Sprite sprite{ resources.textures().get(tilePath) };
+        const ScreenPosition pos = indexToScreenPosition(tileIndex, isRoof);
+        sprite.setPosition({ static_cast<float>(pos.x), static_cast<float>(pos.y) });
+        return sprite;
+    } catch (const std::exception& e) {
+        spdlog::warn("buildTileSprite: tile {} art failed: {}", tileId, e.what());
+        return std::nullopt;
     }
 }
 

--- a/src/pattern/PatternSprite.h
+++ b/src/pattern/PatternSprite.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace geck {
+class HexagonGrid;
+class Object;
+namespace resource {
+    class GameResources;
+}
+} // namespace geck
+
+namespace geck::pattern {
+
+/// Resolve `frmPid` to game art and build an Object sprite positioned at hex `hex`,
+/// facing `direction`. Returns nullptr if the art cannot be resolved/loaded (the
+/// caller skips it). Shared by the stamper, the stamp ghost preview and the
+/// thumbnail compositor so the FRM->sprite->Object path lives in one place.
+std::shared_ptr<Object> buildSpriteObject(resource::GameResources& resources,
+    const HexagonGrid& hexgrid,
+    uint32_t frmPid,
+    int hex,
+    uint32_t direction);
+
+} // namespace geck::pattern

--- a/src/pattern/PatternSprite.h
+++ b/src/pattern/PatternSprite.h
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
+
+#include <SFML/Graphics/Sprite.hpp>
 
 namespace geck {
 class HexagonGrid;
@@ -22,5 +25,13 @@ std::shared_ptr<Object> buildSpriteObject(resource::GameResources& resources,
     uint32_t frmPid,
     int hex,
     uint32_t direction);
+
+/// Build a floor/roof tile sprite (tile id -> tiles.lst name -> art) positioned at the
+/// tile's isometric screen coordinates. Returns std::nullopt for empty/unresolvable
+/// tiles. Shared by the thumbnail compositor and the stamp ghost preview.
+std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
+    int tileIndex,
+    bool isRoof,
+    uint16_t tileId);
 
 } // namespace geck::pattern

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -24,12 +24,25 @@ PatternStamper::Plan PatternStamper::plan(const PatternVariant& variant, int tar
 
     const int anchorCol = columnOf(variant.anchorHex);
     const int anchorRow = rowOf(variant.anchorHex);
+
+    // Objects place at hex precision (cube translation, shape-preserving) but tiles only
+    // at tile precision (2-hex steps). Because the hex grid is column-offset, those two
+    // translations only agree when the target column has the same parity as the anchor
+    // column; otherwise the cube-translated objects drift relative to the tiles (visible
+    // as the roof sitting off the walls, differently for each click). Snapping the target
+    // column to the anchor's parity locks objects and tiles together.
+    int targetCol = columnOf(targetHex);
+    if (((targetCol ^ anchorCol) & 1) != 0) {
+        targetCol += (targetCol > 0) ? -1 : 1;
+    }
+    const int snappedTarget = rowOf(targetHex) * WIDTH + targetCol;
+
     for (const PatternObject& obj : variant.objects) {
         const int col = anchorCol + obj.dxHex;
         const int row = anchorRow + obj.dyHex;
         std::optional<int> placed;
         if (col >= 0 && col < WIDTH && row >= 0 && row < HEIGHT) {
-            placed = translate(row * WIDTH + col, variant.anchorHex, targetHex);
+            placed = translate(row * WIDTH + col, variant.anchorHex, snappedTarget);
         }
         if (placed.has_value()) {
             p.objects.push_back({ *placed, obj.proPid, obj.frmPid, obj.direction, obj.flags });
@@ -39,9 +52,9 @@ PatternStamper::Plan PatternStamper::plan(const PatternVariant& variant, int tar
     }
 
     // Tile offsets are relative to the anchor's tile, so a stamp re-anchors them on the
-    // target hex's tile. The tile grid is a plain square grid (no parity offset).
-    const int targetTileCol = columnOf(targetHex) / 2;
-    const int targetTileRow = rowOf(targetHex) / 2;
+    // (snapped) target hex's tile. The tile grid is a plain square grid (no parity offset).
+    const int targetTileCol = targetCol / 2;
+    const int targetTileRow = rowOf(snappedTarget) / 2;
     const auto resolveTiles = [&](const std::vector<PatternTile>& src, bool isRoof) {
         for (const PatternTile& t : src) {
             const int col = targetTileCol + t.dxTile;

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -1,0 +1,162 @@
+#include "pattern/PatternStamper.h"
+
+#include <optional>
+
+#include <SFML/Graphics.hpp>
+#include <spdlog/spdlog.h>
+
+#include "editor/HexGeometry.h"
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/frm/Frm.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/Tile.h"
+#include "resource/GameResources.h"
+#include "ui/core/TileChange.h"
+#include "ui/editing/ObjectCommandController.h"
+
+namespace geck::pattern {
+
+PatternStamper::Plan PatternStamper::plan(const PatternVariant& variant, int targetHex) {
+    using namespace geck::hexgrid;
+    Plan p;
+
+    const int anchorCol = columnOf(variant.anchorHex);
+    const int anchorRow = rowOf(variant.anchorHex);
+    for (const PatternObject& obj : variant.objects) {
+        const int col = anchorCol + obj.dxHex;
+        const int row = anchorRow + obj.dyHex;
+        std::optional<int> placed;
+        if (col >= 0 && col < WIDTH && row >= 0 && row < HEIGHT) {
+            placed = translate(row * WIDTH + col, variant.anchorHex, targetHex);
+        }
+        if (placed.has_value()) {
+            p.objects.push_back({ *placed, obj.proPid, obj.frmPid, obj.direction, obj.flags });
+        } else {
+            ++p.objectsDropped;
+        }
+    }
+
+    // Tile offsets are relative to the anchor's tile, so a stamp re-anchors them on the
+    // target hex's tile. The tile grid is a plain square grid (no parity offset).
+    const int targetTileCol = columnOf(targetHex) / 2;
+    const int targetTileRow = rowOf(targetHex) / 2;
+    const auto resolveTiles = [&](const std::vector<PatternTile>& src, bool isRoof) {
+        for (const PatternTile& t : src) {
+            const int col = targetTileCol + t.dxTile;
+            const int row = targetTileRow + t.dyTile;
+            if (col >= 0 && col < HexagonGrid::TILE_GRID_WIDTH && row >= 0 && row < HexagonGrid::TILE_GRID_HEIGHT) {
+                p.tiles.push_back({ row * HexagonGrid::TILE_GRID_WIDTH + col, isRoof, t.tileId });
+            } else {
+                ++p.tilesDropped;
+            }
+        }
+    };
+    resolveTiles(variant.floor, false);
+    resolveTiles(variant.roof, true);
+
+    return p;
+}
+
+PatternStamper::PatternStamper(resource::GameResources& resources, const HexagonGrid& hexgrid,
+    ObjectCommandController& controller, Map& map)
+    : _resources(resources)
+    , _hexgrid(hexgrid)
+    , _controller(controller)
+    , _map(map) { }
+
+std::shared_ptr<Object> PatternStamper::buildObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid) const {
+    const Frm* frm = nullptr;
+    std::string frmPath;
+    try {
+        frmPath = _resources.frmResolver().resolve(frmPid);
+        if (!frmPath.empty()) {
+            frm = _resources.repository().load<Frm>(frmPath);
+        }
+    } catch (const std::exception& e) {
+        spdlog::warn("PatternStamper: FRM resolve/load failed for fid {}: {}", frmPid, e.what());
+    }
+
+    // Object requires valid art (it draws a sprite); without a resolvable FRM there is
+    // nothing to place, so the caller skips this entry rather than crashing.
+    if (frm == nullptr) {
+        return nullptr;
+    }
+
+    try {
+        auto object = std::make_shared<Object>(frm);
+        object->setMapObject(mapObject);
+        sf::Sprite sprite{ _resources.textures().get(frmPath) };
+        object->setSprite(std::move(sprite));
+        object->setDirection(static_cast<ObjectDirection>(mapObject->direction));
+        if (auto hex = _hexgrid.getHexByPosition(static_cast<uint32_t>(mapObject->position)); hex.has_value()) {
+            object->setHexPosition(hex->get());
+        }
+        return object;
+    } catch (const std::exception& e) {
+        spdlog::warn("PatternStamper: failed to build object for fid {}: {}", frmPid, e.what());
+        return nullptr;
+    }
+}
+
+PatternStamper::Result PatternStamper::stamp(const PatternVariant& variant, int targetHex, int elevation) {
+    const Plan p = plan(variant, targetHex);
+    Result r;
+    r.dropped = p.objectsDropped + p.tilesDropped;
+    if (p.objects.empty() && p.tiles.empty()) {
+        return r;
+    }
+
+    const std::string desc = variant.label.empty() ? "Stamp pattern" : ("Stamp pattern: " + variant.label);
+    ScopedUndoBatch batch(_controller, desc);
+
+    for (const ObjectPlacement& op : p.objects) {
+        auto mapObject = std::make_shared<MapObject>();
+        mapObject->position = op.hex;
+        mapObject->elevation = static_cast<uint32_t>(elevation);
+        mapObject->direction = op.direction;
+        mapObject->frame_number = 0;
+        if (auto hex = _hexgrid.getHexByPosition(static_cast<uint32_t>(op.hex)); hex.has_value()) {
+            mapObject->x = static_cast<uint32_t>(hex->get().x());
+            mapObject->y = static_cast<uint32_t>(hex->get().y());
+        }
+        mapObject->pro_pid = op.proPid;
+        mapObject->frm_pid = op.frmPid;
+        mapObject->flags = op.flags;
+        mapObject->critter_index = -1;
+        mapObject->map_scripts_pid = -1;
+        mapObject->script_id = -1;
+        mapObject->amount = 1;
+
+        auto object = buildObject(mapObject, op.frmPid);
+        if (object && _controller.registerObjectPlacement(mapObject, object)) {
+            ++r.objectsPlaced;
+        } else {
+            ++r.objectsFailed;
+        }
+    }
+
+    if (!p.tiles.empty()) {
+        std::vector<TileChange> changes;
+        changes.reserve(p.tiles.size());
+        const auto& tilesByElevation = _map.getMapFile().tiles;
+        const auto it = tilesByElevation.find(elevation);
+        for (const TilePlacement& tp : p.tiles) {
+            uint16_t before = static_cast<uint16_t>(Map::EMPTY_TILE);
+            if (it != tilesByElevation.end() && tp.tileIndex >= 0
+                && tp.tileIndex < static_cast<int>(it->second.size())) {
+                before = tp.isRoof ? it->second[tp.tileIndex].getRoof() : it->second[tp.tileIndex].getFloor();
+            }
+            changes.push_back({ elevation, tp.tileIndex, tp.isRoof, before, tp.tileId });
+        }
+        _controller.applyTileChanges(changes, true);
+        _controller.registerTileEdit(desc + " (tiles)", changes);
+        r.tilesPainted = static_cast<int>(changes.size());
+    }
+
+    r.success = true;
+    return r;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -25,17 +25,20 @@ PatternStamper::Plan PatternStamper::plan(const PatternVariant& variant, int tar
     const int anchorCol = columnOf(variant.anchorHex);
     const int anchorRow = rowOf(variant.anchorHex);
 
-    // Objects place at hex precision (cube translation, shape-preserving) but tiles only
-    // at tile precision (2-hex steps). Because the hex grid is column-offset, those two
-    // translations only agree when the target column has the same parity as the anchor
-    // column; otherwise the cube-translated objects drift relative to the tiles (visible
-    // as the roof sitting off the walls, differently for each click). Snapping the target
-    // column to the anchor's parity locks objects and tiles together.
+    // Objects place at hex precision but tiles only at tile precision (hex/2 in both
+    // axes). For the hex->tile division to round the same way at capture and stamp time,
+    // the target must share the anchor's parity in BOTH column and row; otherwise the
+    // tiles round up to half a tile off the objects (visible as the roof sitting off the
+    // walls, slightly and differently for each click). Snap both axes to the anchor.
     int targetCol = columnOf(targetHex);
+    int targetRow = rowOf(targetHex);
     if (((targetCol ^ anchorCol) & 1) != 0) {
         targetCol += (targetCol > 0) ? -1 : 1;
     }
-    const int snappedTarget = rowOf(targetHex) * WIDTH + targetCol;
+    if (((targetRow ^ anchorRow) & 1) != 0) {
+        targetRow += (targetRow > 0) ? -1 : 1;
+    }
+    const int snappedTarget = targetRow * WIDTH + targetCol;
 
     for (const PatternObject& obj : variant.objects) {
         const int col = anchorCol + obj.dxHex;
@@ -54,7 +57,7 @@ PatternStamper::Plan PatternStamper::plan(const PatternVariant& variant, int tar
     // Tile offsets are relative to the anchor's tile, so a stamp re-anchors them on the
     // (snapped) target hex's tile. The tile grid is a plain square grid (no parity offset).
     const int targetTileCol = targetCol / 2;
-    const int targetTileRow = rowOf(snappedTarget) / 2;
+    const int targetTileRow = targetRow / 2;
     const auto resolveTiles = [&](const std::vector<PatternTile>& src, bool isRoof) {
         for (const PatternTile& t : src) {
             const int col = targetTileCol + t.dxTile;

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -12,6 +12,7 @@
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "format/map/Tile.h"
+#include "pattern/PatternSprite.h"
 #include "resource/GameResources.h"
 #include "ui/core/TileChange.h"
 #include "ui/editing/ObjectCommandController.h"
@@ -83,37 +84,11 @@ PatternStamper::PatternStamper(resource::GameResources& resources, const Hexagon
     , _map(map) { }
 
 std::shared_ptr<Object> PatternStamper::buildObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid) const {
-    const Frm* frm = nullptr;
-    std::string frmPath;
-    try {
-        frmPath = _resources.frmResolver().resolve(frmPid);
-        if (!frmPath.empty()) {
-            frm = _resources.repository().load<Frm>(frmPath);
-        }
-    } catch (const std::exception& e) {
-        spdlog::warn("PatternStamper: FRM resolve/load failed for fid {}: {}", frmPid, e.what());
-    }
-
-    // Object requires valid art (it draws a sprite); without a resolvable FRM there is
-    // nothing to place, so the caller skips this entry rather than crashing.
-    if (frm == nullptr) {
-        return nullptr;
-    }
-
-    try {
-        auto object = std::make_shared<Object>(frm);
+    auto object = buildSpriteObject(_resources, _hexgrid, frmPid, mapObject->position, mapObject->direction);
+    if (object) {
         object->setMapObject(mapObject);
-        sf::Sprite sprite{ _resources.textures().get(frmPath) };
-        object->setSprite(std::move(sprite));
-        object->setDirection(static_cast<ObjectDirection>(mapObject->direction));
-        if (auto hex = _hexgrid.getHexByPosition(static_cast<uint32_t>(mapObject->position)); hex.has_value()) {
-            object->setHexPosition(hex->get());
-        }
-        return object;
-    } catch (const std::exception& e) {
-        spdlog::warn("PatternStamper: failed to build object for fid {}: {}", frmPid, e.what());
-        return nullptr;
     }
+    return object;
 }
 
 PatternStamper::Result PatternStamper::stamp(const PatternVariant& variant, int targetHex, int elevation) {

--- a/src/pattern/PatternStamper.h
+++ b/src/pattern/PatternStamper.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "pattern/Pattern.h"
+
+namespace geck {
+class HexagonGrid;
+class Map;
+class Object;
+struct MapObject;
+class ObjectCommandController;
+namespace resource {
+    class GameResources;
+}
+} // namespace geck
+
+namespace geck::pattern {
+
+/// Places a pattern variant onto the map. Resolution (where each entry lands when the
+/// variant's anchor is dropped on a target hex) is a pure, dependency-free static step;
+/// application builds the objects/tiles and routes them through ObjectCommandController
+/// as a single undo entry. Entries are placed verbatim (no rotation) — orientation is
+/// chosen by selecting a variant, since Fallout 2 object art is direction-specific.
+class PatternStamper {
+public:
+    struct ObjectPlacement {
+        int hex = 0;
+        uint32_t proPid = 0;
+        uint32_t frmPid = 0;
+        uint32_t direction = 0;
+        uint32_t flags = 0;
+    };
+    struct TilePlacement {
+        int tileIndex = 0;
+        bool isRoof = false;
+        uint16_t tileId = 0;
+    };
+    struct Plan {
+        std::vector<ObjectPlacement> objects;
+        std::vector<TilePlacement> tiles;
+        int objectsDropped = 0; ///< Objects whose target hex falls off the grid.
+        int tilesDropped = 0;   ///< Tiles whose target falls off the tile grid.
+    };
+    struct Result {
+        int objectsPlaced = 0;
+        int objectsFailed = 0; ///< Resolved on-grid, but their art could not be loaded.
+        int tilesPainted = 0;
+        int dropped = 0; ///< Objects/tiles whose target fell off the grid.
+        bool success = false;
+    };
+
+    /// Resolve where each entry of `variant` lands when its anchor is stamped on
+    /// `targetHex`. Object offsets translate in cube space (parity-correct); tile
+    /// offsets translate in tile space. Off-grid entries are dropped and counted. Pure.
+    static Plan plan(const PatternVariant& variant, int targetHex);
+
+    PatternStamper(resource::GameResources& resources,
+        const HexagonGrid& hexgrid,
+        ObjectCommandController& controller,
+        Map& map);
+
+    /// Apply `variant` at `targetHex` on `elevation` as one undo entry.
+    Result stamp(const PatternVariant& variant, int targetHex, int elevation);
+
+private:
+    std::shared_ptr<Object> buildObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid) const;
+
+    resource::GameResources& _resources;
+    const HexagonGrid& _hexgrid;
+    ObjectCommandController& _controller;
+    Map& _map;
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternStamper.h
+++ b/src/pattern/PatternStamper.h
@@ -52,9 +52,13 @@ public:
         bool success = false;
     };
 
-    /// Resolve where each entry of `variant` lands when its anchor is stamped on
-    /// `targetHex`. Object offsets translate in cube space (parity-correct); tile
-    /// offsets translate in tile space. Off-grid entries are dropped and counted. Pure.
+    /// Resolve where each entry of `variant` lands when its anchor is stamped near
+    /// `targetHex`. Objects place at hex precision but tiles only at tile (2-hex)
+    /// precision, so `targetHex` is first **snapped to the anchor's column/row parity**
+    /// (placement is therefore tile-granular — the actual anchor may be up to one hex
+    /// from `targetHex`); this keeps floor/roof tiles locked to the objects. Object
+    /// offsets then translate in cube space, tile offsets in tile space; off-grid entries
+    /// are dropped and counted. Pure.
     static Plan plan(const PatternVariant& variant, int targetHex);
 
     PatternStamper(resource::GameResources& resources,
@@ -62,7 +66,8 @@ public:
         ObjectCommandController& controller,
         Map& map);
 
-    /// Apply `variant` at `targetHex` on `elevation` as one undo entry.
+    /// Apply `variant` near `targetHex` on `elevation` as one undo entry. `targetHex` is
+    /// snapped to the anchor's parity (see plan()), so placement is tile-granular.
     Result stamp(const PatternVariant& variant, int targetHex, int elevation);
 
 private:

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -4,7 +4,6 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 #include <SFML/Graphics.hpp>
@@ -18,13 +17,9 @@
 
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
-#include "format/lst/Lst.h"
-#include "format/map/Map.h"
 #include "pattern/Pattern.h"
 #include "pattern/PatternSprite.h"
 #include "pattern/PatternStamper.h"
-#include "resource/GameResources.h"
-#include "util/TileUtils.h"
 
 namespace geck::pattern {
 
@@ -44,29 +39,6 @@ namespace {
         return QImage(image.getPixelsPtr(), static_cast<int>(sz.x), static_cast<int>(sz.y),
             QImage::Format_RGBA8888)
             .copy();
-    }
-
-    // Build a floor/roof tile sprite (tile id -> tiles.lst name -> art) positioned at the
-    // tile's isometric screen coordinates. Returns nullopt for empty/unresolvable tiles.
-    std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
-        int tileIndex, bool isRoof, uint16_t tileId) {
-        if (tileId == static_cast<uint16_t>(Map::EMPTY_TILE)) {
-            return std::nullopt;
-        }
-        const auto* tileList = resources.repository().find<Lst>("art/tiles/tiles.lst");
-        if (tileList == nullptr || tileId >= tileList->list().size()) {
-            return std::nullopt;
-        }
-        try {
-            const std::string tilePath = "art/tiles/" + tileList->list()[tileId];
-            sf::Sprite sprite{ resources.textures().get(tilePath) };
-            const ScreenPosition pos = indexToScreenPosition(tileIndex, isRoof);
-            sprite.setPosition({ static_cast<float>(pos.x), static_cast<float>(pos.y) });
-            return sprite;
-        } catch (const std::exception& e) {
-            spdlog::warn("PatternThumbnail: tile {} art failed: {}", tileId, e.what());
-            return std::nullopt;
-        }
     }
 
 } // namespace

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -8,17 +8,15 @@
 #include <SFML/Graphics.hpp>
 #include <spdlog/spdlog.h>
 
-#include <QCryptographicHash>
 #include <QDateTime>
-#include <QDir>
 #include <QFileInfo>
 #include <QImage>
 #include <QPainter>
+#include <QPixmapCache>
 
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
 #include "pattern/Pattern.h"
-#include "pattern/PatternLibrary.h"
 #include "pattern/PatternSprite.h"
 #include "pattern/PatternStamper.h"
 
@@ -26,16 +24,12 @@ namespace geck::pattern {
 
 namespace {
 
-    // Disk cache path for a pattern's thumbnail, invalidated by the source file's size+mtime.
-    QString cachePath(const QString& sourcePath, int size) {
-        const QFileInfo info(sourcePath);
-        const QString key = sourcePath + '|' + QString::number(info.size()) + '|'
-            + QString::number(info.lastModified().toSecsSinceEpoch()) + '|' + QString::number(size);
-        const QString hash = QString::fromLatin1(
-            QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Sha1).toHex());
-        const QString dir = QDir(PatternLibrary::rootDir()).filePath(QStringLiteral(".thumbnails"));
-        QDir().mkpath(dir);
-        return QDir(dir).filePath(hash + QStringLiteral(".png"));
+    // In-memory cache key, invalidated by the source file's mtime. Only a handful of
+    // small thumbnails are live at a time, so they are rendered on demand and kept in
+    // Qt's global pixmap cache rather than written to disk.
+    QString cacheKey(const QString& sourcePath, int size) {
+        const qint64 mtime = QFileInfo(sourcePath).lastModified().toSecsSinceEpoch();
+        return sourcePath + '|' + QString::number(mtime) + '|' + QString::number(size);
     }
 
     // Copy an SFML RGBA image into an owned QImage.
@@ -50,10 +44,10 @@ namespace {
 
 QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sourcePath,
     resource::GameResources& resources, const HexagonGrid& hexgrid, int size) {
-    const QString cache = sourcePath.isEmpty() ? QString() : cachePath(sourcePath, size);
-    if (!cache.isEmpty() && QFileInfo::exists(cache)) {
+    const QString key = sourcePath.isEmpty() ? QString() : cacheKey(sourcePath, size);
+    if (!key.isEmpty()) {
         QPixmap cached;
-        if (cached.load(cache)) {
+        if (QPixmapCache::find(key, &cached)) {
             return cached;
         }
     }
@@ -118,8 +112,8 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
     painter.end();
 
     QPixmap pixmap = QPixmap::fromImage(canvas);
-    if (!cache.isEmpty()) {
-        pixmap.save(cache, "PNG");
+    if (!key.isEmpty()) {
+        QPixmapCache::insert(key, pixmap);
     }
     return pixmap;
 }

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -1,0 +1,127 @@
+#include "pattern/PatternThumbnail.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include <SFML/Graphics.hpp>
+#include <spdlog/spdlog.h>
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QImage>
+#include <QPainter>
+
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "pattern/Pattern.h"
+#include "pattern/PatternLibrary.h"
+#include "pattern/PatternSprite.h"
+#include "pattern/PatternStamper.h"
+
+namespace geck::pattern {
+
+namespace {
+
+    // Disk cache path for a pattern's thumbnail, invalidated by the source file's size+mtime.
+    QString cachePath(const QString& sourcePath, int size) {
+        const QFileInfo info(sourcePath);
+        const QString key = sourcePath + '|' + QString::number(info.size()) + '|'
+            + QString::number(info.lastModified().toSecsSinceEpoch()) + '|' + QString::number(size);
+        const QString hash = QString::fromLatin1(
+            QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Sha1).toHex());
+        const QString dir = QDir(PatternLibrary::rootDir()).filePath(QStringLiteral(".thumbnails"));
+        QDir().mkpath(dir);
+        return QDir(dir).filePath(hash + QStringLiteral(".png"));
+    }
+
+    // Copy an SFML RGBA image into an owned QImage.
+    QImage toQImage(const sf::Image& image) {
+        const sf::Vector2u sz = image.getSize();
+        return QImage(image.getPixelsPtr(), static_cast<int>(sz.x), static_cast<int>(sz.y),
+            QImage::Format_RGBA8888)
+            .copy();
+    }
+
+} // namespace
+
+QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sourcePath,
+    resource::GameResources& resources, const HexagonGrid& hexgrid, int size) {
+    const QString cache = sourcePath.isEmpty() ? QString() : cachePath(sourcePath, size);
+    if (!cache.isEmpty() && QFileInfo::exists(cache)) {
+        QPixmap cached;
+        if (cached.load(cache)) {
+            return cached;
+        }
+    }
+
+    if (pattern.variants.empty()) {
+        return {};
+    }
+
+    // Build positioned sprites for variant 0 at its authored hexes.
+    const PatternVariant& variant = pattern.variants.front();
+    const PatternStamper::Plan plan = PatternStamper::plan(variant, variant.anchorHex);
+    std::vector<std::shared_ptr<Object>> objects;
+    for (const PatternStamper::ObjectPlacement& op : plan.objects) {
+        if (auto object = buildSpriteObject(resources, hexgrid, op.frmPid, op.hex, op.direction)) {
+            objects.push_back(std::move(object));
+        }
+    }
+    if (objects.empty()) {
+        return {}; // no resolvable art
+    }
+
+    // Union of all sprite bounds, with a small margin.
+    float minX = std::numeric_limits<float>::max();
+    float minY = std::numeric_limits<float>::max();
+    float maxX = std::numeric_limits<float>::lowest();
+    float maxY = std::numeric_limits<float>::lowest();
+    for (const auto& object : objects) {
+        const sf::FloatRect b = object->getSprite().getGlobalBounds();
+        minX = std::min(minX, b.position.x);
+        minY = std::min(minY, b.position.y);
+        maxX = std::max(maxX, b.position.x + b.size.x);
+        maxY = std::max(maxY, b.position.y + b.size.y);
+    }
+    constexpr float pad = 4.0f;
+    minX -= pad;
+    minY -= pad;
+    maxX += pad;
+    maxY += pad;
+    const auto width = static_cast<unsigned int>(std::max(1.0f, maxX - minX));
+    const auto height = static_cast<unsigned int>(std::max(1.0f, maxY - minY));
+
+    sf::RenderTexture renderTexture;
+    if (!renderTexture.resize({ width, height })) {
+        spdlog::warn("PatternThumbnail: failed to create {}x{} render texture", width, height);
+        return {};
+    }
+    renderTexture.setView(sf::View(sf::FloatRect({ minX, minY },
+        { static_cast<float>(width), static_cast<float>(height) })));
+    renderTexture.clear(sf::Color::Transparent);
+    for (const auto& object : objects) {
+        renderTexture.draw(object->getSprite());
+    }
+    renderTexture.display();
+
+    const QImage rendered = toQImage(renderTexture.getTexture().copyToImage());
+    const QImage scaled = rendered.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+    QImage canvas(size, size, QImage::Format_RGBA8888);
+    canvas.fill(Qt::transparent);
+    QPainter painter(&canvas);
+    painter.drawImage((size - scaled.width()) / 2, (size - scaled.height()) / 2, scaled);
+    painter.end();
+
+    QPixmap pixmap = QPixmap::fromImage(canvas);
+    if (!cache.isEmpty()) {
+        pixmap.save(cache, "PNG");
+    }
+    return pixmap;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -1,25 +1,19 @@
 #include "pattern/PatternThumbnail.h"
 
-#include <algorithm>
-#include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
-#include <SFML/Graphics.hpp>
-#include <spdlog/spdlog.h>
+#include <SFML/Graphics/Sprite.hpp>
 
 #include <QDateTime>
 #include <QFileInfo>
-#include <QImage>
-#include <QPainter>
-#include <QPixmapCache>
 
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
 #include "pattern/Pattern.h"
 #include "pattern/PatternSprite.h"
 #include "pattern/PatternStamper.h"
+#include "ui/rendering/ThumbnailRenderer.h"
 
 namespace geck::pattern {
 
@@ -27,18 +21,10 @@ namespace {
 
     // In-memory cache key, invalidated by the source file's mtime. Only a handful of
     // small thumbnails are live at a time, so they are rendered on demand and kept in
-    // Qt's global pixmap cache rather than written to disk.
+    // the shared in-memory cache rather than written to disk.
     QString cacheKey(const QString& sourcePath, int size) {
         const qint64 mtime = QFileInfo(sourcePath).lastModified().toSecsSinceEpoch();
         return sourcePath + '|' + QString::number(mtime) + '|' + QString::number(size);
-    }
-
-    // Copy an SFML RGBA image into an owned QImage.
-    QImage toQImage(const sf::Image& image) {
-        const sf::Vector2u sz = image.getSize();
-        return QImage(image.getPixelsPtr(), static_cast<int>(sz.x), static_cast<int>(sz.y),
-            QImage::Format_RGBA8888)
-            .copy();
     }
 
 } // namespace
@@ -46,11 +32,8 @@ namespace {
 QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sourcePath,
     resource::GameResources& resources, const HexagonGrid& hexgrid, int size) {
     const QString key = sourcePath.isEmpty() ? QString() : cacheKey(sourcePath, size);
-    if (!key.isEmpty()) {
-        QPixmap cached;
-        if (QPixmapCache::find(key, &cached)) {
-            return cached;
-        }
+    if (auto hit = ThumbnailRenderer::cached(key)) {
+        return *hit;
     }
 
     if (pattern.variants.empty()) {
@@ -58,7 +41,7 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
     }
 
     // Build positioned sprites for variant 0 at its authored positions: floor and roof
-    // tiles plus objects.
+    // tiles plus objects. They are kept alive here while ThumbnailRenderer draws them.
     const PatternVariant& variant = pattern.variants.front();
     const PatternStamper::Plan plan = PatternStamper::plan(variant, variant.anchorHex);
 
@@ -77,72 +60,20 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
         }
     }
 
-    if (floorSprites.empty() && roofSprites.empty() && objects.empty()) {
-        return {}; // no resolvable art
-    }
-
-    // Union of all sprite bounds, with a small margin.
-    float minX = std::numeric_limits<float>::max();
-    float minY = std::numeric_limits<float>::max();
-    float maxX = std::numeric_limits<float>::lowest();
-    float maxY = std::numeric_limits<float>::lowest();
-    const auto extend = [&](const sf::FloatRect& b) {
-        minX = std::min(minX, b.position.x);
-        minY = std::min(minY, b.position.y);
-        maxX = std::max(maxX, b.position.x + b.size.x);
-        maxY = std::max(maxY, b.position.y + b.size.y);
-    };
-    for (const auto& sprite : floorSprites) {
-        extend(sprite.getGlobalBounds());
+    // Flatten into the editor's draw order: floor tiles, then objects, then roof tiles.
+    std::vector<const sf::Sprite*> ordered;
+    ordered.reserve(floorSprites.size() + objects.size() + roofSprites.size());
+    for (const sf::Sprite& sprite : floorSprites) {
+        ordered.push_back(&sprite);
     }
     for (const auto& object : objects) {
-        extend(object->getSprite().getGlobalBounds());
+        ordered.push_back(&object->getSprite());
     }
-    for (const auto& sprite : roofSprites) {
-        extend(sprite.getGlobalBounds());
+    for (const sf::Sprite& sprite : roofSprites) {
+        ordered.push_back(&sprite);
     }
-    constexpr float pad = 4.0f;
-    minX -= pad;
-    minY -= pad;
-    maxX += pad;
-    maxY += pad;
-    const auto width = static_cast<unsigned int>(std::max(1.0f, maxX - minX));
-    const auto height = static_cast<unsigned int>(std::max(1.0f, maxY - minY));
 
-    sf::RenderTexture renderTexture;
-    if (!renderTexture.resize({ width, height })) {
-        spdlog::warn("PatternThumbnail: failed to create {}x{} render texture", width, height);
-        return {};
-    }
-    renderTexture.setView(sf::View(sf::FloatRect({ minX, minY },
-        { static_cast<float>(width), static_cast<float>(height) })));
-    renderTexture.clear(sf::Color::Transparent);
-    // Draw order matches the editor: floor tiles, then objects, then roof tiles on top.
-    for (const auto& sprite : floorSprites) {
-        renderTexture.draw(sprite);
-    }
-    for (const auto& object : objects) {
-        renderTexture.draw(object->getSprite());
-    }
-    for (const auto& sprite : roofSprites) {
-        renderTexture.draw(sprite);
-    }
-    renderTexture.display();
-
-    const QImage rendered = toQImage(renderTexture.getTexture().copyToImage());
-    const QImage scaled = rendered.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-
-    QImage canvas(size, size, QImage::Format_RGBA8888);
-    canvas.fill(Qt::transparent);
-    QPainter painter(&canvas);
-    painter.drawImage((size - scaled.width()) / 2, (size - scaled.height()) / 2, scaled);
-    painter.end();
-
-    QPixmap pixmap = QPixmap::fromImage(canvas);
-    if (!key.isEmpty()) {
-        QPixmapCache::insert(key, pixmap);
-    }
-    return pixmap;
+    return ThumbnailRenderer::render(ordered, size, key);
 }
 
 } // namespace geck::pattern

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include <SFML/Graphics.hpp>
@@ -16,9 +18,13 @@
 
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
+#include "format/lst/Lst.h"
+#include "format/map/Map.h"
 #include "pattern/Pattern.h"
 #include "pattern/PatternSprite.h"
 #include "pattern/PatternStamper.h"
+#include "resource/GameResources.h"
+#include "util/TileUtils.h"
 
 namespace geck::pattern {
 
@@ -40,6 +46,29 @@ namespace {
             .copy();
     }
 
+    // Build a floor/roof tile sprite (tile id -> tiles.lst name -> art) positioned at the
+    // tile's isometric screen coordinates. Returns nullopt for empty/unresolvable tiles.
+    std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
+        int tileIndex, bool isRoof, uint16_t tileId) {
+        if (tileId == static_cast<uint16_t>(Map::EMPTY_TILE)) {
+            return std::nullopt;
+        }
+        const auto* tileList = resources.repository().find<Lst>("art/tiles/tiles.lst");
+        if (tileList == nullptr || tileId >= tileList->list().size()) {
+            return std::nullopt;
+        }
+        try {
+            const std::string tilePath = "art/tiles/" + tileList->list()[tileId];
+            sf::Sprite sprite{ resources.textures().get(tilePath) };
+            const ScreenPosition pos = indexToScreenPosition(tileIndex, isRoof);
+            sprite.setPosition({ static_cast<float>(pos.x), static_cast<float>(pos.y) });
+            return sprite;
+        } catch (const std::exception& e) {
+            spdlog::warn("PatternThumbnail: tile {} art failed: {}", tileId, e.what());
+            return std::nullopt;
+        }
+    }
+
 } // namespace
 
 QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sourcePath,
@@ -56,16 +85,27 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
         return {};
     }
 
-    // Build positioned sprites for variant 0 at its authored hexes.
+    // Build positioned sprites for variant 0 at its authored positions: floor and roof
+    // tiles plus objects.
     const PatternVariant& variant = pattern.variants.front();
     const PatternStamper::Plan plan = PatternStamper::plan(variant, variant.anchorHex);
+
+    std::vector<sf::Sprite> floorSprites;
+    std::vector<sf::Sprite> roofSprites;
+    for (const PatternStamper::TilePlacement& tp : plan.tiles) {
+        if (auto sprite = buildTileSprite(resources, tp.tileIndex, tp.isRoof, tp.tileId)) {
+            (tp.isRoof ? roofSprites : floorSprites).push_back(std::move(*sprite));
+        }
+    }
+
     std::vector<std::shared_ptr<Object>> objects;
     for (const PatternStamper::ObjectPlacement& op : plan.objects) {
         if (auto object = buildSpriteObject(resources, hexgrid, op.frmPid, op.hex, op.direction)) {
             objects.push_back(std::move(object));
         }
     }
-    if (objects.empty()) {
+
+    if (floorSprites.empty() && roofSprites.empty() && objects.empty()) {
         return {}; // no resolvable art
     }
 
@@ -74,12 +114,20 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
     float minY = std::numeric_limits<float>::max();
     float maxX = std::numeric_limits<float>::lowest();
     float maxY = std::numeric_limits<float>::lowest();
-    for (const auto& object : objects) {
-        const sf::FloatRect b = object->getSprite().getGlobalBounds();
+    const auto extend = [&](const sf::FloatRect& b) {
         minX = std::min(minX, b.position.x);
         minY = std::min(minY, b.position.y);
         maxX = std::max(maxX, b.position.x + b.size.x);
         maxY = std::max(maxY, b.position.y + b.size.y);
+    };
+    for (const auto& sprite : floorSprites) {
+        extend(sprite.getGlobalBounds());
+    }
+    for (const auto& object : objects) {
+        extend(object->getSprite().getGlobalBounds());
+    }
+    for (const auto& sprite : roofSprites) {
+        extend(sprite.getGlobalBounds());
     }
     constexpr float pad = 4.0f;
     minX -= pad;
@@ -97,8 +145,15 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
     renderTexture.setView(sf::View(sf::FloatRect({ minX, minY },
         { static_cast<float>(width), static_cast<float>(height) })));
     renderTexture.clear(sf::Color::Transparent);
+    // Draw order matches the editor: floor tiles, then objects, then roof tiles on top.
+    for (const auto& sprite : floorSprites) {
+        renderTexture.draw(sprite);
+    }
     for (const auto& object : objects) {
         renderTexture.draw(object->getSprite());
+    }
+    for (const auto& sprite : roofSprites) {
+        renderTexture.draw(sprite);
     }
     renderTexture.display();
 

--- a/src/pattern/PatternThumbnail.h
+++ b/src/pattern/PatternThumbnail.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QPixmap>
+#include <QString>
+
+namespace geck {
+class HexagonGrid;
+namespace resource {
+    class GameResources;
+}
+} // namespace geck
+
+namespace geck::pattern {
+
+struct Pattern;
+
+/// Renders a pattern to a thumbnail image for the browser grid.
+class PatternThumbnail {
+public:
+    /// Render variant 0 of `pattern` to a `size`x`size` transparent thumbnail using game
+    /// art. The result is cached on disk (under the library's .thumbnails folder, keyed by
+    /// `sourcePath` + size/mtime), so the first browse pays the render cost and later opens
+    /// are instant. Returns a null QPixmap when nothing could be rendered (e.g. no art
+    /// loaded or the pattern has no objects).
+    static QPixmap forPattern(const Pattern& pattern,
+        const QString& sourcePath,
+        resource::GameResources& resources,
+        const HexagonGrid& hexgrid,
+        int size = 96);
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternThumbnail.h
+++ b/src/pattern/PatternThumbnail.h
@@ -18,10 +18,10 @@ struct Pattern;
 class PatternThumbnail {
 public:
     /// Render variant 0 of `pattern` to a `size`x`size` transparent thumbnail using game
-    /// art. The result is cached on disk (under the library's .thumbnails folder, keyed by
-    /// `sourcePath` + size/mtime), so the first browse pays the render cost and later opens
-    /// are instant. Returns a null QPixmap when nothing could be rendered (e.g. no art
-    /// loaded or the pattern has no objects).
+    /// art. Only a few dozen thumbnails are live at a time, so they are rendered on demand
+    /// and kept in Qt's in-memory pixmap cache (keyed by `sourcePath` + size/mtime) — no
+    /// files are written. Returns a null QPixmap when nothing could be rendered (e.g. no
+    /// art loaded or the pattern has no objects).
     static QPixmap forPattern(const Pattern& pattern,
         const QString& sourcePath,
         resource::GameResources& resources,

--- a/src/ui/core/EditorMode.h
+++ b/src/ui/core/EditorMode.h
@@ -10,6 +10,7 @@ enum class EditorMode {
     PlaceExitGrid,     ///< Placing exit-grid markers.
     MarkExits,         ///< Selecting exit grids to edit their properties.
     SetPlayerPosition, ///< One-shot: next click sets the player start hex.
+    StampPattern,      ///< Placing a loaded prefab pattern by clicking hexes.
 };
 
 } // namespace geck

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -30,6 +30,7 @@
 
 #include "editor/Object.h"
 #include "pattern/PatternStamper.h"
+#include "pattern/PatternSprite.h"
 #include "editor/HexagonGrid.h"
 
 #include "format/frm/Frm.h"
@@ -1220,32 +1221,12 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
     const pattern::PatternStamper::Plan plan = pattern::PatternStamper::plan(variant, hex);
 
     for (const pattern::PatternStamper::ObjectPlacement& op : plan.objects) {
-        const Frm* frm = nullptr;
-        std::string frmPath;
-        try {
-            frmPath = _resources.frmResolver().resolve(op.frmPid);
-            if (!frmPath.empty()) {
-                frm = _resources.repository().load<Frm>(frmPath);
-            }
-        } catch (const std::exception&) {
-            frm = nullptr;
-        }
-        if (frm == nullptr) {
+        auto object = pattern::buildSpriteObject(_resources, _hexgrid, op.frmPid, op.hex, op.direction);
+        if (!object) {
             continue;
         }
-        try {
-            auto object = std::make_shared<Object>(frm);
-            sf::Sprite sprite{ _resources.textures().get(frmPath) };
-            object->setSprite(std::move(sprite));
-            object->setDirection(static_cast<ObjectDirection>(op.direction));
-            if (auto h = _hexgrid.getHexByPosition(static_cast<uint32_t>(op.hex)); h.has_value()) {
-                object->setHexPosition(h->get());
-            }
-            object->getSprite().setColor(sf::Color(255, 255, 255, 140)); // semi-transparent ghost
-            _stampPreviewObjects.push_back(std::move(object));
-        } catch (const std::exception&) {
-            // Skip objects whose sprite cannot be built.
-        }
+        object->getSprite().setColor(sf::Color(255, 255, 255, 140)); // semi-transparent ghost
+        _stampPreviewObjects.push_back(std::move(object));
     }
 }
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -797,7 +797,10 @@ void EditorWidget::setupInputCallbacks() {
     };
 
     callbacks.onEscape = [this]() {
-        if (_tilePlacementManager->isTilePlacementMode()) {
+        if (_mode == EditorMode::StampPattern) {
+            setMode(EditorMode::Select);
+            Q_EMIT statusMessageRequested("Pattern stamping cancelled.");
+        } else if (_tilePlacementManager->isTilePlacementMode()) {
             _tilePlacementManager->resetState();
             if (_mainWindow && _mainWindow->getTilePalettePanel()) {
                 _mainWindow->getTilePalettePanel()->deselectTile();
@@ -1144,9 +1147,13 @@ void EditorWidget::beginStampPattern(pattern::Pattern pattern) {
     _stampPattern = std::move(pattern);
     _stampVariantIndex = 0;
     setMode(EditorMode::StampPattern);
-    Q_EMIT statusMessageRequested(
-        QString("Stamp mode: click to place '%1'. Right-click or Esc to exit.")
-            .arg(QString::fromStdString(_stampPattern->name)));
+    QString message = QString("Stamp mode: click to place '%1'.")
+                          .arg(QString::fromStdString(_stampPattern->name));
+    if (_stampPattern->variants.size() > 1) {
+        message += " R cycles variants.";
+    }
+    message += " Right-click or Esc to exit.";
+    Q_EMIT statusMessageRequested(message);
 }
 
 void EditorWidget::cycleStampVariant() {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -29,6 +29,7 @@
 #include "util/Coordinates.h"
 
 #include "editor/Object.h"
+#include "pattern/PatternStamper.h"
 #include "editor/HexagonGrid.h"
 
 #include "format/frm/Frm.h"
@@ -761,6 +762,19 @@ void EditorWidget::setupInputCallbacks() {
         _exitGridPlacementManager->handleExitGridPlacement(worldPos);
     };
 
+    callbacks.onStampPattern = [this](sf::Vector2f worldPos) {
+        stampPatternAt(worldPos);
+    };
+
+    callbacks.onStampPatternCancel = [this]() {
+        setMode(EditorMode::Select);
+        Q_EMIT statusMessageRequested("Pattern stamping cancelled.");
+    };
+
+    callbacks.onStampCycleVariant = [this]() {
+        cycleStampVariant();
+    };
+
     callbacks.onMarkExitsSelection = [this](sf::Vector2f worldPos) {
         _exitGridPlacementManager->handleMarkExitsSelection(worldPos);
     };
@@ -1051,6 +1065,7 @@ void EditorWidget::setMode(EditorMode mode, int tileIndex, bool isRoof) {
         _inputHandler->setExitGridPlacementMode(false);
         _inputHandler->setMarkExitsMode(false);
         _inputHandler->setPlayerPositionMode(false);
+        _inputHandler->setStampPatternMode(false);
     }
 
     switch (mode) {
@@ -1081,6 +1096,11 @@ void EditorWidget::setMode(EditorMode mode, int tileIndex, bool isRoof) {
                 _inputHandler->setPlayerPositionMode(true);
             }
             break;
+        case EditorMode::StampPattern:
+            if (_inputHandler) {
+                _inputHandler->setStampPatternMode(true);
+            }
+            break;
     }
 
     Q_EMIT editorModeChanged(_mode);
@@ -1104,6 +1124,65 @@ void EditorWidget::setExitGridPlacementMode(bool enabled) {
 
 void EditorWidget::setMarkExitsMode(bool enabled) {
     setMode(enabled ? EditorMode::MarkExits : EditorMode::Select);
+}
+
+void EditorWidget::beginStampPattern(pattern::Pattern pattern) {
+    if (pattern.variants.empty()) {
+        Q_EMIT statusMessageRequested("Pattern has no variants to stamp.");
+        return;
+    }
+    _stampPattern = std::move(pattern);
+    _stampVariantIndex = 0;
+    setMode(EditorMode::StampPattern);
+    Q_EMIT statusMessageRequested(
+        QString("Stamp mode: click to place '%1'. Right-click or Esc to exit.")
+            .arg(QString::fromStdString(_stampPattern->name)));
+}
+
+void EditorWidget::cycleStampVariant() {
+    if (!_stampPattern || _stampPattern->variants.size() <= 1) {
+        return;
+    }
+    _stampVariantIndex = (_stampVariantIndex + 1) % static_cast<int>(_stampPattern->variants.size());
+    const std::string& label = _stampPattern->variants[_stampVariantIndex].label;
+    Q_EMIT statusMessageRequested(
+        QString("Pattern variant %1/%2: %3")
+            .arg(_stampVariantIndex + 1)
+            .arg(_stampPattern->variants.size())
+            .arg(label.empty() ? QStringLiteral("(unnamed)") : QString::fromStdString(label)));
+}
+
+void EditorWidget::stampPatternAt(sf::Vector2f worldPos) {
+    if (!_stampPattern || !_map || _stampPattern->variants.empty()) {
+        return;
+    }
+    const int hex = _viewportController->worldPosToHexIndex(worldPos);
+    if (!_hexgrid.containsPosition(hex)) {
+        return;
+    }
+    if (_stampVariantIndex < 0 || _stampVariantIndex >= static_cast<int>(_stampPattern->variants.size())) {
+        _stampVariantIndex = 0;
+    }
+    const pattern::PatternVariant& variant = _stampPattern->variants[_stampVariantIndex];
+
+    pattern::PatternStamper stamper(_resources, _hexgrid, *_objectCommandController, *_map);
+    const pattern::PatternStamper::Result result = stamper.stamp(variant, hex, _currentElevation);
+
+    // PatternStamper appends object sprites and applies tile sprites incrementally
+    // through the controller, so no full refresh is needed here (mirrors the single
+    // placeObjectAtPosition path).
+
+    QString message = QString("Stamped '%1': %2 objects, %3 tiles")
+                          .arg(QString::fromStdString(_stampPattern->name))
+                          .arg(result.objectsPlaced)
+                          .arg(result.tilesPainted);
+    if (result.objectsFailed > 0) {
+        message += QString(" (%1 missing art)").arg(result.objectsFailed);
+    }
+    if (result.dropped > 0) {
+        message += QString(" (%1 off-grid)").arg(result.dropped);
+    }
+    Q_EMIT statusMessageRequested(message);
 }
 
 bool EditorWidget::isTilePlacementMode() const {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -893,7 +893,9 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     renderData.selectedHexPositions = &_selectedHexPositions;
     renderData.dragPreviewObject = &_dragPreviewObject;
     renderData.isDraggingFromPalette = _isDraggingFromPalette;
+    renderData.stampPreviewFloorTiles = &_stampPreviewFloorTiles;
     renderData.stampPreviewObjects = &_stampPreviewObjects;
+    renderData.stampPreviewRoofTiles = &_stampPreviewRoofTiles;
     renderData.selectionRectangle = &_selectionRectangle;
     // Use InputHandler state for drag selection rendering
     renderData.isDragSelecting = _inputHandler && _inputHandler->isDragging();
@@ -1194,7 +1196,9 @@ void EditorWidget::stampPatternAt(sf::Vector2f worldPos) {
 }
 
 void EditorWidget::clearStampPreview() {
+    _stampPreviewFloorTiles.clear();
     _stampPreviewObjects.clear();
+    _stampPreviewRoofTiles.clear();
     _stampPreviewHex = -1;
 }
 
@@ -1212,7 +1216,9 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
         return; // still over the same hex; the ghost is unchanged
     }
     _stampPreviewHex = hex;
+    _stampPreviewFloorTiles.clear();
     _stampPreviewObjects.clear();
+    _stampPreviewRoofTiles.clear();
 
     if (_stampVariantIndex < 0 || _stampVariantIndex >= static_cast<int>(_stampPattern->variants.size())) {
         _stampVariantIndex = 0;
@@ -1220,12 +1226,20 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
     const pattern::PatternVariant& variant = _stampPattern->variants[_stampVariantIndex];
     const pattern::PatternStamper::Plan plan = pattern::PatternStamper::plan(variant, hex);
 
+    const auto ghostAlpha = sf::Color(255, 255, 255, 140);
+    for (const pattern::PatternStamper::TilePlacement& tp : plan.tiles) {
+        if (auto sprite = pattern::buildTileSprite(_resources, tp.tileIndex, tp.isRoof, tp.tileId)) {
+            sprite->setColor(ghostAlpha);
+            (tp.isRoof ? _stampPreviewRoofTiles : _stampPreviewFloorTiles).push_back(std::move(*sprite));
+        }
+    }
+
     for (const pattern::PatternStamper::ObjectPlacement& op : plan.objects) {
         auto object = pattern::buildSpriteObject(_resources, _hexgrid, op.frmPid, op.hex, op.direction);
         if (!object) {
             continue;
         }
-        object->getSprite().setColor(sf::Color(255, 255, 255, 140)); // semi-transparent ghost
+        object->getSprite().setColor(ghostAlpha); // semi-transparent ghost
         _stampPreviewObjects.push_back(std::move(object));
     }
 }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -790,6 +790,9 @@ void EditorWidget::setupInputCallbacks() {
     callbacks.onMouseMove = [this](sf::Vector2f worldPos) {
         _currentHoverHex = _viewportController->updateHoverHex(worldPos);
         Q_EMIT hexHoverChanged(_currentHoverHex);
+        if (_mode == EditorMode::StampPattern) {
+            updateStampPreview(worldPos);
+        }
     };
 
     callbacks.onEscape = [this]() {
@@ -889,6 +892,7 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     renderData.selectedHexPositions = &_selectedHexPositions;
     renderData.dragPreviewObject = &_dragPreviewObject;
     renderData.isDraggingFromPalette = _isDraggingFromPalette;
+    renderData.stampPreviewObjects = &_stampPreviewObjects;
     renderData.selectionRectangle = &_selectionRectangle;
     // Use InputHandler state for drag selection rendering
     renderData.isDragSelecting = _inputHandler && _inputHandler->isDragging();
@@ -1060,6 +1064,9 @@ void EditorWidget::setMode(EditorMode mode, int tileIndex, bool isRoof) {
     _exitGridPlacementManager->setExitGridPlacementMode(false);
     _exitGridPlacementManager->setMarkExitsMode(false);
     _playerPositionSelectionMode = false;
+    if (mode != EditorMode::StampPattern) {
+        clearStampPreview();
+    }
     if (_inputHandler) {
         _inputHandler->setTilePlacementMode(false, -1, false);
         _inputHandler->setExitGridPlacementMode(false);
@@ -1183,6 +1190,63 @@ void EditorWidget::stampPatternAt(sf::Vector2f worldPos) {
         message += QString(" (%1 off-grid)").arg(result.dropped);
     }
     Q_EMIT statusMessageRequested(message);
+}
+
+void EditorWidget::clearStampPreview() {
+    _stampPreviewObjects.clear();
+    _stampPreviewHex = -1;
+}
+
+void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
+    if (!_stampPattern || _mode != EditorMode::StampPattern || _stampPattern->variants.empty()) {
+        clearStampPreview();
+        return;
+    }
+    const int hex = _viewportController->worldPosToHexIndex(worldPos);
+    if (!_hexgrid.containsPosition(hex)) {
+        clearStampPreview();
+        return;
+    }
+    if (hex == _stampPreviewHex) {
+        return; // still over the same hex; the ghost is unchanged
+    }
+    _stampPreviewHex = hex;
+    _stampPreviewObjects.clear();
+
+    if (_stampVariantIndex < 0 || _stampVariantIndex >= static_cast<int>(_stampPattern->variants.size())) {
+        _stampVariantIndex = 0;
+    }
+    const pattern::PatternVariant& variant = _stampPattern->variants[_stampVariantIndex];
+    const pattern::PatternStamper::Plan plan = pattern::PatternStamper::plan(variant, hex);
+
+    for (const pattern::PatternStamper::ObjectPlacement& op : plan.objects) {
+        const Frm* frm = nullptr;
+        std::string frmPath;
+        try {
+            frmPath = _resources.frmResolver().resolve(op.frmPid);
+            if (!frmPath.empty()) {
+                frm = _resources.repository().load<Frm>(frmPath);
+            }
+        } catch (const std::exception&) {
+            frm = nullptr;
+        }
+        if (frm == nullptr) {
+            continue;
+        }
+        try {
+            auto object = std::make_shared<Object>(frm);
+            sf::Sprite sprite{ _resources.textures().get(frmPath) };
+            object->setSprite(std::move(sprite));
+            object->setDirection(static_cast<ObjectDirection>(op.direction));
+            if (auto h = _hexgrid.getHexByPosition(static_cast<uint32_t>(op.hex)); h.has_value()) {
+                object->setHexPosition(h->get());
+            }
+            object->getSprite().setColor(sf::Color(255, 255, 255, 140)); // semi-transparent ghost
+            _stampPreviewObjects.push_back(std::move(object));
+        } catch (const std::exception&) {
+            // Skip objects whose sprite cannot be built.
+        }
+    }
 }
 
 bool EditorWidget::isTilePlacementMode() const {

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -25,6 +25,7 @@
 #include "ui/rendering/MapSpriteLoader.h"
 #include "ui/tiles/TilePlacementContext.h"
 #include "ui/core/EditorMode.h"
+#include "pattern/Pattern.h"
 #include "ui/tools/ExitGridContext.h"
 #include "ui/dragdrop/DragDropContext.h"
 #include "TileChange.h"
@@ -114,6 +115,11 @@ public:
     // Exit grid placement mode control
     void setExitGridPlacementMode(bool enabled);
     void setMarkExitsMode(bool enabled);
+
+    // Pattern stamping: enter stamp mode with a loaded prefab; clicks place the current
+    // variant, and cycleStampVariant() advances which orientation is placed.
+    void beginStampPattern(pattern::Pattern pattern);
+    void cycleStampVariant();
 
     // Object refresh methods
     void refreshObjects() override;
@@ -339,6 +345,11 @@ private:
 
     // Active tool mode (single source of truth; see setMode).
     EditorMode _mode = EditorMode::Select;
+
+    // Loaded prefab being stamped (StampPattern mode) and the active variant index.
+    std::optional<pattern::Pattern> _stampPattern;
+    int _stampVariantIndex = 0;
+    void stampPatternAt(sf::Vector2f worldPos);
 
     // Player position selection state
     bool _playerPositionSelectionMode = false;

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -351,6 +351,12 @@ private:
     int _stampVariantIndex = 0;
     void stampPatternAt(sf::Vector2f worldPos);
 
+    // Semi-transparent ghost of the current variant under the cursor (StampPattern mode).
+    std::vector<std::shared_ptr<Object>> _stampPreviewObjects;
+    int _stampPreviewHex = -1;
+    void updateStampPreview(sf::Vector2f worldPos);
+    void clearStampPreview();
+
     // Player position selection state
     bool _playerPositionSelectionMode = false;
 

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -351,8 +351,11 @@ private:
     int _stampVariantIndex = 0;
     void stampPatternAt(sf::Vector2f worldPos);
 
-    // Semi-transparent ghost of the current variant under the cursor (StampPattern mode).
+    // Semi-transparent ghost of the current variant under the cursor (StampPattern mode):
+    // floor tiles (drawn under), objects, and roof tiles (drawn over).
+    std::vector<sf::Sprite> _stampPreviewFloorTiles;
     std::vector<std::shared_ptr<Object>> _stampPreviewObjects;
+    std::vector<sf::Sprite> _stampPreviewRoofTiles;
     int _stampPreviewHex = -1;
     void updateStampPreview(sf::Vector2f worldPos);
     void clearStampPreview();

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -618,7 +618,9 @@ void MainWindow::setupToolBar() {
 
     _mainToolBar->addSeparator();
 
-    addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object", QKeySequence("R"));
+    // Stored so it can be disabled while stamping a pattern — otherwise its "R" shortcut
+    // swallows the key before it reaches the viewport, where R cycles pattern variants.
+    _rotateAction = addToolAction(":/icons/actions/rotate.svg", "Rotate", &MainWindow::rotateObjectRequested, "Rotate selected object", QKeySequence("R"));
 
     _mainToolBar->addSeparator();
 
@@ -685,6 +687,11 @@ void MainWindow::syncToolModeActions(EditorMode mode) {
     sync(_selectToolAction, EditorMode::Select);
     sync(_markExitsAction, EditorMode::MarkExits);
     sync(_placeExitGridAction, EditorMode::PlaceExitGrid);
+
+    // Free up "R" for variant cycling while a pattern is being stamped.
+    if (_rotateAction) {
+        _rotateAction->setEnabled(mode != EditorMode::StampPattern);
+    }
 }
 
 void MainWindow::setupDockWidgets() {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -19,6 +19,10 @@
 #include "state/loader/DataPathLoader.h"
 #include "state/GameLauncher.h"
 #include "selection/SelectionState.h"
+#include "selection/SelectionManager.h"
+#include "pattern/PatternBuilder.h"
+#include "pattern/PatternSerializer.h"
+#include "format/map/Map.h"
 #include "util/Types.h"
 #include "util/Settings.h"
 #include "util/QtDialogs.h"
@@ -45,6 +49,9 @@
 #include <QMenu>
 #include <QIcon>
 #include <QSignalBlocker>
+#include <QFileDialog>
+#include <QFile>
+#include <QFileInfo>
 #include <SFML/Window/Event.hpp>
 #include <spdlog/spdlog.h>
 
@@ -364,6 +371,7 @@ void MainWindow::setupMenuBar() {
 
     _editMenu->addSeparator();
     addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence("B"), "Draw rectangle and place scroll blockers on borders");
+    addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
 
     _editMenu->addSeparator();
 
@@ -1666,6 +1674,42 @@ void MainWindow::onPlayGame() {
     }
 
     _gameLauncher->playGame(mapFile, mapFilename);
+}
+
+void MainWindow::showSavePatternDialog() {
+    if (!_currentEditorWidget || !hasActiveMap()) {
+        showStatusMessage("Open a map and select objects or tiles first.");
+        return;
+    }
+    auto* selectionManager = _currentEditorWidget->getSelectionManager();
+    Map* map = _currentEditorWidget->getMap();
+    if (!selectionManager || !map) {
+        return;
+    }
+
+    const QString path = QFileDialog::getSaveFileName(
+        this, "Save Selection as Pattern", QString(), "Gecko Pattern (*.json)");
+    if (path.isEmpty()) {
+        return;
+    }
+
+    const std::string name = QFileInfo(path).completeBaseName().toStdString();
+    auto pattern = pattern::PatternBuilder::fromSelection(
+        selectionManager->getCurrentSelection(), *map, _currentEditorWidget->getCurrentElevation(), name);
+    if (!pattern.has_value()) {
+        showStatusMessage("Nothing selected to save as a pattern.");
+        return;
+    }
+
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        showStatusMessage("Failed to write pattern file.");
+        return;
+    }
+    file.write(pattern::PatternSerializer::serialize(*pattern));
+    showStatusMessage(QString("Saved pattern '%1' (%2 variant).")
+            .arg(QString::fromStdString(pattern->name))
+            .arg(pattern->variants.size()));
 }
 
 void MainWindow::showStatusMessage(const QString& message) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include "selection/SelectionState.h"
 #include "selection/SelectionManager.h"
 #include "pattern/PatternBuilder.h"
+#include "pattern/PatternLibrary.h"
 #include "pattern/PatternSerializer.h"
 #include "format/map/Map.h"
 #include "util/Types.h"
@@ -1689,7 +1690,7 @@ void MainWindow::showSavePatternDialog() {
     }
 
     const QString path = QFileDialog::getSaveFileName(
-        this, "Save Selection as Pattern", QString(), "Gecko Pattern (*.json)");
+        this, "Save Selection as Pattern", pattern::PatternLibrary::rootDir(), "Gecko Pattern (*.json)");
     if (path.isEmpty()) {
         return;
     }
@@ -1720,7 +1721,7 @@ void MainWindow::showStampPatternDialog() {
     }
 
     const QString path = QFileDialog::getOpenFileName(
-        this, "Stamp Pattern", QString(), "Gecko Pattern (*.json)");
+        this, "Stamp Pattern", pattern::PatternLibrary::rootDir(), "Gecko Pattern (*.json)");
     if (path.isEmpty()) {
         return;
     }

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include "ui/tools/ExitGridPlacementManager.h"
 #include "ui/dialogs/SettingsDialog.h"
 #include "ui/dialogs/AboutDialog.h"
+#include "ui/dialogs/PatternBrowserDialog.h"
 #include "ui/UIConstants.h"
 #include "resource/GameResources.h"
 #include "state/loader/MapLoader.h"
@@ -1720,26 +1721,14 @@ void MainWindow::showStampPatternDialog() {
         return;
     }
 
-    const QString path = QFileDialog::getOpenFileName(
-        this, "Stamp Pattern", pattern::PatternLibrary::rootDir(), "Gecko Pattern (*.json)");
-    if (path.isEmpty()) {
+    PatternBrowserDialog dialog(*_resourcesShared, this);
+    if (dialog.exec() != QDialog::Accepted) {
         return;
     }
-
-    QFile file(path);
-    if (!file.open(QIODevice::ReadOnly)) {
-        showStatusMessage("Failed to open pattern file.");
-        return;
+    auto selected = dialog.selectedPattern();
+    if (selected.has_value()) {
+        _currentEditorWidget->beginStampPattern(std::move(*selected));
     }
-
-    QString error;
-    auto loaded = pattern::PatternSerializer::deserialize(file.readAll(), &error);
-    if (!loaded.has_value()) {
-        showStatusMessage(QString("Invalid pattern: %1").arg(error));
-        return;
-    }
-
-    _currentEditorWidget->beginStampPattern(std::move(*loaded));
 }
 
 void MainWindow::showStatusMessage(const QString& message) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -372,6 +372,7 @@ void MainWindow::setupMenuBar() {
     _editMenu->addSeparator();
     addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence("B"), "Draw rectangle and place scroll blockers on borders");
     addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
+    addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, QKeySequence(), "Load a prefab pattern and click to place it");
 
     _editMenu->addSeparator();
 
@@ -1710,6 +1711,34 @@ void MainWindow::showSavePatternDialog() {
     showStatusMessage(QString("Saved pattern '%1' (%2 variant).")
             .arg(QString::fromStdString(pattern->name))
             .arg(pattern->variants.size()));
+}
+
+void MainWindow::showStampPatternDialog() {
+    if (!_currentEditorWidget || !hasActiveMap()) {
+        showStatusMessage("Open a map before stamping a pattern.");
+        return;
+    }
+
+    const QString path = QFileDialog::getOpenFileName(
+        this, "Stamp Pattern", QString(), "Gecko Pattern (*.json)");
+    if (path.isEmpty()) {
+        return;
+    }
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        showStatusMessage("Failed to open pattern file.");
+        return;
+    }
+
+    QString error;
+    auto loaded = pattern::PatternSerializer::deserialize(file.readAll(), &error);
+    if (!loaded.has_value()) {
+        showStatusMessage(QString("Invalid pattern: %1").arg(error));
+        return;
+    }
+
+    _currentEditorWidget->beginStampPattern(std::move(*loaded));
 }
 
 void MainWindow::showStatusMessage(const QString& message) {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -111,6 +111,7 @@ private slots:
     void showAbout();
     void onPlayGame();
     void showSavePatternDialog();
+    void showStampPatternDialog();
 
 public slots:
     void showStatusMessage(const QString& message);

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -110,6 +110,7 @@ private slots:
     void showPreferences();
     void showAbout();
     void onPlayGame();
+    void showSavePatternDialog();
 
 public slots:
     void showStatusMessage(const QString& message);

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -184,6 +184,7 @@ private:
     QAction* _selectToolAction = nullptr;
     QAction* _markExitsAction = nullptr;
     QAction* _placeExitGridAction = nullptr;
+    QAction* _rotateAction = nullptr;
     QAction* _undoAction = nullptr;
     QAction* _redoAction = nullptr;
 

--- a/src/ui/dialogs/PatternBrowserDialog.cpp
+++ b/src/ui/dialogs/PatternBrowserDialog.cpp
@@ -1,0 +1,154 @@
+#include "ui/dialogs/PatternBrowserDialog.h"
+
+#include <QDir>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QFileSystemModel>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QIcon>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSplitter>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+#include "editor/HexagonGrid.h"
+#include "pattern/PatternLibrary.h"
+#include "pattern/PatternSerializer.h"
+#include "pattern/PatternThumbnail.h"
+
+namespace geck {
+
+namespace {
+    constexpr int THUMBNAIL_SIZE = 96;
+    constexpr int PATH_ROLE = Qt::UserRole + 1;
+
+    std::optional<pattern::Pattern> loadPattern(const QString& path) {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly)) {
+            return std::nullopt;
+        }
+        return pattern::PatternSerializer::deserialize(file.readAll());
+    }
+} // namespace
+
+PatternBrowserDialog::PatternBrowserDialog(resource::GameResources& resources, QWidget* parent)
+    : QDialog(parent)
+    , _resources(resources)
+    , _hexgrid(std::make_unique<HexagonGrid>()) {
+    setWindowTitle("Pattern Library");
+    resize(720, 480);
+
+    const QString root = pattern::PatternLibrary::rootDir();
+
+    _folderModel = new QFileSystemModel(this);
+    _folderModel->setRootPath(root);
+    _folderModel->setFilter(QDir::Dirs | QDir::NoDotAndDotDot);
+
+    _folderTree = new QTreeView(this);
+    _folderTree->setModel(_folderModel);
+    _folderTree->setRootIndex(_folderModel->index(root));
+    _folderTree->setHeaderHidden(true);
+    for (int column = 1; column < _folderModel->columnCount(); ++column) {
+        _folderTree->hideColumn(column); // show names only, not size/type/date
+    }
+
+    _grid = new QListWidget(this);
+    _grid->setViewMode(QListView::IconMode);
+    _grid->setIconSize(QSize(THUMBNAIL_SIZE, THUMBNAIL_SIZE));
+    _grid->setGridSize(QSize(THUMBNAIL_SIZE + 24, THUMBNAIL_SIZE + 36));
+    _grid->setResizeMode(QListView::Adjust);
+    _grid->setMovement(QListView::Static);
+    _grid->setWordWrap(true);
+
+    auto* splitter = new QSplitter(this);
+    splitter->addWidget(_folderTree);
+    splitter->addWidget(_grid);
+    splitter->setStretchFactor(0, 1);
+    splitter->setStretchFactor(1, 3);
+
+    auto* importButton = new QPushButton("Import…", this);
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    buttons->addButton(importButton, QDialogButtonBox::ActionRole);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(splitter, 1);
+    layout->addWidget(buttons);
+
+    connect(_folderTree->selectionModel(), &QItemSelectionModel::currentChanged,
+        this, [this](const QModelIndex& current, const QModelIndex&) { onFolderSelected(current); });
+    connect(_grid, &QListWidget::itemActivated, this, &PatternBrowserDialog::onPatternActivated);
+    connect(importButton, &QPushButton::clicked, this, &PatternBrowserDialog::onImport);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    populateGrid(root);
+}
+
+PatternBrowserDialog::~PatternBrowserDialog() = default;
+
+void PatternBrowserDialog::onFolderSelected(const QModelIndex& index) {
+    if (index.isValid()) {
+        populateGrid(_folderModel->filePath(index));
+    }
+}
+
+void PatternBrowserDialog::populateGrid(const QString& folder) {
+    _currentFolder = folder;
+    _grid->clear();
+
+    const QDir dir(folder);
+    const QStringList files = dir.entryList({ QStringLiteral("*.json") }, QDir::Files, QDir::Name);
+    for (const QString& file : files) {
+        const QString path = dir.filePath(file);
+        const auto pattern = loadPattern(path);
+        if (!pattern.has_value()) {
+            continue; // skip files that are not valid patterns
+        }
+
+        auto* item = new QListWidgetItem(QFileInfo(file).completeBaseName(), _grid);
+        item->setData(PATH_ROLE, path);
+        item->setTextAlignment(Qt::AlignHCenter | Qt::AlignTop);
+        const QPixmap thumbnail = pattern::PatternThumbnail::forPattern(
+            *pattern, path, _resources, *_hexgrid, THUMBNAIL_SIZE);
+        if (!thumbnail.isNull()) {
+            item->setIcon(QIcon(thumbnail));
+        }
+    }
+}
+
+void PatternBrowserDialog::onPatternActivated(QListWidgetItem* item) {
+    if (item == nullptr) {
+        return;
+    }
+    const QString path = item->data(PATH_ROLE).toString();
+    auto pattern = loadPattern(path);
+    if (!pattern.has_value()) {
+        return;
+    }
+    _selected = std::move(pattern);
+    accept();
+}
+
+void PatternBrowserDialog::onImport() {
+    const QString source = QFileDialog::getOpenFileName(
+        this, "Import Pattern", QString(), "Gecko Pattern (*.json)");
+    if (source.isEmpty()) {
+        return;
+    }
+    // Reject files that don't parse as patterns before copying them in.
+    if (!loadPattern(source).has_value()) {
+        return;
+    }
+
+    const QString target = QDir(_currentFolder).filePath(QFileInfo(source).fileName());
+    if (QFileInfo(source) != QFileInfo(target)) {
+        QFile::remove(target);
+        QFile::copy(source, target);
+    }
+    populateGrid(_currentFolder);
+}
+
+} // namespace geck

--- a/src/ui/dialogs/PatternBrowserDialog.h
+++ b/src/ui/dialogs/PatternBrowserDialog.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <QDialog>
+#include <QString>
+
+#include "pattern/Pattern.h"
+
+class QFileSystemModel;
+class QListWidget;
+class QListWidgetItem;
+class QModelIndex;
+class QTreeView;
+
+namespace geck {
+
+class HexagonGrid;
+namespace resource {
+    class GameResources;
+}
+
+/// Browses the user's pattern library as a folder tree + thumbnail grid, with import.
+/// Picking a pattern (double-click or Open) accepts the dialog; the chosen pattern is
+/// then available via selectedPattern().
+class PatternBrowserDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit PatternBrowserDialog(resource::GameResources& resources, QWidget* parent = nullptr);
+    ~PatternBrowserDialog() override;
+
+    std::optional<pattern::Pattern> selectedPattern() const { return _selected; }
+
+private slots:
+    void onFolderSelected(const QModelIndex& index);
+    void onPatternActivated(QListWidgetItem* item);
+    void onImport();
+
+private:
+    void populateGrid(const QString& folder);
+
+    resource::GameResources& _resources;
+    std::unique_ptr<HexagonGrid> _hexgrid;
+    QFileSystemModel* _folderModel = nullptr;
+    QTreeView* _folderTree = nullptr;
+    QListWidget* _grid = nullptr;
+    QString _currentFolder;
+    std::optional<pattern::Pattern> _selected;
+};
+
+} // namespace geck

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -271,6 +271,12 @@ void InputHandler::handleKeyPressed(const sf::Event::KeyPressed& event) {
         if (_callbacks.onDeleteObjects) {
             _callbacks.onDeleteObjects();
         }
+    } else if (event.code == sf::Keyboard::Key::R) {
+        // In stamp mode, R cycles the pattern's orientation variants (the Rotate toolbar
+        // shortcut is disabled by the editor while stamping, so the key reaches us here).
+        if (_stampPatternMode && _callbacks.onStampCycleVariant) {
+            _callbacks.onStampCycleVariant();
+        }
     }
 }
 

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -54,6 +54,13 @@ void InputHandler::handleMousePressed(const sf::Event::MouseButtonPressed& event
             return;
         }
 
+        if (_stampPatternMode) {
+            if (_callbacks.onStampPattern) {
+                _callbacks.onStampPattern(worldPos);
+            }
+            return;
+        }
+
         // Mark exits mode is handled in mouse release (not here) so drag selection works.
 
         SelectionModifier modifier = getSelectionModifier();
@@ -105,6 +112,12 @@ void InputHandler::handleMousePressed(const sf::Event::MouseButtonPressed& event
                 _callbacks.onMarkExitsModeCancelled();
             }
             spdlog::info("Mark exits mode cancelled with right-click");
+        } else if (_stampPatternMode) {
+            _stampPatternMode = false;
+            if (_callbacks.onStampPatternCancel) {
+                _callbacks.onStampPatternCancel();
+            }
+            spdlog::info("Stamp pattern mode cancelled with right-click");
         } else {
             _currentAction = EditorAction::PANNING;
             _mouseStartPos = event.position;

--- a/src/ui/input/InputHandler.h
+++ b/src/ui/input/InputHandler.h
@@ -61,6 +61,9 @@ public:
         std::function<void(sf::FloatRect area)> onScrollBlockerRectangle;
         std::function<void()> onTilePlacementCancel;
         std::function<void(sf::Vector2f worldPos)> onExitGridPlacement;
+        std::function<void(sf::Vector2f worldPos)> onStampPattern;
+        std::function<void()> onStampPatternCancel;
+        std::function<void()> onStampCycleVariant;
         std::function<void(sf::Vector2f worldPos)> onMarkExitsSelection;
         std::function<void(sf::Vector2f startPos, sf::Vector2f endPos)> onMarkExitsAreaSelection;
         std::function<void(sf::Vector2f startPos, sf::Vector2f currentPos)> onMarkExitsPreview;
@@ -109,6 +112,8 @@ public:
      */
     void setPlayerPositionMode(bool enabled) { _playerPositionMode = enabled; }
     void setExitGridPlacementMode(bool enabled) { _exitGridPlacementMode = enabled; }
+    void setStampPatternMode(bool enabled) { _stampPatternMode = enabled; }
+    bool isInStampPatternMode() const { return _stampPatternMode; }
     void setMarkExitsMode(bool enabled) {
         _markExitsMode = enabled;
     }
@@ -154,6 +159,7 @@ private:
     bool _tilePlacementReplaceMode = false;
     bool _exitGridPlacementMode = false;
     bool _markExitsMode = false;
+    bool _stampPatternMode = false;
     int _tilePlacementIndex = -1;
     bool _tilePlacementIsRoof = false;
 };

--- a/src/ui/rendering/RenderingEngine.cpp
+++ b/src/ui/rendering/RenderingEngine.cpp
@@ -44,6 +44,15 @@ void RenderingEngine::render(sf::RenderTarget& target,
         target.draw((*renderData.dragPreviewObject)->getSprite());
     }
 
+    // Layer 4b: Pattern stamp ghost preview (objects already carry their semi-transparency)
+    if (renderData.stampPreviewObjects) {
+        for (const auto& object : *renderData.stampPreviewObjects) {
+            if (object) {
+                target.draw(object->getSprite());
+            }
+        }
+    }
+
     // Layer 5: Roof tiles (if enabled)
     renderRoofTiles(target, renderData, visibility.showRoof);
 

--- a/src/ui/rendering/RenderingEngine.cpp
+++ b/src/ui/rendering/RenderingEngine.cpp
@@ -44,12 +44,23 @@ void RenderingEngine::render(sf::RenderTarget& target,
         target.draw((*renderData.dragPreviewObject)->getSprite());
     }
 
-    // Layer 4b: Pattern stamp ghost preview (objects already carry their semi-transparency)
+    // Layer 4b: Pattern stamp ghost preview (sprites already carry their semi-transparency):
+    // floor tiles, then objects, then roof tiles on top.
+    if (renderData.stampPreviewFloorTiles) {
+        for (const auto& sprite : *renderData.stampPreviewFloorTiles) {
+            target.draw(sprite);
+        }
+    }
     if (renderData.stampPreviewObjects) {
         for (const auto& object : *renderData.stampPreviewObjects) {
             if (object) {
                 target.draw(object->getSprite());
             }
+        }
+    }
+    if (renderData.stampPreviewRoofTiles) {
+        for (const auto& sprite : *renderData.stampPreviewRoofTiles) {
+            target.draw(sprite);
         }
     }
 

--- a/src/ui/rendering/RenderingEngine.h
+++ b/src/ui/rendering/RenderingEngine.h
@@ -57,8 +57,11 @@ public:
         const std::shared_ptr<Object>* dragPreviewObject = nullptr;
         bool isDraggingFromPalette = false;
 
-        // Pattern stamp ghost preview (semi-transparent objects under the cursor)
+        // Pattern stamp ghost preview (semi-transparent) under the cursor: floor tiles
+        // (under), objects, roof tiles (over)
+        const std::vector<sf::Sprite>* stampPreviewFloorTiles = nullptr;
         const std::vector<std::shared_ptr<Object>>* stampPreviewObjects = nullptr;
+        const std::vector<sf::Sprite>* stampPreviewRoofTiles = nullptr;
 
         // Selection rectangle
         const sf::RectangleShape* selectionRectangle = nullptr;

--- a/src/ui/rendering/RenderingEngine.h
+++ b/src/ui/rendering/RenderingEngine.h
@@ -57,6 +57,9 @@ public:
         const std::shared_ptr<Object>* dragPreviewObject = nullptr;
         bool isDraggingFromPalette = false;
 
+        // Pattern stamp ghost preview (semi-transparent objects under the cursor)
+        const std::vector<std::shared_ptr<Object>>* stampPreviewObjects = nullptr;
+
         // Selection rectangle
         const sf::RectangleShape* selectionRectangle = nullptr;
         bool isDragSelecting = false;

--- a/src/ui/rendering/ThumbnailRenderer.cpp
+++ b/src/ui/rendering/ThumbnailRenderer.cpp
@@ -1,0 +1,98 @@
+#include "ui/rendering/ThumbnailRenderer.h"
+
+#include <algorithm>
+#include <limits>
+
+#include <SFML/Graphics.hpp>
+#include <spdlog/spdlog.h>
+
+#include <QImage>
+#include <QPainter>
+#include <QPixmapCache>
+
+namespace geck {
+
+namespace {
+
+    // Copy an SFML RGBA image into an owned QImage.
+    QImage toQImage(const sf::Image& image) {
+        const sf::Vector2u sz = image.getSize();
+        return QImage(image.getPixelsPtr(), static_cast<int>(sz.x), static_cast<int>(sz.y),
+            QImage::Format_RGBA8888)
+            .copy();
+    }
+
+} // namespace
+
+std::optional<QPixmap> ThumbnailRenderer::cached(const QString& key) {
+    if (key.isEmpty()) {
+        return std::nullopt;
+    }
+    QPixmap pixmap;
+    if (QPixmapCache::find(key, &pixmap)) {
+        return pixmap;
+    }
+    return std::nullopt;
+}
+
+QPixmap ThumbnailRenderer::render(const std::vector<const sf::Sprite*>& sprites, int size,
+    const QString& cacheKey) {
+    // Union of all sprite bounds, with a small margin.
+    float minX = std::numeric_limits<float>::max();
+    float minY = std::numeric_limits<float>::max();
+    float maxX = std::numeric_limits<float>::lowest();
+    float maxY = std::numeric_limits<float>::lowest();
+    for (const sf::Sprite* sprite : sprites) {
+        if (sprite == nullptr) {
+            continue;
+        }
+        const sf::FloatRect b = sprite->getGlobalBounds();
+        minX = std::min(minX, b.position.x);
+        minY = std::min(minY, b.position.y);
+        maxX = std::max(maxX, b.position.x + b.size.x);
+        maxY = std::max(maxY, b.position.y + b.size.y);
+    }
+    if (minX > maxX || minY > maxY) {
+        return {}; // nothing to draw
+    }
+
+    constexpr float pad = 4.0f;
+    minX -= pad;
+    minY -= pad;
+    maxX += pad;
+    maxY += pad;
+    const auto width = static_cast<unsigned int>(std::max(1.0f, maxX - minX));
+    const auto height = static_cast<unsigned int>(std::max(1.0f, maxY - minY));
+
+    sf::RenderTexture renderTexture;
+    if (!renderTexture.resize({ width, height })) {
+        spdlog::warn("ThumbnailRenderer: failed to create {}x{} render texture", width, height);
+        return {};
+    }
+    renderTexture.setView(sf::View(sf::FloatRect({ minX, minY },
+        { static_cast<float>(width), static_cast<float>(height) })));
+    renderTexture.clear(sf::Color::Transparent);
+    for (const sf::Sprite* sprite : sprites) {
+        if (sprite != nullptr) {
+            renderTexture.draw(*sprite);
+        }
+    }
+    renderTexture.display();
+
+    const QImage rendered = toQImage(renderTexture.getTexture().copyToImage());
+    const QImage scaled = rendered.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+    QImage canvas(size, size, QImage::Format_RGBA8888);
+    canvas.fill(Qt::transparent);
+    QPainter painter(&canvas);
+    painter.drawImage((size - scaled.width()) / 2, (size - scaled.height()) / 2, scaled);
+    painter.end();
+
+    QPixmap pixmap = QPixmap::fromImage(canvas);
+    if (!cacheKey.isEmpty()) {
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
+    return pixmap;
+}
+
+} // namespace geck

--- a/src/ui/rendering/ThumbnailRenderer.h
+++ b/src/ui/rendering/ThumbnailRenderer.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <QPixmap>
+#include <QString>
+
+namespace sf {
+class Sprite;
+}
+
+namespace geck {
+
+/// Renders a set of positioned SFML sprites into a square thumbnail image. Generic and
+/// content-agnostic — patterns and (later) maps build their own sprites and hand them
+/// here, so the offscreen render + scale + in-memory cache live in one place.
+class ThumbnailRenderer {
+public:
+    /// Look up a previously rendered thumbnail in the in-memory cache (Qt's QPixmapCache).
+    /// Returns std::nullopt on a miss or an empty key.
+    static std::optional<QPixmap> cached(const QString& key);
+
+    /// Render `sprites` (already positioned, in back-to-front draw order) into a
+    /// `size`x`size` transparent thumbnail, aspect-scaled and centered. When `cacheKey`
+    /// is non-empty the result is stored in the cache. Returns a null QPixmap when there
+    /// is nothing to draw.
+    static QPixmap render(const std::vector<const sf::Sprite*>& sprites,
+        int size,
+        const QString& cacheKey = QString());
+};
+
+} // namespace geck

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(general_tests
     general/test_reading_map.cpp
     general/test_pattern_serializer.cpp
     general/test_hex_geometry.cpp
+    general/test_pattern_stamper.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(general_tests
     general/test_reading_dat.cpp
     general/test_reading_map.cpp
     general/test_pattern_serializer.cpp
+    general/test_hex_geometry.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(general_tests
     general/test_object_queries.cpp
     general/test_reading_dat.cpp
     general/test_reading_map.cpp
+    general/test_pattern_serializer.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(general_tests
     general/test_pattern_serializer.cpp
     general/test_hex_geometry.cpp
     general/test_pattern_stamper.cpp
+    general/test_pattern_builder.cpp
 )
 
 # Performance tests (Catch2 with benchmarking) - Reader performance tests

--- a/tests/general/test_hex_geometry.cpp
+++ b/tests/general/test_hex_geometry.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+
+#include "editor/HexGeometry.h"
+
+using namespace geck::hexgrid;
+
+namespace {
+
+// Unit cube vectors for the six Fallout 2 hex directions (derived so the even-q
+// offset<->cube conversion reproduces the engine's neighbour deltas).
+constexpr std::array<Cube, 6> DIRECTION_CUBES = { {
+    { -1, 1, 0 },
+    { -1, 0, 1 },
+    { 0, -1, 1 },
+    { 1, -1, 0 },
+    { 1, 0, -1 },
+    { 0, 1, -1 },
+} };
+
+// Ground-truth neighbour deltas (in position space) from fallout2-ce src/tile.cc
+// `_dir_tile[parity][direction]`, with the engine's hex-grid width of 200:
+//   _dir_tile[0] = { -1, W-1, W, W+1, 1, -W }   (even column)
+//   _dir_tile[1] = { -W-1, -1, W, 1, 1-W, -W }  (odd column)
+constexpr std::array<std::array<int, 6>, 2> ENGINE_DIR_TILE = { {
+    { -1, WIDTH - 1, WIDTH, WIDTH + 1, 1, -WIDTH },
+    { -WIDTH - 1, -1, WIDTH, 1, 1 - WIDTH, -WIDTH },
+} };
+
+// Steps one hex from `position` along direction `d` using the cube model under test.
+int stepInDirection(int position, int d) {
+    const ColRow next = cubeToOffset(cubeOfPosition(position) + DIRECTION_CUBES[d]);
+    return next.row * WIDTH + next.col;
+}
+
+} // namespace
+
+TEST_CASE("offset<->cube round-trips over the grid", "[hex_geometry]") {
+    for (int row = 0; row < HEIGHT; row += 7) {
+        for (int col = 0; col < WIDTH; col += 5) {
+            const Cube cube = offsetToCube(col, row);
+            CHECK(cube.x + cube.y + cube.z == 0); // cube invariant
+            CHECK(cubeToOffset(cube) == ColRow{ col, row });
+        }
+    }
+}
+
+TEST_CASE("cube direction steps match the fallout2-ce _dir_tile table", "[hex_geometry]") {
+    // An even and an odd column away from the edges so neighbours stay on-grid.
+    const int evenColPos = 40 * WIDTH + 10; // col 10 (even)
+    const int oddColPos = 40 * WIDTH + 11;  // col 11 (odd)
+
+    for (int d = 0; d < 6; ++d) {
+        INFO("direction " << d);
+        CHECK(stepInDirection(evenColPos, d) - evenColPos == ENGINE_DIR_TILE[0][d]);
+        CHECK(stepInDirection(oddColPos, d) - oddColPos == ENGINE_DIR_TILE[1][d]);
+    }
+}
+
+TEST_CASE("translate preserves a shape's cube-relative layout", "[hex_geometry]") {
+    const int fromAnchor = 50 * WIDTH + 50; // even column
+    const int toAnchor = 120 * WIDTH + 81;  // odd column -> different parity
+
+    SECTION("the anchor maps onto the target anchor") {
+        CHECK(translate(fromAnchor, fromAnchor, toAnchor) == toAnchor);
+    }
+
+    SECTION("a neighbour maps to the same-direction neighbour of the target") {
+        for (int d = 0; d < 6; ++d) {
+            const int authored = stepInDirection(fromAnchor, d);
+            const auto placed = translate(authored, fromAnchor, toAnchor);
+            INFO("direction " << d);
+            REQUIRE(placed.has_value());
+            CHECK(*placed == stepInDirection(toAnchor, d));
+        }
+    }
+
+    SECTION("the cube vector relative to the anchor is preserved across parities") {
+        const int authored = 47 * WIDTH + 53;
+        const auto placed = translate(authored, fromAnchor, toAnchor);
+        REQUIRE(placed.has_value());
+        const Cube authoredRel = cubeOfPosition(authored) - cubeOfPosition(fromAnchor);
+        const Cube placedRel = cubeOfPosition(*placed) - cubeOfPosition(toAnchor);
+        CHECK(authoredRel == placedRel);
+    }
+}
+
+TEST_CASE("translate is the identity when the anchors coincide", "[hex_geometry]") {
+    const int anchor = 100 * WIDTH + 100;
+    const int pos = 103 * WIDTH + 97;
+    CHECK(translate(pos, anchor, anchor) == pos);
+}
+
+TEST_CASE("translate reports positions that fall off the grid", "[hex_geometry]") {
+    // A shape authored near the centre stamped at a corner pushes part of it off-grid.
+    const int fromAnchor = 100 * WIDTH + 100;
+    const int toAnchor = 0 * WIDTH + 0;   // top-left corner
+    const int authored = 98 * WIDTH + 98; // up-left of the authoring anchor
+    CHECK_FALSE(translate(authored, fromAnchor, toAnchor).has_value());
+}

--- a/tests/general/test_object_command_controller.cpp
+++ b/tests/general/test_object_command_controller.cpp
@@ -7,74 +7,42 @@
 #include <stdexcept>
 #include <vector>
 
-#include "editor/HexagonGrid.h"
-#include "editor/Object.h"
-#include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
-#include "resource/GameResources.h"
 #include "ui/editing/ObjectCommandController.h"
-#include "ui/rendering/MapSpriteLoader.h"
-#include "util/UndoStack.h"
+
+#include "support/ControllerFixture.h"
 
 using namespace geck;
+using geck::test::ControllerFixture;
 
 namespace {
 
 constexpr int ITEM_SECTION = static_cast<int>(MapScript::ScriptType::ITEM);
 
-// Wires an ObjectCommandController to a fresh empty map. The resource and sprite
-// dependencies are unused by the elevation commands under test (they only touch
-// the map's objects and scripts), so default-constructed instances suffice.
-struct ControllerFixture {
-    resource::GameResources resources;
-    HexagonGrid hexgrid;
-    MapSpriteLoader spriteLoader{ resources, hexgrid };
-    std::vector<std::shared_ptr<Object>> objects;
-    std::vector<sf::Sprite> overlays;
-    UndoStack undoStack;
-    std::unique_ptr<Map> map;
-    ObjectCommandController controller;
+// Adds an object on `elevation` carrying an attached ITEM script and returns it.
+std::shared_ptr<MapObject> addScriptedObject(ControllerFixture& fx, int elevation, uint32_t oid, uint32_t scriptIndex) {
+    auto& mf = fx.mapFile();
+    MapScript script = MapScript::makeObjectScript(
+        MapScript::ScriptType::ITEM, scriptIndex, /*programIndex*/ 100, oid);
 
-    ControllerFixture()
-        : map(std::make_unique<Map>("test.map"))
-        , controller(
-              resources, map, hexgrid, spriteLoader, objects, overlays, undoStack,
-              [] { /* refreshObjects: no rendering in tests */ },
-              [] { /* onStackChanged: no UI to notify */ },
-              [this](int elevation) -> std::vector<Tile>& { return map->getMapFile().tiles[elevation]; },
-              [] { return 0; },
-              [](int, bool, int) { /* updateTileSprite: no rendering in tests */ },
-              [] { /* reloadTiles: no rendering in tests */ }) {
-        map->setMapFile(std::make_unique<Map::MapFile>(Map::createEmptyMapFile()));
-    }
+    auto obj = std::make_shared<MapObject>();
+    obj->elevation = static_cast<uint32_t>(elevation);
+    obj->unknown0 = oid;
+    obj->map_scripts_pid = static_cast<int32_t>(script.pid);
 
-    Map::MapFile& mapFile() { return map->getMapFile(); }
-
-    // Adds an object on `elevation` carrying an attached ITEM script and returns it.
-    std::shared_ptr<MapObject> addScriptedObject(int elevation, uint32_t oid, uint32_t scriptIndex) {
-        auto& mf = mapFile();
-        MapScript script = MapScript::makeObjectScript(
-            MapScript::ScriptType::ITEM, scriptIndex, /*programIndex*/ 100, oid);
-
-        auto obj = std::make_shared<MapObject>();
-        obj->elevation = static_cast<uint32_t>(elevation);
-        obj->unknown0 = oid;
-        obj->map_scripts_pid = static_cast<int32_t>(script.pid);
-
-        mf.map_scripts[ITEM_SECTION].push_back(script);
-        mf.scripts_in_section[ITEM_SECTION] = static_cast<int>(mf.map_scripts[ITEM_SECTION].size());
-        mf.map_objects[elevation].push_back(obj);
-        return obj;
-    }
-};
+    mf.map_scripts[ITEM_SECTION].push_back(script);
+    mf.scripts_in_section[ITEM_SECTION] = static_cast<int>(mf.map_scripts[ITEM_SECTION].size());
+    mf.map_objects[elevation].push_back(obj);
+    return obj;
+}
 
 } // namespace
 
 TEST_CASE("clearElevationObjects removes attached scripts and undo restores both", "[undo][controller]") {
     ControllerFixture fx;
-    fx.addScriptedObject(0, 1, 0);
-    fx.addScriptedObject(0, 2, 1);
+    addScriptedObject(fx, 0, 1, 0);
+    addScriptedObject(fx, 0, 2, 1);
 
     REQUIRE(fx.mapFile().map_objects[0].size() == 2);
     REQUIRE(fx.mapFile().map_scripts[ITEM_SECTION].size() == 2);
@@ -104,7 +72,7 @@ TEST_CASE("clearElevationObjects returns false for an empty elevation", "[undo][
 
 TEST_CASE("copyElevation detaches cloned objects from source scripts", "[undo][controller]") {
     ControllerFixture fx;
-    auto src = fx.addScriptedObject(0, 5, 0);
+    auto src = addScriptedObject(fx, 0, 5, 0);
     const size_t scriptsBefore = fx.mapFile().map_scripts[ITEM_SECTION].size();
 
     REQUIRE(fx.controller.copyElevation(0, 1));
@@ -135,7 +103,7 @@ TEST_CASE("copyElevation detaches cloned objects from source scripts", "[undo][c
 
 TEST_CASE("copyElevation rejects copying an elevation onto itself", "[undo][controller]") {
     ControllerFixture fx;
-    fx.addScriptedObject(0, 1, 0);
+    addScriptedObject(fx, 0, 1, 0);
     CHECK_FALSE(fx.controller.copyElevation(0, 0));
     CHECK_FALSE(fx.undoStack.canUndo());
 }

--- a/tests/general/test_pattern_builder.cpp
+++ b/tests/general/test_pattern_builder.cpp
@@ -79,7 +79,9 @@ TEST_CASE("PatternBuilder and PatternStamper are inverses", "[pattern][builder]"
     }
 
     SECTION("stamping at a new anchor translates every object by the same cube delta") {
-        const int target = 120 * hexgrid::WIDTH + 91; // different column parity
+        // Same column parity as the anchor (col 80), so the stamper's parity-snap is a
+        // no-op and the placement is exactly the cube translation.
+        const int target = 120 * hexgrid::WIDTH + 90;
         const auto plan = PatternStamper::plan(v, target);
         REQUIRE(plan.objects.size() == 3);
         for (size_t i = 0; i < objects.size(); ++i) {

--- a/tests/general/test_pattern_builder.cpp
+++ b/tests/general/test_pattern_builder.cpp
@@ -1,0 +1,89 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include "editor/HexGeometry.h"
+#include "format/map/MapObject.h"
+#include "pattern/Pattern.h"
+#include "pattern/PatternBuilder.h"
+#include "pattern/PatternStamper.h"
+
+using namespace geck;
+using namespace geck::pattern;
+
+namespace {
+
+constexpr int ANCHOR = 80 * hexgrid::WIDTH + 80; // col 80, row 80
+
+MapObject objAt(int hex, uint32_t proPid, uint32_t frmPid, uint32_t direction, uint32_t flags) {
+    MapObject o;
+    o.position = hex;
+    o.pro_pid = proPid;
+    o.frm_pid = frmPid;
+    o.direction = direction;
+    o.flags = flags;
+    return o;
+}
+
+} // namespace
+
+TEST_CASE("PatternBuilder::buildVariant captures offsets and engine ids verbatim", "[pattern][builder]") {
+    const MapObject a = objAt(ANCHOR, 33555201u, 16777345u, 0u, 0u);
+    const MapObject b = objAt(ANCHOR + 1, 33555202u, 16777346u, 2u, 0x10u);           // col +1
+    const MapObject c = objAt(ANCHOR + hexgrid::WIDTH, 33555203u, 16777347u, 4u, 0u); // row +1
+    const std::vector<const MapObject*> objects{ &a, &b, &c };
+
+    // Floor tile at the anchor's own tile (col 40, row 40 -> index 4040), and one shifted.
+    const int anchorTile = 40 * HexagonGrid::TILE_GRID_WIDTH + 40;
+    const std::vector<PatternBuilder::TileSelection> floor{
+        { anchorTile, 271 },
+        { anchorTile + 1, 272 }, // col +1
+    };
+
+    const PatternVariant v = PatternBuilder::buildVariant(objects, floor, {}, ANCHOR, "default");
+
+    CHECK(v.anchorHex == ANCHOR);
+    REQUIRE(v.objects.size() == 3);
+    CHECK(v.objects[0].dxHex == 0);
+    CHECK(v.objects[0].dyHex == 0);
+    CHECK(v.objects[0].proPid == 33555201u);
+    CHECK(v.objects[1].dxHex == 1);
+    CHECK(v.objects[1].direction == 2u);
+    CHECK(v.objects[1].flags == 0x10u);
+    CHECK(v.objects[2].dyHex == 1);
+    CHECK(v.objects[2].frmPid == 16777347u);
+
+    REQUIRE(v.floor.size() == 2);
+    CHECK(v.floor[0].dxTile == 0);
+    CHECK(v.floor[0].dyTile == 0);
+    CHECK(v.floor[0].tileId == 271);
+    CHECK(v.floor[1].dxTile == 1);
+    CHECK(v.floor[1].tileId == 272);
+}
+
+TEST_CASE("PatternBuilder and PatternStamper are inverses", "[pattern][builder]") {
+    const MapObject a = objAt(ANCHOR, 1u, 1u, 0u, 0u);
+    const MapObject b = objAt(ANCHOR + 2, 2u, 2u, 1u, 0u);
+    const MapObject c = objAt(ANCHOR + 3 * hexgrid::WIDTH - 1, 3u, 3u, 5u, 0u);
+    const std::vector<const MapObject*> objects{ &a, &b, &c };
+
+    const PatternVariant v = PatternBuilder::buildVariant(objects, {}, {}, ANCHOR, "default");
+
+    SECTION("stamping at the original anchor reproduces the original hexes") {
+        const auto plan = PatternStamper::plan(v, ANCHOR);
+        REQUIRE(plan.objects.size() == 3);
+        CHECK(plan.objects[0].hex == a.position);
+        CHECK(plan.objects[1].hex == b.position);
+        CHECK(plan.objects[2].hex == c.position);
+    }
+
+    SECTION("stamping at a new anchor translates every object by the same cube delta") {
+        const int target = 120 * hexgrid::WIDTH + 91; // different column parity
+        const auto plan = PatternStamper::plan(v, target);
+        REQUIRE(plan.objects.size() == 3);
+        for (size_t i = 0; i < objects.size(); ++i) {
+            CHECK(plan.objects[i].hex == hexgrid::translate(objects[i]->position, ANCHOR, target));
+        }
+    }
+}

--- a/tests/general/test_pattern_serializer.cpp
+++ b/tests/general/test_pattern_serializer.cpp
@@ -1,0 +1,183 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <QByteArray>
+#include <QString>
+
+#include "pattern/Pattern.h"
+#include "pattern/PatternSerializer.h"
+
+using namespace geck::pattern;
+
+namespace {
+
+Pattern makeSamplePattern() {
+    Pattern p;
+    p.name = "small_tent";
+    p.version = 1;
+
+    PatternVariant west;
+    west.label = "entrance west";
+    west.anchorHex = 19998;
+    // PIDs chosen to exceed 2^24 so the round-trip proves no precision loss.
+    west.objects.push_back(PatternObject{ 0, 0, 33555201u, 16777345u, 0u, 0u });
+    west.objects.push_back(PatternObject{ 2, 0, 33555201u, 16777345u, 2u, 0x10u });
+    // Negative offsets must survive (objects can sit "before" the anchor).
+    west.objects.push_back(PatternObject{ -3, -1, 33554435u, 16777220u, 5u, 0u });
+    west.floor.push_back(PatternTile{ 0, 0, 271 });
+    west.floor.push_back(PatternTile{ 1, 0, 271 });
+    west.roof.push_back(PatternTile{ 0, 0, 4096 });
+    p.variants.push_back(west);
+
+    PatternVariant south;
+    south.label = "entrance south";
+    south.anchorHex = 20050;
+    south.objects.push_back(PatternObject{ 0, 0, 33555202u, 16777346u, 3u, 0u });
+    p.variants.push_back(south);
+
+    return p;
+}
+
+// Wraps an extra top-level fragment into an otherwise-minimal valid pattern document,
+// so rejection cases differ only by the part under test.
+QByteArray patternDoc(const QByteArray& extraFields) {
+    QByteArray fields = R"("name": "x", "version": 1)";
+    if (!extraFields.isEmpty()) {
+        fields += ", " + extraFields;
+    }
+    return "{ " + fields + " }";
+}
+
+// A minimal valid single-variant document, with an extra fragment merged into that
+// variant for the per-variant rejection cases.
+QByteArray variantDoc(const QByteArray& extraVariantFields) {
+    QByteArray variant = R"("anchorHex": 0)";
+    if (!extraVariantFields.isEmpty()) {
+        variant += ", " + extraVariantFields;
+    }
+    return patternDoc("\"variants\": [ { " + variant + " } ]");
+}
+
+// Asserts a document is rejected. When `needle` is given, also asserts the error names
+// the offending field; otherwise just that some error was reported.
+void checkRejected(const QByteArray& doc, const char* needle = nullptr) {
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(doc, &error);
+    INFO("error: " << error.toStdString());
+    CHECK_FALSE(parsed.has_value());
+    if (needle != nullptr) {
+        CHECK(error.contains(QLatin1String(needle)));
+    } else {
+        CHECK_FALSE(error.isEmpty());
+    }
+}
+
+} // namespace
+
+TEST_CASE("PatternSerializer round-trips a pattern verbatim", "[pattern]") {
+    const Pattern original = makeSamplePattern();
+
+    const QByteArray json = PatternSerializer::serialize(original);
+    REQUIRE_FALSE(json.isEmpty());
+
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(json, &error);
+    INFO("error: " << error.toStdString()); // shown if the REQUIRE below fails
+    REQUIRE(parsed.has_value());
+
+    CHECK(parsed->name == original.name);
+    CHECK(parsed->version == original.version);
+    REQUIRE(parsed->variants.size() == original.variants.size());
+
+    const auto& west = parsed->variants[0];
+    CHECK(west.label == "entrance west");
+    CHECK(west.anchorHex == 19998);
+    REQUIRE(west.objects.size() == 3);
+    for (size_t i = 0; i < original.variants[0].objects.size(); ++i) {
+        const auto& a = original.variants[0].objects[i];
+        const auto& b = west.objects[i];
+        CHECK(b.dxHex == a.dxHex);
+        CHECK(b.dyHex == a.dyHex);
+        CHECK(b.proPid == a.proPid); // verbatim engine PID, no precision loss
+        CHECK(b.frmPid == a.frmPid);
+        CHECK(b.direction == a.direction);
+        CHECK(b.flags == a.flags);
+    }
+    REQUIRE(west.floor.size() == 2);
+    CHECK(west.floor[1].dxTile == 1);
+    CHECK(west.floor[1].tileId == 271);
+    REQUIRE(west.roof.size() == 1);
+    CHECK(west.roof[0].tileId == 4096);
+
+    const auto& south = parsed->variants[1];
+    CHECK(south.label == "entrance south");
+    CHECK(south.anchorHex == 20050);
+    REQUIRE(south.objects.size() == 1);
+    CHECK(south.objects[0].direction == 3u);
+    CHECK(south.roof.empty()); // omitted section defaults to empty
+}
+
+TEST_CASE("PatternSerializer parses a hand-written document", "[pattern]") {
+    const QByteArray doc = R"({
+        "name": "two_walls",
+        "version": 1,
+        "variants": [
+            { "label": "default", "anchorHex": 12345,
+              "objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 33555201, "frmPid": 16777345, "direction": 1 } ],
+              "floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 100 } ] }
+        ]
+    })";
+
+    QString error;
+    const auto parsed = PatternSerializer::deserialize(doc, &error);
+    INFO("error: " << error.toStdString());
+    REQUIRE(parsed.has_value());
+    CHECK(parsed->name == "two_walls");
+    REQUIRE(parsed->variants.size() == 1);
+    const auto& v = parsed->variants[0];
+    CHECK(v.anchorHex == 12345);
+    CHECK(v.label == "default");
+    REQUIRE(v.objects.size() == 1);
+    CHECK(v.objects[0].proPid == 33555201u);
+    CHECK(v.objects[0].direction == 1u);
+    REQUIRE(v.floor.size() == 1);
+    CHECK(v.roof.empty()); // omitted section defaults to empty
+}
+
+TEST_CASE("PatternSerializer rejects malformed and out-of-spec input", "[pattern]") {
+    SECTION("invalid JSON") {
+        checkRejected(QByteArray("{ not json"));
+    }
+    SECTION("top-level array is not an object") {
+        checkRejected(QByteArray("[]"));
+    }
+    SECTION("missing version") {
+        checkRejected(QByteArray(R"({ "name": "x", "variants": [] })"));
+    }
+    SECTION("unsupported version") {
+        checkRejected(QByteArray(R"({ "version": 99, "name": "x" })"), "version");
+    }
+    SECTION("missing name") {
+        checkRejected(QByteArray(R"({ "version": 1, "variants": [] })"), "name");
+    }
+    SECTION("missing variants") {
+        checkRejected(patternDoc(""), "variants");
+    }
+    SECTION("empty variants array") {
+        checkRejected(patternDoc(R"("variants": [])"), "variant");
+    }
+    SECTION("variant missing anchorHex") {
+        checkRejected(patternDoc(R"("variants": [ { "objects": [] } ])"), "anchorHex");
+    }
+    SECTION("object missing a required field") {
+        checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1 } ])"), "frmPid");
+    }
+    SECTION("a negative proPid would wrap when narrowed, so it is rejected") {
+        checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": -1, "frmPid": 0 } ])"), "proPid");
+    }
+    SECTION("a tileId above 65535 is rejected") {
+        checkRejected(variantDoc(R"("floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 70000 } ])"), "tileId");
+    }
+    SECTION("a present-but-non-numeric direction is rejected, not defaulted") {
+        checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": "north" } ])"), "direction");
+    }
+}

--- a/tests/general/test_pattern_serializer.cpp
+++ b/tests/general/test_pattern_serializer.cpp
@@ -25,7 +25,7 @@ Pattern makeSamplePattern() {
     west.objects.push_back(PatternObject{ -3, -1, 33554435u, 16777220u, 5u, 0u });
     west.floor.push_back(PatternTile{ 0, 0, 271 });
     west.floor.push_back(PatternTile{ 1, 0, 271 });
-    west.roof.push_back(PatternTile{ 0, 0, 4096 });
+    west.roof.push_back(PatternTile{ 0, 0, 2048 });
     p.variants.push_back(west);
 
     PatternVariant south;
@@ -106,7 +106,7 @@ TEST_CASE("PatternSerializer round-trips a pattern verbatim", "[pattern]") {
     CHECK(west.floor[1].dxTile == 1);
     CHECK(west.floor[1].tileId == 271);
     REQUIRE(west.roof.size() == 1);
-    CHECK(west.roof[0].tileId == 4096);
+    CHECK(west.roof[0].tileId == 2048);
 
     const auto& south = parsed->variants[1];
     CHECK(south.label == "entrance south");
@@ -174,10 +174,13 @@ TEST_CASE("PatternSerializer rejects malformed and out-of-spec input", "[pattern
     SECTION("a negative proPid would wrap when narrowed, so it is rejected") {
         checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": -1, "frmPid": 0 } ])"), "proPid");
     }
-    SECTION("a tileId above 65535 is rejected") {
-        checkRejected(variantDoc(R"("floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 70000 } ])"), "tileId");
+    SECTION("a tileId above the engine's 12-bit limit is rejected") {
+        checkRejected(variantDoc(R"("floor": [ { "dxTile": 0, "dyTile": 0, "tileId": 4096 } ])"), "tileId");
     }
     SECTION("a present-but-non-numeric direction is rejected, not defaulted") {
         checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": "north" } ])"), "direction");
+    }
+    SECTION("a direction outside 0..5 is rejected") {
+        checkRejected(variantDoc(R"("objects": [ { "dxHex": 0, "dyHex": 0, "proPid": 1, "frmPid": 2, "direction": 6 } ])"), "direction");
     }
 }

--- a/tests/general/test_pattern_stamper.cpp
+++ b/tests/general/test_pattern_stamper.cpp
@@ -59,6 +59,25 @@ TEST_CASE("PatternStamper::plan resolves object and tile positions", "[pattern][
     CHECK(plan.tiles[0].tileId == 271);
 }
 
+TEST_CASE("PatternStamper::plan keeps tiles aligned with objects at any click parity", "[pattern][stamper]") {
+    using namespace geck::hexgrid;
+    PatternVariant aligned;
+    aligned.anchorHex = 80 * WIDTH + 80; // col 80 (even), row 80
+    // An object 3 columns / 2 rows from the anchor, plus the floor tile that sits under it.
+    aligned.objects.push_back(PatternObject{ 3, 2, 1u, 1u, 0u, 0u });
+    aligned.floor.push_back(PatternTile{ (80 + 3) / 2 - 80 / 2, (80 + 2) / 2 - 80 / 2, 271 });
+
+    // Stamp on an ODD-column target (opposite parity to the even anchor) — the case that
+    // used to drift the tiles relative to the objects.
+    const auto alignedPlan = PatternStamper::plan(aligned, 50 * WIDTH + 51);
+
+    REQUIRE(alignedPlan.objects.size() == 1);
+    REQUIRE(alignedPlan.tiles.size() == 1);
+    const int objHex = alignedPlan.objects[0].hex;
+    const int objTile = (rowOf(objHex) / 2) * HexagonGrid::TILE_GRID_WIDTH + (columnOf(objHex) / 2);
+    CHECK(alignedPlan.tiles[0].tileIndex == objTile); // the floor tile still sits under the object
+}
+
 TEST_CASE("PatternStamper::plan drops entries that fall off the grid", "[pattern][stamper]") {
     PatternVariant v;
     v.anchorHex = 0;                                              // top-left corner

--- a/tests/general/test_pattern_stamper.cpp
+++ b/tests/general/test_pattern_stamper.cpp
@@ -63,19 +63,22 @@ TEST_CASE("PatternStamper::plan keeps tiles aligned with objects at any click pa
     using namespace geck::hexgrid;
     PatternVariant aligned;
     aligned.anchorHex = 80 * WIDTH + 80; // col 80 (even), row 80
-    // An object 3 columns / 2 rows from the anchor, plus the floor tile that sits under it.
-    aligned.objects.push_back(PatternObject{ 3, 2, 1u, 1u, 0u, 0u });
-    aligned.floor.push_back(PatternTile{ (80 + 3) / 2 - 80 / 2, (80 + 2) / 2 - 80 / 2, 271 });
+    // An object an ODD number of columns and rows from the anchor, plus the floor tile
+    // that sits under it. Odd offsets are what expose the hex/2 rounding mismatch.
+    aligned.objects.push_back(PatternObject{ 3, 3, 1u, 1u, 0u, 0u });
+    aligned.floor.push_back(PatternTile{ (80 + 3) / 2 - 80 / 2, (80 + 3) / 2 - 80 / 2, 271 });
 
-    // Stamp on an ODD-column target (opposite parity to the even anchor) — the case that
-    // used to drift the tiles relative to the objects.
-    const auto alignedPlan = PatternStamper::plan(aligned, 50 * WIDTH + 51);
-
-    REQUIRE(alignedPlan.objects.size() == 1);
-    REQUIRE(alignedPlan.tiles.size() == 1);
-    const int objHex = alignedPlan.objects[0].hex;
-    const int objTile = (rowOf(objHex) / 2) * HexagonGrid::TILE_GRID_WIDTH + (columnOf(objHex) / 2);
-    CHECK(alignedPlan.tiles[0].tileIndex == objTile); // the floor tile still sits under the object
+    // Stamp on an ODD-column, ODD-row target (opposite parity in both axes to the even
+    // anchor) — the case that used to drift the tiles relative to the objects.
+    for (const int target : { 50 * WIDTH + 51, 51 * WIDTH + 50, 51 * WIDTH + 51, 50 * WIDTH + 50 }) {
+        const auto alignedPlan = PatternStamper::plan(aligned, target);
+        REQUIRE(alignedPlan.objects.size() == 1);
+        REQUIRE(alignedPlan.tiles.size() == 1);
+        const int objHex = alignedPlan.objects[0].hex;
+        const int objTile = (rowOf(objHex) / 2) * HexagonGrid::TILE_GRID_WIDTH + (columnOf(objHex) / 2);
+        INFO("target " << target);
+        CHECK(alignedPlan.tiles[0].tileIndex == objTile); // the floor tile still sits under the object
+    }
 }
 
 TEST_CASE("PatternStamper::plan drops entries that fall off the grid", "[pattern][stamper]") {

--- a/tests/general/test_pattern_stamper.cpp
+++ b/tests/general/test_pattern_stamper.cpp
@@ -1,0 +1,114 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include "editor/HexGeometry.h"
+#include "format/map/Map.h"
+#include "format/map/Tile.h"
+#include "pattern/Pattern.h"
+#include "pattern/PatternStamper.h"
+
+#include "support/ControllerFixture.h"
+
+using namespace geck;
+using namespace geck::pattern;
+using geck::test::ControllerFixture;
+
+namespace {
+
+constexpr int ANCHOR = 100 * hexgrid::WIDTH + 100; // col 100, row 100
+constexpr int TARGET = 50 * hexgrid::WIDTH + 50;   // col 50, row 50
+
+PatternVariant sampleVariant() {
+    PatternVariant v;
+    v.label = "entrance west";
+    v.anchorHex = ANCHOR;
+    v.objects.push_back(PatternObject{ 0, 0, 33555201u, 16777345u, 0u, 0u });
+    v.objects.push_back(PatternObject{ 1, 0, 33555202u, 16777346u, 2u, 0x10u });
+    v.objects.push_back(PatternObject{ 0, 1, 33555203u, 16777347u, 4u, 0u });
+    v.floor.push_back(PatternTile{ 0, 0, 271 });
+    return v;
+}
+
+} // namespace
+
+TEST_CASE("PatternStamper::plan resolves object and tile positions", "[pattern][stamper]") {
+    const PatternVariant v = sampleVariant();
+    const auto plan = PatternStamper::plan(v, TARGET);
+
+    REQUIRE(plan.objects.size() == 3);
+    // The (0,0) object lands exactly on the target anchor, verbatim PID/direction.
+    CHECK(plan.objects[0].hex == TARGET);
+    CHECK(plan.objects[0].proPid == 33555201u);
+    CHECK(plan.objects[0].frmPid == 16777345u);
+    CHECK(plan.objects[0].direction == 0u);
+    CHECK(plan.objects[1].direction == 2u);
+    CHECK(plan.objects[1].flags == 0x10u);
+    // Every object translates the same way translate() would.
+    for (size_t i = 0; i < v.objects.size(); ++i) {
+        const int authored = (hexgrid::rowOf(ANCHOR) + v.objects[i].dyHex) * hexgrid::WIDTH
+            + (hexgrid::columnOf(ANCHOR) + v.objects[i].dxHex);
+        CHECK(plan.objects[i].hex == hexgrid::translate(authored, ANCHOR, TARGET));
+    }
+
+    // floor tile re-anchors on the target hex's tile (col 25, row 25 -> index 2525).
+    REQUIRE(plan.tiles.size() == 1);
+    CHECK(plan.tiles[0].tileIndex == 25 * HexagonGrid::TILE_GRID_WIDTH + 25);
+    CHECK_FALSE(plan.tiles[0].isRoof);
+    CHECK(plan.tiles[0].tileId == 271);
+}
+
+TEST_CASE("PatternStamper::plan drops entries that fall off the grid", "[pattern][stamper]") {
+    PatternVariant v;
+    v.anchorHex = 0;                                              // top-left corner
+    v.objects.push_back(PatternObject{ -5, -5, 1u, 1u, 0u, 0u }); // up-left of a corner anchor
+    v.floor.push_back(PatternTile{ -5, -5, 100 });
+
+    const auto plan = PatternStamper::plan(v, 0); // stamp back at the corner
+    CHECK(plan.objects.empty());
+    CHECK(plan.objectsDropped == 1);
+    CHECK(plan.tiles.empty());
+    CHECK(plan.tilesDropped == 1);
+}
+
+TEST_CASE("PatternStamper::stamp applies a variant as one undo entry", "[pattern][stamper]") {
+    ControllerFixture fx;
+    // Seed elevation 0 with a full set of empty tiles so the tile edits have somewhere
+    // to land and a readable before-value.
+    fx.mapFile().tiles[0] = std::vector<Tile>(
+        Map::TILES_PER_ELEVATION, Tile(static_cast<uint16_t>(Map::EMPTY_TILE), static_cast<uint16_t>(Map::EMPTY_TILE)));
+
+    PatternStamper stamper(fx.resources, fx.hexgrid, fx.controller, *fx.map);
+
+    PatternVariant v = sampleVariant();
+    v.roof.push_back(PatternTile{ 0, 0, 200 }); // floor + roof => two tile sections
+    const auto plan = PatternStamper::plan(v, TARGET);
+    const int floorTile = plan.tiles[0].tileIndex;
+    const int roofTile = plan.tiles[1].tileIndex;
+
+    const auto result = stamper.stamp(v, TARGET, 0);
+    REQUIRE(result.success);
+    // The fixture has no mounted game art, so object FRMs do not resolve and the objects
+    // are skipped (their placement math is covered by PatternStamper::plan above). Tiles
+    // need no art and are applied.
+    CHECK(result.objectsPlaced == 0);
+    CHECK(result.objectsFailed == 3);
+    CHECK(result.tilesPainted == 2);
+
+    CHECK(fx.mapFile().tiles[0][floorTile].getFloor() == 271);
+    CHECK(fx.mapFile().tiles[0][roofTile].getRoof() == 200);
+
+    // The whole stamp collapses to ONE undo entry, labelled with the variant — proof the
+    // ScopedUndoBatch wrapped the edits rather than recording each separately.
+    CHECK(fx.undoStack.lastUndoLabel() == "Stamp pattern: entrance west");
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().tiles[0][floorTile].getFloor() == static_cast<uint16_t>(Map::EMPTY_TILE));
+    CHECK(fx.mapFile().tiles[0][roofTile].getRoof() == static_cast<uint16_t>(Map::EMPTY_TILE));
+    CHECK_FALSE(fx.undoStack.canUndo()); // single entry
+
+    REQUIRE(fx.undoStack.redo());
+    CHECK(fx.mapFile().tiles[0][floorTile].getFloor() == 271);
+    CHECK(fx.mapFile().tiles[0][roofTile].getRoof() == 200);
+}

--- a/tests/general/test_pro_roundtrip.cpp
+++ b/tests/general/test_pro_roundtrip.cpp
@@ -86,7 +86,7 @@ TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]"
 }
 
 // ---------------------------------------------------------------------------
-// Level 2: WP-1.1 guard. ProWriter::writeWallData previously serialized hard
+// Level 2: wall flagsExt/SID guard. ProWriter::writeWallData previously serialized hard
 // zeros for the extended flags and SID fields (writeBE32(0)), silently losing
 // any non-zero engine values. Wall .pro files are derived purely from the PID
 // type nibble (Pro::type() == (PID & 0x0F000000) >> 24), so a faithful wall
@@ -96,7 +96,7 @@ TEST_CASE("PRO generic round-trip preserves bytes and state", "[pro][roundtrip]"
 // and assert they survive. Against the old writeBE32(0) code these reads return
 // 0 and the test FAILS; against the fix they round-trip and the test PASSES.
 // ---------------------------------------------------------------------------
-TEST_CASE("PRO wall round-trip preserves flagsExt and SID (WP-1.1)", "[pro][roundtrip][wall]") {
+TEST_CASE("PRO wall round-trip preserves flagsExt and SID", "[pro][roundtrip][wall]") {
     TempFile tmpFile{ "test_pro_roundtrip_wall", ".pro" };
     const auto& tempPath = tmpFile.path();
 
@@ -141,7 +141,7 @@ TEST_CASE("PRO wall round-trip preserves flagsExt and SID (WP-1.1)", "[pro][roun
     REQUIRE(reparsed->header.light_intensity == 65536);
     REQUIRE(reparsed->header.flags == 0x00000020);
 
-    // The actual WP-1.1 regression assertions: these are the fields the old
+    // The actual wall-fix regression assertions: these are the fields the old
     // writer zeroed out.
     REQUIRE(reparsed->commonItemData.flagsExt == SENTINEL_FLAGS_EXT);
     REQUIRE(reparsed->commonItemData.SID == SENTINEL_SID);

--- a/tests/general/test_selection_manager.cpp
+++ b/tests/general/test_selection_manager.cpp
@@ -26,7 +26,7 @@ using namespace geck::selection;
 //
 // MockEditorWidget implements the narrow SelectionDataProvider interface so
 // SelectionManager can be exercised without the real EditorWidget god-object
-// (this is the point of WP-4). The hit-test methods use a deliberately simple
+// (the point of the SelectionDataProvider seam). The hit-test methods use a deliberately simple
 // fabricated coordinate formula; the real world->hex/tile conversion is covered
 // by test_viewport_controller.cpp.
 //==============================================================================
@@ -162,7 +162,7 @@ TEST_CASE("Mock provider position-based tile hit tests", "[selection_manager][mo
 //==============================================================================
 // SECTION: Real SelectionManager construction through the mock provider
 //
-// These tests close the WP-4 testability gap: previously MockEditorWidget only
+// These tests close the testability gap: previously MockEditorWidget only
 // proved the SelectionDataProvider interface compiled. Here we actually construct
 // geck::selection::SelectionManager(mockWidget) and drive provider-backed paths
 // end-to-end. We deliberately avoid the HEXES single-click branch, because the
@@ -227,7 +227,7 @@ TEST_CASE("SelectionManager drives provider-backed selection paths", "[selection
 //==============================================================================
 // SECTION: Elevation regression for finishAreaSelection()
 //
-// REGRESSION TEST for the elevation bug fixed in WP-4:
+// REGRESSION TEST for the elevation bug fixed in the manager-decoupling work:
 // SelectionManager::finishAreaSelection() used to call selectArea(area, mode, 0)
 // with a HARDCODED elevation of 0, which broke area selection on every elevation
 // other than the ground floor. It now calls selectArea(area, mode,

--- a/tests/support/ControllerFixture.h
+++ b/tests/support/ControllerFixture.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+
+#include <memory>
+#include <vector>
+
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/map/Map.h"
+#include "format/map/Tile.h"
+#include "resource/GameResources.h"
+#include "ui/editing/ObjectCommandController.h"
+#include "ui/rendering/MapSpriteLoader.h"
+#include "util/UndoStack.h"
+
+namespace geck::test {
+
+/// Wires an ObjectCommandController to a fresh empty map for headless tests. The
+/// resource/sprite dependencies are default-constructed; the rendering callbacks are
+/// no-ops, so commands that only touch the map's objects, tiles and scripts work
+/// without a graphics context.
+struct ControllerFixture {
+    resource::GameResources resources;
+    HexagonGrid hexgrid;
+    MapSpriteLoader spriteLoader{ resources, hexgrid };
+    std::vector<std::shared_ptr<Object>> objects;
+    std::vector<sf::Sprite> overlays;
+    UndoStack undoStack;
+    std::unique_ptr<Map> map;
+    ObjectCommandController controller;
+
+    ControllerFixture()
+        : map(std::make_unique<Map>("test.map"))
+        , controller(
+              resources, map, hexgrid, spriteLoader, objects, overlays, undoStack,
+              [] { /* refreshObjects: no rendering in tests */ },
+              [] { /* onStackChanged: no UI to notify */ },
+              [this](int elevation) -> std::vector<Tile>& { return map->getMapFile().tiles[elevation]; },
+              [] { return 0; },
+              [](int, bool, int) { /* updateTileSprite: no rendering in tests */ },
+              [] { /* reloadTiles: no rendering in tests */ }) {
+        map->setMapFile(std::make_unique<Map::MapFile>(Map::createEmptyMapFile()));
+    }
+
+    Map::MapFile& mapFile() { return map->getMapFile(); }
+};
+
+} // namespace geck::test


### PR DESCRIPTION
Reusable prefabs for Fallout 2 maps: capture a selection as a pattern, browse a library by thumbnail, and stamp it back onto the map as one undo step.

## Design: orientation by variant, not rotation
F2 object art is direction-specific (a wall facing NE is a different PRO/FRM than one facing NW), so a prefab can't be geometrically rotated. A pattern instead holds one or more **pre-authored orientation variants**; stamping places a variant verbatim, cube-translated to the target.

## What's in it
- **Format** (`pattern/Pattern`, `PatternSerializer`): name + variants of relative object (hex) and floor/roof tile (tile-space) offsets at an anchor; QJson round-trip, engine IDs verbatim, strictly validated.
- **Geometry** (`editor/HexGeometry`): cube coordinates + parity-correct translation, validated against fallout2-ce's `_dir_tile`.
- **Stamp** (`PatternStamper`): pure `plan()` (off-grid dropped, anchor parity-snap so tiles stay locked to objects) + `stamp()` through `ObjectCommandController` as one `ScopedUndoBatch`.
- **Capture** (`PatternBuilder`): inverse of the stamper (round-trip tested).
- **UI**: Save Selection as Pattern; Stamp Pattern mode (click to place, full floor/object/roof **ghost preview** under the cursor); a **library browser** (folder tree + in-memory-rendered thumbnail grid + import), defaulting to a user pattern folder.
- **Rendering** (`ThumbnailRenderer`, shared `PatternSprite` builders): generic offscreen sprite→QPixmap renderer reused across the feature (and ready for the map loader).

## Tests (headless)
Format round-trip/validation, hex geometry vs the engine table, stamper `plan` + one-undo-entry application + parity alignment, and capture↔stamp inverse. Full suite green (170 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)