### PR TITLE
fix: macOS build — use std::thread, not std::jthread, in resource concurrency test

### DIFF
--- a/tests/general/test_resource_repository.cpp
+++ b/tests/general/test_resource_repository.cpp
@@ -118,10 +118,11 @@ TEST_CASE("ResourceRepository load is thread-safe and deduplicates under content
     std::atomic sawMismatch{ false }; // load() and a same-key find() disagreed
 
     // Note: Catch2 assertion macros are not thread-safe, so workers only set
-    // atomics; all assertions run on the main thread once the jthreads join at
-    // the end of this scope.
+    // atomics; all assertions run on the main thread once the threads join at
+    // the end of this scope. (std::thread + explicit join, not std::jthread, for
+    // macOS/AppleClang libc++ compatibility.)
     {
-        std::vector<std::jthread> threads;
+        std::vector<std::thread> threads;
         threads.reserve(kThreads);
         for (int t = 0; t < kThreads; ++t) {
             threads.emplace_back([&repo, &keys, &sawNull, &sawMismatch, t] {
@@ -137,6 +138,9 @@ TEST_CASE("ResourceRepository load is thread-safe and deduplicates under content
                     }
                 }
             });
+        }
+        for (auto& thread : threads) {
+            thread.join();
         }
     }
 


### PR DESCRIPTION
The macOS pipeline failed building `tests/general/test_resource_repository.cpp`:

```
error: no member named 'jthread' in namespace 'std'
  124 |         std::vector<std::jthread> threads;
```

`std::jthread` is absent from the macOS CI toolchain's libc++. The concurrency stress test added in the architecture-cleanup work (PR #66) used it; the macOS job was *skipped* during that PR, so it slipped through and only failed once it ran on master.

## Fix
Switch the test to `std::thread` with an explicit join loop — identical behaviour (all 16 workers join before the main-thread Catch2 assertions), just portable. This matches the existing `std::thread` pattern already used in `test_dat_concurrency.cpp` for the same reason.

Verified locally: `general_tests` builds and the `[resource]` cases pass (11 cases, 64 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)