### PR TITLE
README: correct Qt6 SVG dev package name (qt6-svg-dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ found, and otherwise downloaded and built automatically by CMake. Qt6 must be in
 ```bash
 # Build tools and dependencies (Ubuntu/Debian)
 sudo apt install cmake g++ git \
-                 qt6-base-dev qt6-base-dev-tools libqt6svg6-dev \
+                 qt6-base-dev qt6-base-dev-tools qt6-svg-dev \
                  libspdlog-dev zlib1g-dev
 
 # Enter the cloned git repo folder


### PR DESCRIPTION
Follow-up to #51. The Linux build instructions still listed `libqt6svg6-dev`, which does not exist on Debian or Ubuntu. The correct package on both is `qt6-svg-dev` (verified on Debian Trixie 6.8.2 and Ubuntu noble 6.4.2).

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)