### PR TITLE
Add a map browser with thumbnail previews

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -416,15 +416,25 @@ the user to press Ctrl-Z thousands of times. Therefore:
 
 # Map loader panel with thumbnail previews
 
-> Status: planned. A visual map picker that lists available maps as rendered thumbnails
+> Status: in progress. A visual map picker that lists available maps as rendered thumbnails
 > with their names, so a designer browses maps by sight instead of by filename. Replaces /
 > augments the plain "Open Map" file dialog and the text-only file browser.
+>
+> Done: `MapBrowserDialog` (File → Browse Maps…, Ctrl+B) — grid of map thumbnails + filter
+> box + larger preview pane, double-click / Open loads the map via `handleMapLoadRequest`.
+> Thumbnails come from `MapThumbnail::forMap` (built on the shared `ThumbnailRenderer`) and
+> render **lazily**: only the cells in view, one per event-loop turn, restarted on
+> scroll/filter so browsing a DAT's worth of maps stays responsive. Cache is in-memory
+> (`QPixmapCache`), matching the pattern browser; no on-disk cache.
+>
+> Remaining ideas: source grouping (vanilla vs user maps), a Welcome-screen entry point,
+> and a persisted cross-session cache if first-render latency proves annoying.
 
 ## What it is
-A dockable panel (or a dialog reachable from the Welcome screen / File menu) showing a grid
-of map thumbnails + names, with a larger preview of the highlighted map. Double-click (or an
-"Open" button) loads the map. Optional: a search/filter box and a folder/source grouping
-(vanilla `master.dat` maps vs user/filesystem maps).
+A dialog reachable from the File menu (a dockable panel is a possible later variant) showing a
+grid of map thumbnails + names, with a larger preview of the highlighted map. Double-click (or
+the "Open" button) loads the map. A search/filter box is included; folder/source grouping
+(vanilla `master.dat` maps vs user/filesystem maps) is a possible follow-up.
 
 ## Where maps come from
 Enumerate `*.map` under `maps/` across the mounted VFS (`master.dat`/`critter.dat` + any
@@ -438,9 +448,11 @@ it to "render a set of tiles + objects to an `sf::RenderTexture`, read back to a
 and both patterns and maps feed it. Differences for maps:
 - A map render is **much heavier** than a prefab (up to `TILES_PER_ELEVATION` floor/roof
   tiles + all objects on the default elevation), and producing it means **loading the map**
-  (`MapLoader` parse + FRM/tile resolution). So the **disk cache is mandatory**, keyed by map
-  path + size/mtime, with **lazy** (visible-cell-only) and **background** generation — never
-  block the UI loading dozens of maps up front.
+  (parse + FRM/tile resolution). The dialog therefore renders **lazily** — visible cells
+  only, one per event-loop turn — and caches in memory via `QPixmapCache`, matching the
+  pattern browser. (SFML's GL context rules out a true background thread, so "background" is
+  the event-loop-yielding lazy queue rather than a worker thread.) A persisted on-disk cache
+  keyed by map path + mtime remains a future option if cold-start latency becomes a problem.
 - Decide the thumbnail's elevation (default 0) and whether to include objects/critters or just
   the tile layer (tiles alone are cheaper and already give a recognizable silhouette).
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,6 +168,8 @@ set(GECK_APP_SOURCES
     ui/rendering/RenderingEngine.cpp
     ui/rendering/ThumbnailRenderer.h
     ui/rendering/ThumbnailRenderer.cpp
+    ui/rendering/MapThumbnail.h
+    ui/rendering/MapThumbnail.cpp
     ui/editing/ObjectCommandController.h
     ui/editing/ObjectCommandController.cpp
     ui/input/InputHandler.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,8 @@ set(GECK_APP_SOURCES
     ui/dialogs/AboutDialog.cpp
     ui/dialogs/PatternBrowserDialog.h
     ui/dialogs/PatternBrowserDialog.cpp
+    ui/dialogs/MapBrowserDialog.h
+    ui/dialogs/MapBrowserDialog.cpp
 
     # Qt6 UI Widgets
     ui/widgets/SFMLWidget.h

--- a/src/pattern/PatternSprite.cpp
+++ b/src/pattern/PatternSprite.cpp
@@ -11,6 +11,7 @@
 #include "format/lst/Lst.h"
 #include "format/map/Map.h"
 #include "resource/GameResources.h"
+#include "ui/rendering/ThumbnailRenderer.h"
 #include "util/TileUtils.h"
 
 namespace geck::pattern {
@@ -68,6 +69,23 @@ std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
         spdlog::warn("buildTileSprite: tile {} art failed: {}", tileId, e.what());
         return std::nullopt;
     }
+}
+
+QPixmap composeThumbnail(const std::vector<sf::Sprite>& floorSprites,
+    const std::vector<std::shared_ptr<Object>>& objects,
+    const std::vector<sf::Sprite>& roofSprites, int size, const QString& cacheKey) {
+    std::vector<const sf::Sprite*> ordered;
+    ordered.reserve(floorSprites.size() + objects.size() + roofSprites.size());
+    for (const sf::Sprite& sprite : floorSprites) {
+        ordered.push_back(&sprite);
+    }
+    for (const auto& object : objects) {
+        ordered.push_back(&object->getSprite());
+    }
+    for (const sf::Sprite& sprite : roofSprites) {
+        ordered.push_back(&sprite);
+    }
+    return ThumbnailRenderer::render(ordered, size, cacheKey);
 }
 
 } // namespace geck::pattern

--- a/src/pattern/PatternSprite.h
+++ b/src/pattern/PatternSprite.h
@@ -3,8 +3,12 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include <SFML/Graphics/Sprite.hpp>
+
+#include <QPixmap>
+#include <QString>
 
 namespace geck {
 class HexagonGrid;
@@ -33,5 +37,15 @@ std::optional<sf::Sprite> buildTileSprite(resource::GameResources& resources,
     int tileIndex,
     bool isRoof,
     uint16_t tileId);
+
+/// Flatten floor tiles, objects, then roof tiles into the editor's back-to-front draw
+/// order and render them to a `size`x`size` thumbnail via the shared ThumbnailRenderer.
+/// Shared by the pattern and map thumbnail compositors. `cacheKey` is forwarded to the
+/// renderer's in-memory cache (an empty key disables caching).
+QPixmap composeThumbnail(const std::vector<sf::Sprite>& floorSprites,
+    const std::vector<std::shared_ptr<Object>>& objects,
+    const std::vector<sf::Sprite>& roofSprites,
+    int size,
+    const QString& cacheKey);
 
 } // namespace geck::pattern

--- a/src/pattern/PatternThumbnail.cpp
+++ b/src/pattern/PatternThumbnail.cpp
@@ -60,20 +60,7 @@ QPixmap PatternThumbnail::forPattern(const Pattern& pattern, const QString& sour
         }
     }
 
