### PR TITLE
Retire the Settings singleton and clean up audit findings

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -24,7 +24,7 @@ namespace geck {
 
 Application::Application(int argc, char** argv)
     : _qtApp(std::make_unique<QApplication>(argc, argv))
-    , _settings(Settings::create())
+    , _settings(std::make_shared<Settings>())
     , _mainWindow(nullptr)
     , _resources(std::make_shared<resource::GameResources>()) {
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -24,7 +24,7 @@ namespace geck {
 
 Application::Application(int argc, char** argv)
     : _qtApp(std::make_unique<QApplication>(argc, argv))
-    , _settings(Settings::sharedInstance())
+    , _settings(Settings::create())
     , _mainWindow(nullptr)
     , _resources(std::make_shared<resource::GameResources>()) {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,8 @@ set(GECK_APP_SOURCES
     # Qt6 UI Common
     ui/common/BaseWidget.h
     ui/common/BaseWidget.cpp
+    ui/common/BaseDialog.h
+    ui/common/BaseDialog.cpp
     ui/common/BasePaletteWidget.h
     ui/common/BasePanel.h
     ui/common/GridPalettePanel.h

--- a/src/format/map/MapObject.cpp
+++ b/src/format/map/MapObject.cpp
@@ -4,9 +4,7 @@
 namespace geck {
 
 bool MapObject::isWallObject() const {
-    // Extract object type from the protocol ID
-    uint32_t typeId = (pro_pid >> 24) & 0x0F;
-    return typeId == static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL);
+    return objectType() == static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL);
 }
 
 std::unique_ptr<MapObject> MapObject::cloneDeep() const {

--- a/src/format/map/MapObject.h
+++ b/src/format/map/MapObject.h
@@ -81,16 +81,24 @@ struct MapObject {
     uint32_t exit_elevation = 0;
     uint32_t exit_orientation = 0;
 
+    /// Object type from the PID's high byte (matches engine PID_TYPE). Values are
+    /// Pro::OBJECT_TYPE — ITEM=0, CRITTER=1, SCENERY=2, WALL=3, TILE=4, MISC=5.
+    uint32_t objectType() const { return (pro_pid & FileFormat::FULL_TYPE_MASK) >> FileFormat::TYPE_MASK_SHIFT; }
+
+    /// Proto index: the PID's low 24 bits.
+    uint32_t protoId() const { return pro_pid & FileFormat::BASE_ID_MASK; }
+
+    /// Art index: the FID's (frm_pid) low 24 bits.
+    uint32_t fidBaseId() const { return frm_pid & FileFormat::BASE_ID_MASK; }
+
     bool isBlocker() {
-        auto baseId = frm_pid & 0x00FFFFFF;
-        return baseId == 1 && flags & 0x00000010;
+        return fidBaseId() == 1 && flags & 0x00000010;
     }
 
     bool isScrollBlocker() {
         // Scroll blockers are visual indicators only (FRM-based, not proto-based)
         // They use scrblk.frm (FRM baseId == 1)
-        auto baseId = frm_pid & 0x00FFFFFF;
-        return baseId == 1;
+        return fidBaseId() == 1;
     }
 
     bool isWallObject() const;
@@ -110,14 +118,12 @@ struct MapObject {
 
     /// True for the specific light-source scenery object: ITEM/index-0 type with PID index 140 (tile #140 in F2 Dims).
     bool isLightSourceScenery() const {
-        return (pro_pid & 0xFF000000) == 0x00000000 && (pro_pid & 0x00FFFFFF) == 140;
+        return objectType() == 0 && protoId() == 140;
     }
 
     /// True for exit-grid markers: MISC objects (type 0x05) with PID index 16-23 (matches legacy F2 Mapper: misc_ID && nID 16..23).
     bool isExitGridMarker() const {
-        uint32_t objectType = (pro_pid & 0xFF000000) >> 24;
-        uint32_t objectIndex = pro_pid & 0x00FFFFFF;
-        return (objectType == 0x05) && (objectIndex >= 16) && (objectIndex <= 23);
+        return (objectType() == 0x05) && (protoId() >= 16) && (protoId() <= 23);
     }
 };
 

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<MapObject> MapReader::readMapObject() {
     object->unknown10 = read_be_u32();
     object->unknown11 = read_be_u32();
 
-    uint32_t objectTypeId = object->pro_pid >> 24;
+    uint32_t objectTypeId = object->objectType();
 
     auto pro = _proLoadCallback(object->pro_pid);
 

--- a/src/ui/common/BaseDialog.cpp
+++ b/src/ui/common/BaseDialog.cpp
@@ -2,7 +2,7 @@
 
 namespace geck {
 
-BaseDialog::BaseDialog(const QString& title, QWidget* parent, ButtonConfig buttons)
+BaseDialog::BaseDialog(const QString& title, QWidget* parent)
     : QDialog(parent)
     , _mainLayout(nullptr)
     , _buttonBox(nullptr) {

--- a/src/ui/common/BaseDialog.h
+++ b/src/ui/common/BaseDialog.h
@@ -28,9 +28,7 @@ public:
         Custom    // No automatic buttons
     };
 
-    explicit BaseDialog(const QString& title,
-        QWidget* parent = nullptr,
-        ButtonConfig buttons = OkCancel);
+    explicit BaseDialog(const QString& title, QWidget* parent = nullptr);
     virtual ~BaseDialog() = default;
 
 protected:

--- a/src/ui/dialogs/CritterPropertiesDialog.cpp
+++ b/src/ui/dialogs/CritterPropertiesDialog.cpp
@@ -1,6 +1,5 @@
 #include "CritterPropertiesDialog.h"
 
-#include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -18,9 +17,7 @@ namespace {
 
 CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t team, uint32_t hp,
     uint32_t radiation, uint32_t poison, QWidget* parent)
-    : QDialog(parent) {
-
-    setWindowTitle("Critter Properties");
+    : BaseDialog("Critter Properties", parent) {
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
@@ -43,10 +40,7 @@ CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t tea
 
     mainLayout->addLayout(formLayout);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addWidget(createButtonBox());
 }
 
 uint32_t CritterPropertiesDialog::getAiPacket() const { return static_cast<uint32_t>(_aiPacketSpin->value()); }

--- a/src/ui/dialogs/CritterPropertiesDialog.h
+++ b/src/ui/dialogs/CritterPropertiesDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <cstdint>
 
@@ -15,7 +15,7 @@ namespace geck {
 /// poison (see mp_instance.cc protoInstCritterEdit, object.cc critter data).
 /// The AI packet is shown as its raw engine number rather than a name table, to
 /// avoid inventing labels that may not match the loaded game data.
-class CritterPropertiesDialog : public QDialog {
+class CritterPropertiesDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/InstancePropertiesDialog.cpp
+++ b/src/ui/dialogs/InstancePropertiesDialog.cpp
@@ -1,7 +1,6 @@
 #include "InstancePropertiesDialog.h"
 
 #include <QCheckBox>
-#include <QDialogButtonBox>
 #include <QGroupBox>
 #include <QVBoxLayout>
 
@@ -16,12 +15,10 @@ namespace {
 
 InstancePropertiesDialog::InstancePropertiesDialog(bool isDoor, uint32_t doorOpenFlags,
     uint32_t containerDataFlags, QWidget* parent)
-    : QDialog(parent)
+    : BaseDialog(isDoor ? "Door Interaction" : "Container Interaction", parent)
     , _isDoor(isDoor)
     , _doorOpenFlags(doorOpenFlags)
     , _containerDataFlags(containerDataFlags) {
-
-    setWindowTitle(isDoor ? "Door Interaction" : "Container Interaction");
 
     const uint32_t source = isDoor ? doorOpenFlags : containerDataFlags;
 
@@ -40,10 +37,7 @@ InstancePropertiesDialog::InstancePropertiesDialog(bool isDoor, uint32_t doorOpe
 
     mainLayout->addWidget(group);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addWidget(createButtonBox());
 }
 
 uint32_t InstancePropertiesDialog::getDoorOpenFlags() const {

--- a/src/ui/dialogs/InstancePropertiesDialog.h
+++ b/src/ui/dialogs/InstancePropertiesDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <cstdint>
 
@@ -14,7 +14,7 @@ namespace geck {
 /// objectIsLocked): doors use openFlags (our MapObject.walkthrough), containers
 /// use the object data flags (our MapObject.unknown11). The dialog edits
 /// whichever applies and returns the other unchanged.
-class InstancePropertiesDialog : public QDialog {
+class InstancePropertiesDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/LightPropertiesDialog.cpp
+++ b/src/ui/dialogs/LightPropertiesDialog.cpp
@@ -1,6 +1,5 @@
 #include "LightPropertiesDialog.h"
 
-#include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -10,9 +9,7 @@
 namespace geck {
 
 LightPropertiesDialog::LightPropertiesDialog(uint32_t lightRadius, uint32_t lightIntensity, QWidget* parent)
-    : QDialog(parent) {
-
-    setWindowTitle("Light Properties");
+    : BaseDialog("Light Properties", parent) {
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
@@ -34,10 +31,7 @@ LightPropertiesDialog::LightPropertiesDialog(uint32_t lightRadius, uint32_t ligh
 
     mainLayout->addLayout(formLayout);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addWidget(createButtonBox());
 }
 
 uint32_t LightPropertiesDialog::getLightRadius() const {

--- a/src/ui/dialogs/LightPropertiesDialog.h
+++ b/src/ui/dialogs/LightPropertiesDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <cstdint>
 
@@ -14,7 +14,7 @@ namespace geck {
 /// intensity is entered as a 0-100% value and stored raw against the engine's
 /// light scale (0x10000 == 100%). See object.cc objectSetLight and
 /// mp_instance.cc (kInstMaxLightDistance / kInstMaxLightPct / kInstLightScale).
-class LightPropertiesDialog : public QDialog {
+class LightPropertiesDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/ObjectFlagsDialog.cpp
+++ b/src/ui/dialogs/ObjectFlagsDialog.cpp
@@ -1,7 +1,6 @@
 #include "ObjectFlagsDialog.h"
 
 #include <QCheckBox>
-#include <QDialogButtonBox>
 #include <QGroupBox>
 #include <QVBoxLayout>
 
@@ -14,10 +13,8 @@ namespace {
 } // namespace
 
 ObjectFlagsDialog::ObjectFlagsDialog(uint32_t flags, uint32_t objectType, QWidget* parent)
-    : QDialog(parent)
+    : BaseDialog("Object Flags", parent)
     , _originalFlags(flags) {
-
-    setWindowTitle("Object Flags");
 
     auto* mainLayout = new QVBoxLayout(this);
 
@@ -49,10 +46,7 @@ ObjectFlagsDialog::ObjectFlagsDialog(uint32_t flags, uint32_t objectType, QWidge
     addFlag(transparencyLayout, "Energy", bit(Pro::ObjectFlags::OBJECT_TRANS_ENERGY));
     mainLayout->addWidget(transparencyGroup);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addWidget(createButtonBox());
 }
 
 void ObjectFlagsDialog::addFlag(QLayout* layout, const QString& label, uint32_t bit) {

--- a/src/ui/dialogs/ObjectFlagsDialog.h
+++ b/src/ui/dialogs/ObjectFlagsDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <cstdint>
 #include <vector>
@@ -16,7 +16,7 @@ namespace geck {
 /// Shoot Thru, Light Thru, Wall Trans End, and (items only) No Highlight. Bits
 /// that are not shown for the object's type are preserved untouched, so the
 /// animation bits and engine-managed flags are never clobbered.
-class ObjectFlagsDialog : public QDialog {
+class ObjectFlagsDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/SceneryDestinationDialog.cpp
+++ b/src/ui/dialogs/SceneryDestinationDialog.cpp
@@ -1,6 +1,5 @@
 #include "SceneryDestinationDialog.h"
 
-#include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -16,14 +15,12 @@ namespace {
 
 SceneryDestinationDialog::SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType,
     uint32_t elevhex, uint32_t map, uint32_t elevtype, uint32_t elevlevel, QWidget* parent)
-    : QDialog(parent)
+    : BaseDialog("Scenery Destination", parent)
     , _isElevator(sceneryType == Pro::SCENERY_TYPE::ELEVATOR)
     , _elevhex(elevhex)
     , _map(map)
     , _elevtype(elevtype)
     , _elevlevel(elevlevel) {
-
-    setWindowTitle("Scenery Destination");
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
@@ -60,10 +57,7 @@ SceneryDestinationDialog::SceneryDestinationDialog(Pro::SCENERY_TYPE sceneryType
 
     mainLayout->addLayout(formLayout);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    mainLayout->addWidget(buttonBox);
+    mainLayout->addWidget(createButtonBox());
 }
 
 uint32_t SceneryDestinationDialog::getElevhex() const {

--- a/src/ui/dialogs/SceneryDestinationDialog.h
+++ b/src/ui/dialogs/SceneryDestinationDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <cstdint>
 
@@ -16,7 +16,7 @@ namespace geck {
 /// Stairs and ladders store their target as a packed built tile plus a
 /// destination map id; elevators store a type and a current level. Matches
 /// proto.cc scenery objectDataRead/Write and mp_instance.cc protoInstSceneryEdit.
-class SceneryDestinationDialog : public QDialog {
+class SceneryDestinationDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/ScriptSelectorDialog.cpp
+++ b/src/ui/dialogs/ScriptSelectorDialog.cpp
@@ -1,6 +1,5 @@
 #include "ScriptSelectorDialog.h"
 
-#include <QDialogButtonBox>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QVBoxLayout>
@@ -9,9 +8,8 @@ namespace geck {
 
 ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<std::string>& scriptNames,
     int currentIndex, QWidget* parent)
-    : QDialog(parent) {
+    : BaseDialog("Select Script", parent) {
 
-    setWindowTitle("Select Script");
     resize(360, 460);
 
     auto* mainLayout = new QVBoxLayout(this);
@@ -33,9 +31,7 @@ ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<std::string>& scrip
         _listWidget->setCurrentRow(currentIndex);
     }
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    auto* buttonBox = createButtonBox();
     connect(_listWidget, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
     connect(_filterEdit, &QLineEdit::textChanged, this, &ScriptSelectorDialog::onFilterChanged);
     mainLayout->addWidget(buttonBox);

--- a/src/ui/dialogs/ScriptSelectorDialog.h
+++ b/src/ui/dialogs/ScriptSelectorDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <vector>
 #include <string>
@@ -16,7 +16,7 @@ namespace geck {
 /// script "program index" the engine stores as Script::index (our
 /// MapScript.script_id). The script *type* (item/critter) is decided by the
 /// object being scripted, not here - see objectSetScript in the engine.
-class ScriptSelectorDialog : public QDialog {
+class ScriptSelectorDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -16,10 +16,8 @@
 namespace geck {
 
 SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent)
-    : QDialog(parent)
+    : BaseDialog("Add Spatial Script", parent)
     , _scriptNames(scriptNames) {
-
-    setWindowTitle("Add Spatial Script");
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
@@ -48,11 +46,9 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptN
 
     mainLayout->addLayout(formLayout);
 
-    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    auto* buttonBox = createButtonBox();
     _okButton = buttonBox->button(QDialogButtonBox::Ok);
     _okButton->setEnabled(false); // need a script first
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     connect(chooseButton, &QPushButton::clicked, this, &SpatialScriptDialog::onChooseScript);
     mainLayout->addWidget(buttonBox);
 }

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/common/BaseDialog.h"
 
 #include <vector>
 #include <string>
@@ -16,7 +16,7 @@ namespace geck {
 /// placed at a hex with a radius. Mirrors the engine's map_scr_add_spatial - the
 /// script record carries the built-tile position and radius; no saved object is
 /// involved (the engine's hex marker is editor-only / NO_SAVE).
-class SpatialScriptDialog : public QDialog {
+class SpatialScriptDialog : public BaseDialog {
     Q_OBJECT
 
 public:

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1024,7 +1024,7 @@ void SelectionPanel::onEditFlagsClicked() {
         return;
     }
 
-    const uint32_t objectType = mapObject->pro_pid >> 24;
+    const uint32_t objectType = mapObject->objectType();
     ObjectFlagsDialog dialog(mapObject->flags, objectType, this);
     if (dialog.exec() != QDialog::Accepted) {
         return;
@@ -1250,7 +1250,7 @@ void SelectionPanel::onAttachScriptClicked() {
         return;
     }
 
-    const uint32_t objectType = mapObject->pro_pid >> 24;
+    const uint32_t objectType = mapObject->objectType();
     // Critters use the CRITTER section; items/scenery/walls use the ITEM section.
     const int scriptType = (objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER))
         ? static_cast<int>(MapScript::ScriptType::CRITTER)

--- a/src/util/Constants.h
+++ b/src/util/Constants.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace geck {
 
 /**
@@ -86,14 +88,6 @@ namespace UI {
     constexpr int SPACING_LARGE = 20;     ///< Large spacing between widgets
 }
 
-// Hexagon grid constants
-namespace HexGrid {
-    constexpr int HEX_WIDTH = 32;    ///< Width of a hexagon
-    constexpr int HEX_HEIGHT = 16;   ///< Height of a hexagon
-    constexpr int GRID_WIDTH = 200;  ///< Width of the hex grid
-    constexpr int GRID_HEIGHT = 200; ///< Height of the hex grid
-}
-
 // Object rotation constants
 namespace Rotation {
     constexpr int DEFAULT_DIRECTION = 0; ///< Default object direction
@@ -102,9 +96,9 @@ namespace Rotation {
 
 // File format constants
 namespace FileFormat {
-    constexpr int TYPE_MASK_SHIFT = 24;              ///< Bit shift for type mask in PIDs/FIDs
-    constexpr uint32_t TYPE_MASK = 0x0F000000;       ///< Type mask for PIDs/FIDs
-    constexpr uint32_t FULL_TYPE_MASK = 0xFF000000;  ///< Full type mask
+    constexpr int TYPE_MASK_SHIFT = 24;              ///< Bit shift for type field in PIDs/FIDs
+    constexpr uint32_t TYPE_MASK = 0x0F000000;       ///< FID type mask: high nibble only (bits 28-30 hold rotation)
+    constexpr uint32_t FULL_TYPE_MASK = 0xFF000000;  ///< PID type mask: full high byte (PIDs carry no rotation)
     constexpr uint32_t BASE_ID_MASK = 0x00FFFFFF;    ///< Base ID mask for PIDs/FIDs
     constexpr uint32_t CRITTER_ID_MASK = 0x00000FFF; ///< Special mask for critter IDs
     constexpr int FALLOUT2_MAP_VERSION = 20;         ///< Standard Fallout 2 map version

--- a/src/util/Settings.cpp
+++ b/src/util/Settings.cpp
@@ -32,14 +32,6 @@ Settings::Settings()
     : _version(SETTINGS_VERSION) {
 }
 
-std::shared_ptr<Settings> Settings::create() {
-    // Each call yields a fresh, independently-owned instance — ownership lives at the
-    // Application root, not in a global singleton. The constructor is private (controlled
-    // construction), but this static member can reach it; shared_ptr's default deleter
-    // handles destruction via the public destructor.
-    return std::shared_ptr<Settings>(new Settings());
-}
-
 QString Settings::getSettingsFilePath() const {
     QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
     QDir configDir;

--- a/src/util/Settings.cpp
+++ b/src/util/Settings.cpp
@@ -33,11 +33,11 @@ Settings::Settings()
 }
 
 std::shared_ptr<Settings> Settings::create() {
-    // Custom deleter so the shared_ptr can reach the private destructor; the lambda is
-    // local to this member function and therefore has the necessary access to both the
-    // private constructor and destructor. Each call yields a fresh, independently-owned
-    // instance — ownership lives at the Application root, not in a global singleton.
-    return std::shared_ptr<Settings>(new Settings(), [](Settings* s) { delete s; });
+    // Each call yields a fresh, independently-owned instance — ownership lives at the
+    // Application root, not in a global singleton. The constructor is private (controlled
+    // construction), but this static member can reach it; shared_ptr's default deleter
+    // handles destruction via the public destructor.
+    return std::shared_ptr<Settings>(new Settings());
 }
 
 QString Settings::getSettingsFilePath() const {

--- a/src/util/Settings.cpp
+++ b/src/util/Settings.cpp
@@ -32,16 +32,12 @@ Settings::Settings()
     : _version(SETTINGS_VERSION) {
 }
 
-std::shared_ptr<Settings> Settings::sharedInstance() {
-    // Custom deleter so the shared_ptr can reach the private destructor; the
-    // lambda is local to this member function and therefore has the necessary
-    // access to both the private constructor and destructor.
-    static std::shared_ptr<Settings> instance(new Settings(), [](Settings* s) { delete s; });
-    return instance;
-}
-
-Settings& Settings::getInstance() {
-    return *sharedInstance();
+std::shared_ptr<Settings> Settings::create() {
+    // Custom deleter so the shared_ptr can reach the private destructor; the lambda is
+    // local to this member function and therefore has the necessary access to both the
+    // private constructor and destructor. Each call yields a fresh, independently-owned
+    // instance — ownership lives at the Application root, not in a global singleton.
+    return std::shared_ptr<Settings>(new Settings(), [](Settings* s) { delete s; });
 }
 
 QString Settings::getSettingsFilePath() const {

--- a/src/util/Settings.h
+++ b/src/util/Settings.h
@@ -22,18 +22,13 @@ namespace geck {
  */
 class Settings {
 public:
-    // Creates a fresh, caller-owned Settings instance. Ownership lives at the
-    // Application root and is injected from there (mirroring GameResources); there is
-    // no global singleton.
-    static std::shared_ptr<Settings> create();
+    // Constructed and owned at the Application root, then injected (mirroring
+    // GameResources); there is no global singleton.
+    Settings();
 
     // Disable copy/assignment
     Settings(const Settings&) = delete;
     Settings& operator=(const Settings&) = delete;
-
-    // Public so shared_ptr's default deleter can destroy a create()'d instance;
-    // construction stays controlled (the constructor is private).
-    ~Settings() = default;
 
     // Settings management
     void load();
@@ -115,8 +110,6 @@ public:
     static std::vector<DetectedInstallation> detectFallout2InstallationsDetailed();
 
 private:
-    Settings();
-
     // JSON serialization
     QJsonObject toJson() const;
     void fromJson(const QJsonObject& json);

--- a/src/util/Settings.h
+++ b/src/util/Settings.h
@@ -22,12 +22,10 @@ namespace geck {
  */
 class Settings {
 public:
-    // Canonical single shared instance shared by both the migration shim and
-    // dependency-injected pointers.
-    static std::shared_ptr<Settings> sharedInstance();
-
-    // Migration shim -> *sharedInstance(). Kept as the compatibility seam.
-    static Settings& getInstance();
+    // Creates a fresh, caller-owned Settings instance. Ownership lives at the
+    // Application root and is injected from there (mirroring GameResources); there is
+    // no global singleton.
+    static std::shared_ptr<Settings> create();
 
     // Disable copy/assignment
     Settings(const Settings&) = delete;

--- a/src/util/Settings.h
+++ b/src/util/Settings.h
@@ -31,6 +31,10 @@ public:
     Settings(const Settings&) = delete;
     Settings& operator=(const Settings&) = delete;
 
+    // Public so shared_ptr's default deleter can destroy a create()'d instance;
+    // construction stays controlled (the constructor is private).
+    ~Settings() = default;
+
     // Settings management
     void load();
     void save();
@@ -112,7 +116,6 @@ public:
 
 private:
     Settings();
-    ~Settings() = default;
 
     // JSON serialization
     QJsonObject toJson() const;

--- a/src/writer/map/MapWriter.cpp
+++ b/src/writer/map/MapWriter.cpp
@@ -246,7 +246,7 @@ void MapWriter::writeObject(const MapObject& object) {
     utils.writeBE32(object.unknown10);
     utils.writeBE32(object.unknown11);
 
-    uint32_t objectTypeId = object.pro_pid >> 24;
+    uint32_t objectTypeId = object.objectType();
 
     spdlog::debug("Writing object type: {}", objectTypeName(objectTypeId));
 

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -572,7 +572,7 @@ TEST_CASE("MainWindow panel toggles stay wired in the no-map layout", "[qt][main
     removeTestSettings();
 
     auto resources = std::make_shared<geck::resource::GameResources>();
-    geck::MainWindow window(resources, geck::Settings::create());
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
     window.show();
     QTest::qWait(250);
 

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -572,7 +572,7 @@ TEST_CASE("MainWindow panel toggles stay wired in the no-map layout", "[qt][main
     removeTestSettings();
 
     auto resources = std::make_shared<geck::resource::GameResources>();
-    geck::MainWindow window(resources, geck::Settings::sharedInstance());
+    geck::MainWindow window(resources, geck::Settings::create());
     window.show();
     QTest::qWait(250);
 


### PR DESCRIPTION
## What

Completes the Settings DI work and folds in the high-value items from the codebase audit (dedup, constant placement). Commit-separated:

1. **Retire the Settings singleton** — every consumer already took an injected `shared_ptr<Settings>`; the only construction site is `Application`. Replaced the leftover `sharedInstance()` (a function-local `static` — a hidden singleton) and the callerless `getInstance()` shim with a plain public constructor + `std::make_shared<Settings>()`, exactly mirroring how `GameResources` is constructed and injected. No global state.

2. **MapObject PID accessors** — object-type extraction from a PID was hand-rolled at many sites with inconsistent masks (`(pro_pid >> 24) & 0x0F` vs the full `& 0xFF000000`), agreeing only because valid types are 0..5 — a latent trap. Added `objectType()/protoId()/fidBaseId()` and routed the predicates plus the SelectionPanel/MapReader/MapWriter sites through them. Map/PRO round-trip tests pass unchanged (byte-for-byte fidelity).

3. **Dead hex-grid constants** — deleted the unused `Constants.h` `HexGrid` namespace (it shadowed the real `HexagonGrid::`/`Hex::` constants with different values), added the missing `<cstdint>`, and documented the genuinely-distinct FID type mask (`0x0F000000`, nibble — bits 28-30 are rotation) vs PID type mask (`0xFF000000`, full byte).

4. **Adopt BaseDialog** — `BaseDialog` existed but was never added to CMakeLists (hence "unused" — it couldn't link). Added it to the build and routed the seven simple property/selector dialogs through it, removing the repeated OK/Cancel boilerplate.

## Testing

- `gecko`, `general_tests`, `qt_tests` build clean; 170 general + 20 qt tests pass.
- Round-trip tests guard the MapObject PID change.
- The seven dialogs have no automated coverage and warrant a manual smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)