### PR TITLE
Unify selection visuals; ghost objects while dragging

### DIFF
--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -222,7 +222,7 @@ void EditorWidget::initializeSelectionSystem() {
                         auto screenPos = geck::indexToScreenPosition(tileIndex, true); // true for roof offset
                         sf::Sprite backgroundSprite(_resources.textures().get("art/tiles/blank.frm"));
                         backgroundSprite.setPosition({ static_cast<float>(screenPos.x), static_cast<float>(screenPos.y) });
-                        backgroundSprite.setColor(sf::Color(Colors::ERROR_R, Colors::ERROR_G, Colors::ERROR_B, 128)); // 50% transparency
+                        backgroundSprite.setColor(sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, 128)); // 50% transparency
                         this->_selectedRoofTileBackgroundSprites.push_back(backgroundSprite);
                     }
                     break;
@@ -231,7 +231,7 @@ void EditorWidget::initializeSelectionSystem() {
                 case selection::SelectionType::FLOOR_TILE: {
                     int tileIndex = item.getTileIndex();
                     if (isValidTileIndex(tileIndex)) {
-                        this->_floorSprites.at(tileIndex).setColor(geck::ColorUtils::createErrorIndicatorColor());
+                        this->_floorSprites.at(tileIndex).setColor(geck::ColorUtils::createFloorTileSelectionColor());
                     }
                     break;
                 }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1183,7 +1183,7 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
     const pattern::PatternVariant& variant = _stampPattern->variants[_stampVariantIndex];
     const pattern::PatternStamper::Plan plan = pattern::PatternStamper::plan(variant, hex);
 
-    const auto ghostAlpha = sf::Color(255, 255, 255, 140);
+    const auto ghostAlpha = sf::Color(255, 255, 255, ui::constants::sfml::DRAG_PREVIEW_ALPHA);
     for (const pattern::PatternStamper::TilePlacement& tp : plan.tiles) {
         if (auto sprite = pattern::buildTileSprite(_resources, tp.tileIndex, tp.isRoof, tp.tileId)) {
             sprite->setColor(ghostAlpha);

--- a/src/ui/dialogs/InventoryViewerDialog.cpp
+++ b/src/ui/dialogs/InventoryViewerDialog.cpp
@@ -13,11 +13,11 @@
 
 namespace geck {
 
+using ui::inventory::COLUMN_AMOUNT;
 using ui::inventory::COLUMN_ICON;
 using ui::inventory::COLUMN_NAME;
-using ui::inventory::COLUMN_TYPE;
-using ui::inventory::COLUMN_AMOUNT;
 using ui::inventory::COLUMN_PID;
+using ui::inventory::COLUMN_TYPE;
 constexpr int COLUMN_COUNT = ui::inventory::COLUMN_PID + 1;
 
 InventoryViewerDialog::InventoryViewerDialog(resource::GameResources& resources, std::shared_ptr<Object> object, QWidget* parent)
@@ -75,7 +75,8 @@ void InventoryViewerDialog::setupUI() {
     resize(ui::constants::dialog_sizes::LARGE_WIDTH, ui::constants::dialog_sizes::LARGE_HEIGHT);
 
     _mainLayout = new QVBoxLayout(this);
-    _mainLayout->setContentsMargins(8, 8, 8, 4);
+    _mainLayout->setContentsMargins(ui::constants::SPACING_NORMAL, ui::constants::SPACING_NORMAL,
+        ui::constants::SPACING_NORMAL, ui::constants::SPACING_TIGHT);
     _mainLayout->setSpacing(ui::constants::SPACING_TIGHT);
 
     _splitter = new QSplitter(Qt::Horizontal);
@@ -168,7 +169,7 @@ void InventoryViewerDialog::setupUI() {
     // === BUTTON PANEL ===
     _buttonPanel = new QWidget();
     _buttonLayout = new QHBoxLayout(_buttonPanel);
-    _buttonLayout->setContentsMargins(0, 4, 0, 0);
+    _buttonLayout->setContentsMargins(0, ui::constants::SPACING_TIGHT, 0, 0);
     _buttonLayout->setSpacing(ui::constants::SPACING_NORMAL);
 
     _addButton = new QPushButton("Add Item...");

--- a/src/ui/dragdrop/DragDropManager.cpp
+++ b/src/ui/dragdrop/DragDropManager.cpp
@@ -56,6 +56,7 @@ bool DragDropManager::startObjectDrag(sf::Vector2f worldPos) {
     const auto& selection = _context.getSelectionManager()->getCurrentSelection();
     _draggedObjects.clear();
     _objectDragStartPositions.clear();
+    _objectDragStartColors.clear();
 
     for (const auto& item : selection.items) {
         if (item.type == selection::SelectionType::OBJECT) {
@@ -63,15 +64,21 @@ bool DragDropManager::startObjectDrag(sf::Vector2f worldPos) {
             if (object) {
                 _draggedObjects.push_back(object);
 
-                // Store original position for potential cancel
-                sf::Vector2f originalPos = object->getSprite().getPosition();
-                _objectDragStartPositions.push_back(originalPos);
+                // Store original position/color so the drag can be cancelled or finished cleanly.
+                _objectDragStartPositions.push_back(object->getSprite().getPosition());
+                _objectDragStartColors.push_back(object->getSprite().getColor());
             }
         }
     }
 
     if (_draggedObjects.empty()) {
         return false;
+    }
+
+    // Show the dragged objects as a translucent ghost (same alpha as the palette drag preview),
+    // so it's clear they sit at a preview position until dropped.
+    for (const auto& object : _draggedObjects) {
+        object->getSprite().setColor(sf::Color(255, 255, 255, ui::constants::sfml::DRAG_PREVIEW_ALPHA));
     }
 
     _isDraggingObjects = true;
@@ -166,9 +173,15 @@ void DragDropManager::finishObjectDrag(sf::Vector2f finalWorldPos) {
         _context.registerObjectMove(_draggedObjects, movedObjects);
     }
 
+    // End the ghost preview: restore each object's pre-drag (selection) tint.
+    for (size_t i = 0; i < _draggedObjects.size(); ++i) {
+        _draggedObjects[i]->getSprite().setColor(_objectDragStartColors[i]);
+    }
+
     _isDraggingObjects = false;
     _draggedObjects.clear();
     _objectDragStartPositions.clear();
+    _objectDragStartColors.clear();
     _objectDragOffset = sf::Vector2f(0, 0);
 
     _context.getCurrentHoverHex() = -1;
@@ -181,14 +194,16 @@ void DragDropManager::cancelObjectDrag() {
         return;
     }
 
-    // Restore original hex positions
+    // Restore original hex positions and the pre-drag (selection) tint.
     for (size_t i = 0; i < _draggedObjects.size(); ++i) {
         _draggedObjects[i]->getSprite().setPosition(_objectDragStartPositions[i]);
+        _draggedObjects[i]->getSprite().setColor(_objectDragStartColors[i]);
     }
 
     _isDraggingObjects = false;
     _draggedObjects.clear();
     _objectDragStartPositions.clear();
+    _objectDragStartColors.clear();
     _objectDragOffset = sf::Vector2f(0, 0);
 
     _context.getCurrentHoverHex() = -1;

--- a/src/ui/dragdrop/DragDropManager.h
+++ b/src/ui/dragdrop/DragDropManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/View.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <functional>
@@ -68,6 +69,7 @@ private:
     bool _isDraggingObjects = false;
     std::vector<std::shared_ptr<Object>> _draggedObjects;
     std::vector<sf::Vector2f> _objectDragStartPositions;
+    std::vector<sf::Color> _objectDragStartColors; // pre-drag tint, restored after the ghost preview
     sf::Vector2f _dragStartWorldPos;
     sf::Vector2f _objectDragOffset;
 

--- a/src/ui/rendering/HexRenderer.cpp
+++ b/src/ui/rendering/HexRenderer.cpp
@@ -28,7 +28,7 @@ HexRenderer::HexRenderer(resource::GameResources& resources)
     _hoverSprite.setColor(sf::Color(Colors::ERROR_R, Colors::ERROR_G, Colors::ERROR_B, Colors::FULLY_OPAQUE));
 
     _selectionSprite.setTextureRect(overlayRect);
-    _selectionSprite.setColor(sf::Color(SelectionColors::HEX_R, SelectionColors::HEX_G, SelectionColors::HEX_B, SelectionColors::HEX_ALPHA));
+    _selectionSprite.setColor(sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, SelectionColors::HEX_ALPHA));
 
     _playerPositionSprite.setTextureRect(overlayRect);
     _playerPositionSprite.setColor(sf::Color(PlayerColors::POSITION_R, PlayerColors::POSITION_G, PlayerColors::POSITION_B, PlayerColors::POSITION_ALPHA));

--- a/src/util/ColorUtils.h
+++ b/src/util/ColorUtils.h
@@ -5,13 +5,29 @@
 
 namespace geck::ColorUtils {
 
-// SFML Color utilities
+// Every selection visual shares the one theme accent (Colors::SELECTION_*) so selecting an
+// object, a floor/roof tile, a hex or the marquee all read the same. The ERROR_* red is
+// reserved for genuine errors/invalid states.
+
 inline sf::Color createSelectionFillColor() {
-    return sf::Color(Colors::SELECTION_RECT_R, Colors::SELECTION_RECT_G, Colors::SELECTION_RECT_B, Colors::SELECTION_RECT_FILL_ALPHA);
+    return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, Colors::SELECTION_RECT_FILL_ALPHA);
 }
 
 inline sf::Color createSelectionOutlineColor() {
-    return sf::Color(Colors::SELECTION_RECT_R, Colors::SELECTION_RECT_G, Colors::SELECTION_RECT_B, Colors::SELECTION_RECT_OUTLINE_ALPHA);
+    return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, Colors::SELECTION_RECT_OUTLINE_ALPHA);
+}
+
+// Tint applied to a selected object's sprite (multiplied, so full alpha).
+inline sf::Color createObjectSelectionColor() {
+    return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B);
+}
+
+inline sf::Color createFloorTileSelectionColor() {
+    return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, Colors::SELECTION_TILE_ALPHA);
+}
+
+inline sf::Color createRoofTileSelectionColor() {
+    return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G, Colors::SELECTION_B, Colors::SELECTION_TILE_ALPHA);
 }
 
 inline sf::Color createPreviewHighlightColor() {
@@ -28,14 +44,6 @@ inline sf::Color createErrorIndicatorColor() {
 
 inline sf::Color createErrorOutlineColor() {
     return sf::Color(Colors::ERROR_R, Colors::ERROR_G, Colors::ERROR_B, Colors::ERROR_OUTLINE_ALPHA);
-}
-
-inline sf::Color createRoofTileSelectionColor() {
-    return sf::Color(Colors::ERROR_R, Colors::ERROR_G, Colors::ERROR_B, Colors::ROOF_SELECTION_ALPHA);
-}
-
-inline sf::Color createObjectSelectionColor() {
-    return sf::Color::Magenta;
 }
 
 } // namespace geck::ColorUtils

--- a/src/util/Constants.h
+++ b/src/util/Constants.h
@@ -48,10 +48,14 @@ constexpr float AREA_SELECTION_Y_TOTAL_PADDING = 36.0f; ///< Total Y padding (to
 
 // Color constants (RGBA values)
 namespace Colors {
-    // Selection rectangle colors
-    constexpr int SELECTION_RECT_R = 100;
-    constexpr int SELECTION_RECT_G = 150;
-    constexpr int SELECTION_RECT_B = 255;
+    // Unified selection accent — the theme PRIMARY (#4A90E2). Every selection visual (objects,
+    // floor/roof tiles, hexes, the marquee) uses this one accent; the ERROR_* red below is
+    // reserved strictly for errors/invalid states.
+    constexpr int SELECTION_R = 74;
+    constexpr int SELECTION_G = 144;
+    constexpr int SELECTION_B = 226;
+
+    // Selection rectangle (marquee) alphas (RGB comes from the accent above).
     constexpr int SELECTION_RECT_FILL_ALPHA = 50;
     constexpr int SELECTION_RECT_OUTLINE_ALPHA = 200;
 
@@ -69,8 +73,8 @@ namespace Colors {
     constexpr int ERROR_ALPHA = 150;
     constexpr int ERROR_OUTLINE_ALPHA = 255;
 
-    // Roof tile selection colors (higher visibility)
-    constexpr int ROOF_SELECTION_ALPHA = 220;
+    // Tile selection overlay alpha (floor + roof) — higher visibility.
+    constexpr int SELECTION_TILE_ALPHA = 220;
 
     // Standard alpha values
     constexpr int FULLY_OPAQUE = 255;
@@ -186,9 +190,7 @@ namespace PlayerColors {
 }
 
 namespace SelectionColors {
-    constexpr int HEX_R = 100;     ///< Hex selection red
-    constexpr int HEX_G = 150;     ///< Hex selection green
-    constexpr int HEX_B = 255;     ///< Hex selection blue
+    // Hex selection uses the shared Colors::SELECTION_* accent; only the alpha is hex-specific.
     constexpr int HEX_ALPHA = 200; ///< Hex selection alpha
 
     constexpr int SCROLL_BLOCKER_R = 100;             ///< Scroll blocker rectangle red

--- a/src/util/TileUtils.h
+++ b/src/util/TileUtils.h
@@ -246,15 +246,15 @@ namespace TileColors {
         return sf::Color(Colors::ERROR_R, Colors::ERROR_G, Colors::ERROR_B, Colors::ERROR_OUTLINE_ALPHA);
     }
 
-    // Selection rectangle colors
+    // Selection rectangle colors (shared selection accent)
     inline sf::Color selectionFill() {
-        return sf::Color(Colors::SELECTION_RECT_R, Colors::SELECTION_RECT_G,
-            Colors::SELECTION_RECT_B, Colors::SELECTION_RECT_FILL_ALPHA);
+        return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G,
+            Colors::SELECTION_B, Colors::SELECTION_RECT_FILL_ALPHA);
     }
 
     inline sf::Color selectionOutline() {
-        return sf::Color(Colors::SELECTION_RECT_R, Colors::SELECTION_RECT_G,
-            Colors::SELECTION_RECT_B, Colors::SELECTION_RECT_OUTLINE_ALPHA);
+        return sf::Color(Colors::SELECTION_R, Colors::SELECTION_G,
+            Colors::SELECTION_B, Colors::SELECTION_RECT_OUTLINE_ALPHA);
     }
 
     // Standard colors

--- a/tests/general/test_tile_utils.cpp
+++ b/tests/general/test_tile_utils.cpp
@@ -223,15 +223,15 @@ TEST_CASE("Color utilities", "[tile_utils]") {
 
     SECTION("Selection colors") {
         auto selection_fill = TileColors::selectionFill();
-        REQUIRE(selection_fill.r == Colors::SELECTION_RECT_R);
-        REQUIRE(selection_fill.g == Colors::SELECTION_RECT_G);
-        REQUIRE(selection_fill.b == Colors::SELECTION_RECT_B);
+        REQUIRE(selection_fill.r == Colors::SELECTION_R);
+        REQUIRE(selection_fill.g == Colors::SELECTION_G);
+        REQUIRE(selection_fill.b == Colors::SELECTION_B);
         REQUIRE(selection_fill.a == Colors::SELECTION_RECT_FILL_ALPHA);
 
         auto selection_outline = TileColors::selectionOutline();
-        REQUIRE(selection_outline.r == Colors::SELECTION_RECT_R);
-        REQUIRE(selection_outline.g == Colors::SELECTION_RECT_G);
-        REQUIRE(selection_outline.b == Colors::SELECTION_RECT_B);
+        REQUIRE(selection_outline.r == Colors::SELECTION_R);
+        REQUIRE(selection_outline.g == Colors::SELECTION_G);
+        REQUIRE(selection_outline.b == Colors::SELECTION_B);
         REQUIRE(selection_outline.a == Colors::SELECTION_RECT_OUTLINE_ALPHA);
     }
 


### PR DESCRIPTION
## Why

UI polish pass on selection/drag consistency (the inconsistencies flagged in review).

**Selection color** was all over the place:
| Selected | Was | Now |
|---|---|---|
| Object | Magenta | theme accent |
| Floor tile | **ERROR red** | theme accent |
| Roof tile | **ERROR red** | theme accent |
| Hex / marquee | blue (≈ accent) | theme accent (#4A90E2) |

Everything now routes through one `Colors::SELECTION_*` accent (the theme PRIMARY), and the ERROR red is reserved strictly for errors/invalid states. Floor tiles get a real `createFloorTileSelectionColor()` instead of reusing the error indicator.

**Dragging:** moving an existing selected object kept its solid selection tint, while palette placement showed a translucent ghost — inconsistent. Now both ghost: a dragged object goes translucent (same alpha as the palette preview) during the drag and restores its selection tint on drop/cancel.

## Changes
- `Constants.h` / `ColorUtils.h` / `TileUtils.h`: single selection accent; `createFloorTileSelectionColor`; removed the dead `SELECTION_RECT_R/G/B` + `SelectionColors::HEX_R/G/B` RGB constants.
- `HexRenderer`, `EditorWidget` (floor tile + roof background sprite): use the accent.
- `DragDropManager`: store pre-drag colors, ghost on start, restore on finish/cancel.
- Test colors updated.

## Verification
Local build green; `general_tests` + `qt_tests` pass. Visual behaviour is best confirmed in-editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)