-    // Flatten into the editor's draw order: floor tiles, then objects, then roof tiles.
-    std::vector<const sf::Sprite*> ordered;
-    ordered.reserve(floorSprites.size() + objects.size() + roofSprites.size());
-    for (const sf::Sprite& sprite : floorSprites) {
-        ordered.push_back(&sprite);
-    }
-    for (const auto& object : objects) {
-        ordered.push_back(&object->getSprite());
-    }
-    for (const sf::Sprite& sprite : roofSprites) {
-        ordered.push_back(&sprite);
-    }
-
-    return ThumbnailRenderer::render(ordered, size, key);
+    return composeThumbnail(floorSprites, objects, roofSprites, size, key);
 }
 
 } // namespace geck::pattern

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include "ui/tools/ExitGridPlacementManager.h"
 #include "ui/dialogs/SettingsDialog.h"
 #include "ui/dialogs/AboutDialog.h"
+#include "ui/dialogs/MapBrowserDialog.h"
 #include "ui/dialogs/PatternBrowserDialog.h"
 #include "ui/UIConstants.h"
 #include "resource/GameResources.h"
@@ -359,6 +360,7 @@ void MainWindow::setupMenuBar() {
     _fileMenu = _menuBar->addMenu("&File");
     addMenuAction(_fileMenu, ":/icons/actions/new.svg", "&New Map", &MainWindow::newMapRequested, QKeySequence::New, "Create a new map");
     addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Open Map", &MainWindow::openMapRequested, QKeySequence::Open, "Open an existing map");
+    addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Browse Maps...", &MainWindow::showMapBrowserDialog, QKeySequence("Ctrl+B"), "Browse available maps as thumbnails");
     addMenuAction(_fileMenu, ":/icons/actions/save.svg", "&Save Map", &MainWindow::saveMapRequested, QKeySequence::Save, "Save current map");
 
     _fileMenu->addSeparator();
@@ -1735,6 +1737,17 @@ void MainWindow::showStampPatternDialog() {
     auto selected = dialog.selectedPattern();
     if (selected.has_value()) {
         _currentEditorWidget->beginStampPattern(std::move(*selected));
+    }
+}
+
+void MainWindow::showMapBrowserDialog() {
+    MapBrowserDialog dialog(*_resourcesShared, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const QString mapPath = dialog.selectedMapPath();
+    if (!mapPath.isEmpty()) {
+        handleMapLoadRequest(mapPath.toStdString(), false);
     }
 }
 

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -112,6 +112,7 @@ private slots:
     void onPlayGame();
     void showSavePatternDialog();
     void showStampPatternDialog();
+    void showMapBrowserDialog();
 
 public slots:
     void showStatusMessage(const QString& message);

--- a/src/ui/dialogs/MapBrowserDialog.cpp
+++ b/src/ui/dialogs/MapBrowserDialog.cpp
@@ -5,6 +5,7 @@
 
 #include <QColor>
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QFileInfo>
 #include <QLabel>
 #include <QLineEdit>
@@ -25,7 +26,11 @@ namespace geck {
 
 namespace {
     constexpr int THUMBNAIL_SIZE = 128;
-    constexpr int PREVIEW_SIZE = 320;
+    // The preview is rendered once at this resolution (the renderer's own cap), then
+    // scaled to fit the preview pane as it is resized. 160 is a floor so the pane can be
+    // dragged small without the preview vanishing.
+    constexpr int PREVIEW_RENDER_SIZE = 512;
+    constexpr int PREVIEW_MIN_SIZE = 160;
     constexpr int CELL_PADDING_W = 24;
     constexpr int CELL_PADDING_H = 40;
     constexpr int PATH_ROLE = Qt::UserRole + 1;
@@ -62,7 +67,12 @@ MapBrowserDialog::MapBrowserDialog(resource::GameResources& resources, QWidget* 
 
     _previewImage = new QLabel(this);
     _previewImage->setAlignment(Qt::AlignCenter);
-    _previewImage->setMinimumSize(PREVIEW_SIZE, PREVIEW_SIZE);
+    _previewImage->setMinimumSize(PREVIEW_MIN_SIZE, PREVIEW_MIN_SIZE);
+    // Ignore the pixmap's own size hint so the label fills whatever the splitter gives it
+    // (and the scaled pixmap never feeds back into the layout); rescalePreview fits the
+    // image to that size on every resize.
+    _previewImage->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+    _previewImage->installEventFilter(this);
     _previewName = new QLabel(this);
     _previewName->setAlignment(Qt::AlignCenter);
     _previewName->setWordWrap(true);
@@ -176,9 +186,9 @@ void MapBrowserDialog::onCurrentItemChanged(QListWidgetItem* current) {
 }
 
 void MapBrowserDialog::updatePreview(const QListWidgetItem* item) {
+    _previewSource = QPixmap();
     if (item == nullptr) {
-        _previewImage->setText(QString());
-        _previewImage->setPixmap(QPixmap());
+        _previewImage->clear();
         _previewName->clear();
         return;
     }
@@ -193,13 +203,28 @@ void MapBrowserDialog::updatePreview(const QListWidgetItem* item) {
             current == nullptr || current->data(PATH_ROLE).toString() != path) {
             return;
         }
-        const QPixmap preview = MapThumbnail::forMap(path, _resources, *_hexgrid, PREVIEW_SIZE);
-        if (preview.isNull()) {
+        _previewSource = MapThumbnail::forMap(path, _resources, *_hexgrid, PREVIEW_RENDER_SIZE);
+        if (_previewSource.isNull()) {
             _previewImage->setText("No preview");
         } else {
-            _previewImage->setPixmap(preview);
+            rescalePreview();
         }
     });
+}
+
+void MapBrowserDialog::rescalePreview() {
+    if (_previewSource.isNull()) {
+        return;
+    }
+    _previewImage->setPixmap(_previewSource.scaled(
+        _previewImage->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+}
+
+bool MapBrowserDialog::eventFilter(QObject* watched, QEvent* event) {
+    if (watched == _previewImage && event->type() == QEvent::Resize) {
+        rescalePreview();
+    }
+    return QDialog::eventFilter(watched, event);
 }
 
 void MapBrowserDialog::onItemActivated(const QListWidgetItem* item) {

--- a/src/ui/dialogs/MapBrowserDialog.cpp
+++ b/src/ui/dialogs/MapBrowserDialog.cpp
@@ -105,8 +105,7 @@ MapBrowserDialog::MapBrowserDialog(resource::GameResources& resources, QWidget* 
     connect(_thumbnailTimer, &QTimer::timeout, this, &MapBrowserDialog::renderNextVisibleThumbnail);
 
     connect(_search, &QLineEdit::textChanged, this, &MapBrowserDialog::onFilterChanged);
-    connect(_grid, &QListWidget::currentItemChanged, this,
-        [this](QListWidgetItem* current, QListWidgetItem*) { onCurrentItemChanged(current); });
+    connect(_grid, &QListWidget::currentItemChanged, this, &MapBrowserDialog::onCurrentItemChanged);
     connect(_grid, &QListWidget::itemActivated, this, &MapBrowserDialog::onItemActivated);
     connect(_grid->verticalScrollBar(), &QScrollBar::valueChanged, this,
         [this] { _thumbnailTimer->start(); });

--- a/src/ui/dialogs/MapBrowserDialog.cpp
+++ b/src/ui/dialogs/MapBrowserDialog.cpp
@@ -1,0 +1,224 @@
+#include "ui/dialogs/MapBrowserDialog.h"
+
+#include <algorithm>
+#include <vector>
+
+#include <QColor>
+#include <QDialogButtonBox>
+#include <QFileInfo>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QShowEvent>
+#include <QSplitter>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include "editor/HexagonGrid.h"
+#include "resource/GameResources.h"
+#include "ui/rendering/MapThumbnail.h"
+#include "ui/theme/ThemeManager.h"
+
+namespace geck {
+
+namespace {
+    constexpr int THUMBNAIL_SIZE = 128;
+    constexpr int PREVIEW_SIZE = 320;
+    constexpr int CELL_PADDING_W = 24;
+    constexpr int CELL_PADDING_H = 40;
+    constexpr int PATH_ROLE = Qt::UserRole + 1;
+    constexpr int RENDERED_ROLE = Qt::UserRole + 2;
+
+    // A neutral fill shown in a cell until its real thumbnail has been rendered, so the
+    // grid keeps a uniform layout instead of collapsing empty cells.
+    QPixmap placeholderThumbnail() {
+        QPixmap pm(THUMBNAIL_SIZE, THUMBNAIL_SIZE);
+        pm.fill(QColor(ui::theme::colors::SURFACE_DARK));
+        return pm;
+    }
+} // namespace
+
+MapBrowserDialog::MapBrowserDialog(resource::GameResources& resources, QWidget* parent)
+    : QDialog(parent)
+    , _resources(resources)
+    , _hexgrid(std::make_unique<HexagonGrid>()) {
+    setWindowTitle("Open Map");
+    resize(860, 560);
+
+    _search = new QLineEdit(this);
+    _search->setPlaceholderText("Filter maps…");
+    _search->setClearButtonEnabled(true);
+
+    _grid = new QListWidget(this);
+    _grid->setViewMode(QListView::IconMode);
+    _grid->setIconSize(QSize(THUMBNAIL_SIZE, THUMBNAIL_SIZE));
+    _grid->setGridSize(QSize(THUMBNAIL_SIZE + CELL_PADDING_W, THUMBNAIL_SIZE + CELL_PADDING_H));
+    _grid->setResizeMode(QListView::Adjust);
+    _grid->setMovement(QListView::Static);
+    _grid->setUniformItemSizes(true);
+    _grid->setWordWrap(true);
+
+    _previewImage = new QLabel(this);
+    _previewImage->setAlignment(Qt::AlignCenter);
+    _previewImage->setMinimumSize(PREVIEW_SIZE, PREVIEW_SIZE);
+    _previewName = new QLabel(this);
+    _previewName->setAlignment(Qt::AlignCenter);
+    _previewName->setWordWrap(true);
+
+    auto* previewPanel = new QWidget(this);
+    auto* previewLayout = new QVBoxLayout(previewPanel);
+    previewLayout->addWidget(_previewImage, 1);
+    previewLayout->addWidget(_previewName);
+
+    auto* splitter = new QSplitter(this);
+    splitter->addWidget(_grid);
+    splitter->addWidget(previewPanel);
+    splitter->setStretchFactor(0, 3);
+    splitter->setStretchFactor(1, 1);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Open | QDialogButtonBox::Close, this);
+    _openButton = buttons->button(QDialogButtonBox::Open);
+    _openButton->setEnabled(false);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(_search);
+    layout->addWidget(splitter, 1);
+    layout->addWidget(buttons);
+
+    // Drives lazy thumbnail rendering: each timeout renders one visible cell, then the
+    // event loop runs before the next, so scrolling/typing stay responsive. Stops itself
+    // once every visible cell is rendered; scroll/filter restart it for newly-shown cells.
+    _thumbnailTimer = new QTimer(this);
+    _thumbnailTimer->setInterval(0);
+    connect(_thumbnailTimer, &QTimer::timeout, this, &MapBrowserDialog::renderNextVisibleThumbnail);
+
+    connect(_search, &QLineEdit::textChanged, this, &MapBrowserDialog::onFilterChanged);
+    connect(_grid, &QListWidget::currentItemChanged, this,
+        [this](QListWidgetItem* current, QListWidgetItem*) { onCurrentItemChanged(current); });
+    connect(_grid, &QListWidget::itemActivated, this, &MapBrowserDialog::onItemActivated);
+    connect(_grid->verticalScrollBar(), &QScrollBar::valueChanged, this,
+        [this] { _thumbnailTimer->start(); });
+    connect(buttons, &QDialogButtonBox::accepted, this, &MapBrowserDialog::acceptCurrent);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    populate();
+}
+
+MapBrowserDialog::~MapBrowserDialog() = default;
+
+void MapBrowserDialog::populate() {
+    _grid->clear();
+
+    std::vector<QString> mapPaths;
+    for (const auto& path : _resources.files().list("*.map")) {
+        mapPaths.push_back(QString::fromStdString(path.generic_string()));
+    }
+    std::sort(mapPaths.begin(), mapPaths.end(),
+        [](const QString& a, const QString& b) { return a.compare(b, Qt::CaseInsensitive) < 0; });
+
+    const QPixmap placeholder = placeholderThumbnail();
+    for (const QString& path : mapPaths) {
+        auto* item = new QListWidgetItem(QIcon(placeholder), QFileInfo(path).completeBaseName(), _grid);
+        item->setData(PATH_ROLE, path);
+        item->setData(RENDERED_ROLE, false);
+        item->setToolTip(path);
+        item->setTextAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    }
+}
+
+QListWidgetItem* MapBrowserDialog::nextUnrenderedVisibleItem() const {
+    const QRect viewport = _grid->viewport()->rect();
+    for (int i = 0; i < _grid->count(); ++i) {
+        QListWidgetItem* item = _grid->item(i);
+        if (item->isHidden() || item->data(RENDERED_ROLE).toBool()) {
+            continue;
+        }
+        if (viewport.intersects(_grid->visualItemRect(item))) {
+            return item;
+        }
+    }
+    return nullptr;
+}
+
+void MapBrowserDialog::renderNextVisibleThumbnail() {
+    QListWidgetItem* item = nextUnrenderedVisibleItem();
+    if (item == nullptr) {
+        _thumbnailTimer->stop();
+        return;
+    }
+
+    const QString path = item->data(PATH_ROLE).toString();
+    const QPixmap thumbnail = MapThumbnail::forMap(path, _resources, *_hexgrid, THUMBNAIL_SIZE);
+    // Mark rendered even on failure, so an unreadable map isn't retried every tick.
+    item->setData(RENDERED_ROLE, true);
+    if (!thumbnail.isNull()) {
+        item->setIcon(QIcon(thumbnail));
+    }
+}
+
+void MapBrowserDialog::onFilterChanged(const QString& text) {
+    const QString needle = text.trimmed();
+    for (int i = 0; i < _grid->count(); ++i) {
+        QListWidgetItem* item = _grid->item(i);
+        const bool match = needle.isEmpty()
+            || item->text().contains(needle, Qt::CaseInsensitive)
+            || item->data(PATH_ROLE).toString().contains(needle, Qt::CaseInsensitive);
+        item->setHidden(!match);
+    }
+    _thumbnailTimer->start(); // render any cells the filter just revealed
+}
+
+void MapBrowserDialog::onCurrentItemChanged(QListWidgetItem* current) {
+    _openButton->setEnabled(current != nullptr);
+    updatePreview(current);
+}
+
+void MapBrowserDialog::updatePreview(QListWidgetItem* item) {
+    if (item == nullptr) {
+        _previewImage->setText(QString());
+        _previewImage->setPixmap(QPixmap());
+        _previewName->clear();
+        return;
+    }
+
+    const QString path = item->data(PATH_ROLE).toString();
+    _previewName->setText(path);
+    _previewImage->setText("Rendering…");
+    // Defer the heavy render so selection stays snappy; bail if the selection has since
+    // moved on (the cache makes a later re-selection of the same map instant).
+    QTimer::singleShot(0, this, [this, path] {
+        const QListWidgetItem* current = _grid->currentItem();
+        if (current == nullptr || current->data(PATH_ROLE).toString() != path) {
+            return;
+        }
+        const QPixmap preview = MapThumbnail::forMap(path, _resources, *_hexgrid, PREVIEW_SIZE);
+        if (preview.isNull()) {
+            _previewImage->setText("No preview");
+        } else {
+            _previewImage->setPixmap(preview);
+        }
+    });
+}
+
+void MapBrowserDialog::onItemActivated(QListWidgetItem* item) {
+    if (item != nullptr) {
+        _selectedPath = item->data(PATH_ROLE).toString();
+        accept();
+    }
+}
+
+void MapBrowserDialog::acceptCurrent() {
+    if (QListWidgetItem* item = _grid->currentItem()) {
+        _selectedPath = item->data(PATH_ROLE).toString();
+        accept();
+    }
+}
+
+void MapBrowserDialog::showEvent(QShowEvent* event) {
+    QDialog::showEvent(event);
+    _thumbnailTimer->start(); // viewport geometry is valid now, so visible cells resolve
+}
+
+} // namespace geck

--- a/src/ui/dialogs/MapBrowserDialog.cpp
+++ b/src/ui/dialogs/MapBrowserDialog.cpp
@@ -180,7 +180,7 @@ void MapBrowserDialog::onFilterChanged(const QString& text) {
     _thumbnailTimer->start(); // render any cells the filter just revealed
 }
 
-void MapBrowserDialog::onCurrentItemChanged(QListWidgetItem* current) {
+void MapBrowserDialog::onCurrentItemChanged(const QListWidgetItem* current) {
     _openButton->setEnabled(current != nullptr);
     updatePreview(current);
 }

--- a/src/ui/dialogs/MapBrowserDialog.cpp
+++ b/src/ui/dialogs/MapBrowserDialog.cpp
@@ -115,7 +115,7 @@ void MapBrowserDialog::populate() {
     for (const auto& path : _resources.files().list("*.map")) {
         mapPaths.push_back(QString::fromStdString(path.generic_string()));
     }
-    std::sort(mapPaths.begin(), mapPaths.end(),
+    std::ranges::sort(mapPaths,
         [](const QString& a, const QString& b) { return a.compare(b, Qt::CaseInsensitive) < 0; });
 
     const QPixmap placeholder = placeholderThumbnail();
@@ -175,7 +175,7 @@ void MapBrowserDialog::onCurrentItemChanged(QListWidgetItem* current) {
     updatePreview(current);
 }
 
-void MapBrowserDialog::updatePreview(QListWidgetItem* item) {
+void MapBrowserDialog::updatePreview(const QListWidgetItem* item) {
     if (item == nullptr) {
         _previewImage->setText(QString());
         _previewImage->setPixmap(QPixmap());
@@ -189,8 +189,8 @@ void MapBrowserDialog::updatePreview(QListWidgetItem* item) {
     // Defer the heavy render so selection stays snappy; bail if the selection has since
     // moved on (the cache makes a later re-selection of the same map instant).
     QTimer::singleShot(0, this, [this, path] {
-        const QListWidgetItem* current = _grid->currentItem();
-        if (current == nullptr || current->data(PATH_ROLE).toString() != path) {
+        if (const QListWidgetItem* current = _grid->currentItem();
+            current == nullptr || current->data(PATH_ROLE).toString() != path) {
             return;
         }
         const QPixmap preview = MapThumbnail::forMap(path, _resources, *_hexgrid, PREVIEW_SIZE);
@@ -202,7 +202,7 @@ void MapBrowserDialog::updatePreview(QListWidgetItem* item) {
     });
 }
 
-void MapBrowserDialog::onItemActivated(QListWidgetItem* item) {
+void MapBrowserDialog::onItemActivated(const QListWidgetItem* item) {
     if (item != nullptr) {
         _selectedPath = item->data(PATH_ROLE).toString();
         accept();
@@ -210,7 +210,7 @@ void MapBrowserDialog::onItemActivated(QListWidgetItem* item) {
 }
 
 void MapBrowserDialog::acceptCurrent() {
-    if (QListWidgetItem* item = _grid->currentItem()) {
+    if (const QListWidgetItem* item = _grid->currentItem()) {
         _selectedPath = item->data(PATH_ROLE).toString();
         accept();
     }

--- a/src/ui/dialogs/MapBrowserDialog.h
+++ b/src/ui/dialogs/MapBrowserDialog.h
@@ -46,7 +46,7 @@ protected:
 
 private slots:
     void onFilterChanged(const QString& text);
-    void onCurrentItemChanged(QListWidgetItem* current);
+    void onCurrentItemChanged(const QListWidgetItem* current);
     void onItemActivated(const QListWidgetItem* item);
     void renderNextVisibleThumbnail();
 

--- a/src/ui/dialogs/MapBrowserDialog.h
+++ b/src/ui/dialogs/MapBrowserDialog.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <memory>
+
+#include <QDialog>
+#include <QString>
+
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QListWidgetItem;
+class QPushButton;
+class QShowEvent;
+class QTimer;
+
+namespace geck {
+
+class HexagonGrid;
+namespace resource {
+    class GameResources;
+}
+
+/// Browses the maps available in the mounted game data as a thumbnail grid, with a
+/// filter box and a larger preview of the highlighted map. Thumbnails are rendered
+/// lazily — only for the cells currently in view, one per event-loop turn — because
+/// each one parses and renders a whole map, which is far too heavy to do up front for
+/// the hundreds of maps a DAT can hold. Picking a map (double-click or Open) accepts
+/// the dialog; its VFS path is then available via selectedMapPath().
+class MapBrowserDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit MapBrowserDialog(resource::GameResources& resources, QWidget* parent = nullptr);
+    ~MapBrowserDialog() override;
+
+    /// VFS path of the chosen map (e.g. "maps/sfshutl2.map"); empty unless accepted.
+    QString selectedMapPath() const { return _selectedPath; }
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private slots:
+    void onFilterChanged(const QString& text);
+    void onCurrentItemChanged(QListWidgetItem* current);
+    void onItemActivated(QListWidgetItem* item);
+    void renderNextVisibleThumbnail();
+
+private:
+    void populate();
+    void acceptCurrent();
+    void updatePreview(QListWidgetItem* item);
+    QListWidgetItem* nextUnrenderedVisibleItem() const;
+
+    resource::GameResources& _resources;
+    std::unique_ptr<HexagonGrid> _hexgrid;
+    QLineEdit* _search = nullptr;
+    QListWidget* _grid = nullptr;
+    QLabel* _previewImage = nullptr;
+    QLabel* _previewName = nullptr;
+    QPushButton* _openButton = nullptr;
+    QTimer* _thumbnailTimer = nullptr;
+    QString _selectedPath;
+};
+
+} // namespace geck

--- a/src/ui/dialogs/MapBrowserDialog.h
+++ b/src/ui/dialogs/MapBrowserDialog.h
@@ -42,13 +42,13 @@ protected:
 private slots:
     void onFilterChanged(const QString& text);
     void onCurrentItemChanged(QListWidgetItem* current);
-    void onItemActivated(QListWidgetItem* item);
+    void onItemActivated(const QListWidgetItem* item);
     void renderNextVisibleThumbnail();
 
 private:
     void populate();
     void acceptCurrent();
-    void updatePreview(QListWidgetItem* item);
+    void updatePreview(const QListWidgetItem* item);
     QListWidgetItem* nextUnrenderedVisibleItem() const;
 
     resource::GameResources& _resources;

--- a/src/ui/dialogs/MapBrowserDialog.h
+++ b/src/ui/dialogs/MapBrowserDialog.h
@@ -3,12 +3,15 @@
 #include <memory>
 
 #include <QDialog>
+#include <QPixmap>
 #include <QString>
 
+class QEvent;
 class QLabel;
 class QLineEdit;
 class QListWidget;
 class QListWidgetItem;
+class QObject;
 class QPushButton;
 class QShowEvent;
 class QTimer;
@@ -38,6 +41,8 @@ public:
 
 protected:
     void showEvent(QShowEvent* event) override;
+    // Rescales the preview to fit when the preview label is resized (e.g. by the splitter).
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:
     void onFilterChanged(const QString& text);
@@ -49,6 +54,7 @@ private:
     void populate();
     void acceptCurrent();
     void updatePreview(const QListWidgetItem* item);
+    void rescalePreview();
     QListWidgetItem* nextUnrenderedVisibleItem() const;
 
     resource::GameResources& _resources;
@@ -59,6 +65,7 @@ private:
     QLabel* _previewName = nullptr;
     QPushButton* _openButton = nullptr;
     QTimer* _thumbnailTimer = nullptr;
+    QPixmap _previewSource; ///< Native-resolution preview, rescaled to fit on resize.
     QString _selectedPath;
 };
 

--- a/src/ui/rendering/MapThumbnail.cpp
+++ b/src/ui/rendering/MapThumbnail.cpp
@@ -1,0 +1,99 @@
+#include "ui/rendering/MapThumbnail.h"
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <SFML/Graphics/Sprite.hpp>
+#include <spdlog/spdlog.h>
+
+#include "editor/HexagonGrid.h"
+#include "editor/Object.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/Tile.h"
+#include "format/pro/Pro.h"
+#include "pattern/PatternSprite.h"
+#include "reader/map/MapReader.h"
+#include "resource/GameResources.h"
+#include "ui/rendering/ThumbnailRenderer.h"
+#include "util/ProHelper.h"
+
+namespace geck {
+
+QPixmap MapThumbnail::forMap(const QString& vfsPath, resource::GameResources& resources,
+    const HexagonGrid& hexgrid, int size) {
+    const QString key = QStringLiteral("map:") + vfsPath + '|' + QString::number(size);
+    if (auto hit = ThumbnailRenderer::cached(key)) {
+        return *hit;
+    }
+
+    const std::filesystem::path path = vfsPath.toStdString();
+    const auto bytes = resources.files().readRawBytes(path);
+    if (!bytes) {
+        return {};
+    }
+
+    std::unique_ptr<Map> map;
+    try {
+        const auto proLoad = [&resources](uint32_t pid) -> Pro* {
+            return resources.repository().load<Pro>(ProHelper::basePath(resources, pid));
+        };
+        MapReader reader(proLoad);
+        map = reader.openFile(path.string(), *bytes);
+    } catch (const std::exception& e) {
+        spdlog::warn("MapThumbnail: failed to parse {}: {}", vfsPath.toStdString(), e.what());
+        return {};
+    }
+    if (!map) {
+        return {};
+    }
+
+    constexpr int elevation = 0;
+    const Map::MapFile& mapFile = map->getMapFile();
+
+    std::vector<sf::Sprite> floorSprites;
+    std::vector<sf::Sprite> roofSprites;
+    if (const auto it = mapFile.tiles.find(elevation); it != mapFile.tiles.end()) {
+        const std::vector<Tile>& tiles = it->second;
+        for (int index = 0; index < static_cast<int>(tiles.size()); ++index) {
+            if (auto sprite = pattern::buildTileSprite(resources, index, false, tiles[index].getFloor())) {
+                floorSprites.push_back(std::move(*sprite));
+            }
+            if (auto sprite = pattern::buildTileSprite(resources, index, true, tiles[index].getRoof())) {
+                roofSprites.push_back(std::move(*sprite));
+            }
+        }
+    }
+
+    std::vector<std::shared_ptr<Object>> objects;
+    if (const auto it = mapFile.map_objects.find(elevation); it != mapFile.map_objects.end()) {
+        for (const auto& mapObject : it->second) {
+            if (!mapObject) {
+                continue;
+            }
+            if (auto object = pattern::buildSpriteObject(
+                    resources, hexgrid, mapObject->frm_pid, mapObject->position, mapObject->direction)) {
+                objects.push_back(std::move(object));
+            }
+        }
+    }
+
+    // Flatten into draw order: floor tiles, objects, roof tiles.
+    std::vector<const sf::Sprite*> ordered;
+    ordered.reserve(floorSprites.size() + objects.size() + roofSprites.size());
+    for (const sf::Sprite& sprite : floorSprites) {
+        ordered.push_back(&sprite);
+    }
+    for (const auto& object : objects) {
+        ordered.push_back(&object->getSprite());
+    }
+    for (const sf::Sprite& sprite : roofSprites) {
+        ordered.push_back(&sprite);
+    }
+
+    return ThumbnailRenderer::render(ordered, size, key);
+}
+
+} // namespace geck

--- a/src/ui/rendering/MapThumbnail.cpp
+++ b/src/ui/rendering/MapThumbnail.cpp
@@ -80,20 +80,7 @@ QPixmap MapThumbnail::forMap(const QString& vfsPath, resource::GameResources& re
         }
     }
 
-    // Flatten into draw order: floor tiles, objects, roof tiles.
-    std::vector<const sf::Sprite*> ordered;
-    ordered.reserve(floorSprites.size() + objects.size() + roofSprites.size());
-    for (const sf::Sprite& sprite : floorSprites) {
-        ordered.push_back(&sprite);
-    }
-    for (const auto& object : objects) {
-        ordered.push_back(&object->getSprite());
-    }
-    for (const sf::Sprite& sprite : roofSprites) {
-        ordered.push_back(&sprite);
-    }
-
-    return ThumbnailRenderer::render(ordered, size, key);
+    return pattern::composeThumbnail(floorSprites, objects, roofSprites, size, key);
 }
 
 } // namespace geck

--- a/src/ui/rendering/MapThumbnail.cpp
+++ b/src/ui/rendering/MapThumbnail.cpp
@@ -37,7 +37,7 @@ QPixmap MapThumbnail::forMap(const QString& vfsPath, resource::GameResources& re
 
     std::unique_ptr<Map> map;
     try {
-        const auto proLoad = [&resources](uint32_t pid) -> Pro* {
+        const auto proLoad = [&resources](uint32_t pid) {
             return resources.repository().load<Pro>(ProHelper::basePath(resources, pid));
         };
         MapReader reader(proLoad);

--- a/src/ui/rendering/MapThumbnail.h
+++ b/src/ui/rendering/MapThumbnail.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QPixmap>
+#include <QString>
+
+namespace geck {
+
+class HexagonGrid;
+namespace resource {
+    class GameResources;
+}
+
+/// Renders a map file to a thumbnail for the map-loader grid. Mirrors PatternThumbnail:
+/// loads the map, builds its ground-elevation floor/object/roof sprites, and hands them to
+/// the shared ThumbnailRenderer.
+class MapThumbnail {
+public:
+    /// Render elevation 0 of the map at `vfsPath` (a path into the mounted VFS, e.g.
+    /// "maps/sfshutl2.map") to a `size`x`size` thumbnail. Loads + parses the map on a
+    /// cache miss; returns a null QPixmap if it can't be read/parsed. Cached in memory.
+    static QPixmap forMap(const QString& vfsPath,
+        resource::GameResources& resources,
+        const HexagonGrid& hexgrid,
+        int size = 128);
+};
+
+} // namespace geck

--- a/src/ui/rendering/ThumbnailRenderer.cpp
+++ b/src/ui/rendering/ThumbnailRenderer.cpp
@@ -61,16 +61,22 @@ QPixmap ThumbnailRenderer::render(const std::vector<const sf::Sprite*>& sprites,
     minY -= pad;
     maxX += pad;
     maxY += pad;
-    const auto width = static_cast<unsigned int>(std::max(1.0f, maxX - minX));
-    const auto height = static_cast<unsigned int>(std::max(1.0f, maxY - minY));
+    const float bboxWidth = std::max(1.0f, maxX - minX);
+    const float bboxHeight = std::max(1.0f, maxY - minY);
+
+    // Cap the render texture so huge content (whole maps) stays bounded; the world-space
+    // view still covers the full bounds, so the content is supersampled down into it.
+    constexpr float maxRenderDim = 512.0f;
+    const float scale = std::min(1.0f, maxRenderDim / std::max(bboxWidth, bboxHeight));
+    const auto width = static_cast<unsigned int>(std::max(1.0f, bboxWidth * scale));
+    const auto height = static_cast<unsigned int>(std::max(1.0f, bboxHeight * scale));
 
     sf::RenderTexture renderTexture;
     if (!renderTexture.resize({ width, height })) {
         spdlog::warn("ThumbnailRenderer: failed to create {}x{} render texture", width, height);
         return {};
     }
-    renderTexture.setView(sf::View(sf::FloatRect({ minX, minY },
-        { static_cast<float>(width), static_cast<float>(height) })));
+    renderTexture.setView(sf::View(sf::FloatRect({ minX, minY }, { bboxWidth, bboxHeight })));
     renderTexture.clear(sf::Color::Transparent);
     for (const sf::Sprite* sprite : sprites) {
         if (sprite != nullptr) {


### PR DESCRIPTION
## What

Adds a visual map picker so designers browse maps by sight instead of by filename.

`File → Browse Maps…` (Ctrl+B) opens **MapBrowserDialog**: a grid of map thumbnails with a filter box and a larger preview of the highlighted map. Double-click (or Open) loads the map through the existing `handleMapLoadRequest` path.

## How it's built (two commits)

1. **MapThumbnail compositor + render-size cap.** Generalizes the offscreen thumbnail path so a whole map (ground-elevation floor/object/roof) renders through the shared `ThumbnailRenderer`, and caps the offscreen texture so a full-map render stays bounded (supersamples huge content down via a world-space view) instead of allocating an 8000px texture.
2. **MapBrowserDialog + wiring.** Enumerates `*.map` from the mounted game data via `DataFileSystem::list`, renders thumbnails with `MapThumbnail`, and wires the dialog into the File menu.

## Responsiveness

Rendering a thumbnail parses and draws an entire map — far too heavy to do up front for the hundreds of maps a DAT can hold. So thumbnails render **lazily**: only the cells currently in view, one per event-loop turn, with the render queue restarted on scroll and on filter changes. SFML's GL context rules out a true worker thread, so "background" here is the event-loop-yielding lazy queue. Results are cached in memory via `QPixmapCache`, matching the pattern browser; there is no on-disk cache.

## Testing

- `gecko`, `general_tests`, `qt_tests` build clean.
- 170 general + 20 qt test cases pass.
- The dialog itself is UI + heavy game-data I/O, so it has no dedicated unit test (consistent with `PatternBrowserDialog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)