### PR TITLE
Fix crash when creating a New Map

### DIFF
--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1082,12 +1082,18 @@ void EditorWidget::setActiveSelectionLayers(SelectionLayers layers) {
     if (_inputHandler) {
         _inputHandler->setSelectionMode(_currentSelectionMode);
     }
+    if (!_selectionManager) {
+        return; // created lazily with the map; a menu sync can run first (first New Map)
+    }
     _selectionManager->setActiveLayers(layers);
     spdlog::info("Selection layers set to: floor={} roof={} objects={}",
         layers.floorTiles, layers.roofTiles, layers.objects);
 }
 
 SelectionLayers EditorWidget::getActiveSelectionLayers() const {
+    if (!_selectionManager) {
+        return {}; // all layers on by default until the selection system is created
+    }
     return _selectionManager->activeLayers();
 }
 


### PR DESCRIPTION
## Problem

Clicking **New Map** from the toolbar (with no map currently open) crashes with a segfault.

```
SelectionManager::setActiveLayers (SelectionManager.h:95)   <- null deref
EditorWidget::setActiveSelectionLayers (EditorWidget.cpp)
MainWindow::applySelectionLayersFromMenu
MainWindow::syncMenuStateToEditorWidget
MainWindow::setEditorWidget
newMapRequested
```

## Root cause

The selection system is created lazily *with the map* (`initializeSelectionSystem()` runs in the `EditorWidget` constructor only when a map is present, and otherwise in `createNewMap()`). The first New Map bootstraps an `EditorWidget` with a **null map** and then calls `setEditorWidget()`, which runs `syncMenuStateToEditorWidget()` → `applySelectionLayersFromMenu()` → `setActiveSelectionLayers()` **before** `createNewMap()` has created the `SelectionManager`. Those two layer accessors were the only ones in the class that dereferenced `_selectionManager` without a null check.

This is a regression introduced with the combinable selection-layers feature.

## Fix

Guard `_selectionManager` in `setActiveSelectionLayers()` and `getActiveSelectionLayers()`, matching the null checks used everywhere else in the class. `createNewMap()` then creates the manager immediately afterwards with the default all-layers state, so behaviour is unchanged for the user.

## Testing

A headless regression test isn't feasible: constructing an `EditorWidget` requires game-data resources (`art/misc/HEX.frm`), which the qt_tests suite intentionally runs without — so it never constructs a real editor. Verified manually that New Map no longer crashes and the build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)