### PR TITLE
feat(mcp): map-intelligence — describe_map digest + semantic render overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,27 @@ if(GECK_BUILD_TESTS AND TARGET Catch2::Catch2WithMain)
     enable_testing()
 endif()
 
+# Windows: one target stages the runtime DLLs into the shared output dir. Each executable used to
+# copy its own $<TARGET_RUNTIME_DLLS> in a POST_BUILD step, and those steps raced on the Qt/SFML
+# DLLs they share (intermittent, then persistent, "Error copying ...sfml-window-3.dll" on the
+# Windows build). Copying the *union* of every executable's runtime DLLs from a single target makes
+# it one sequential operation — no race. copy_if_different tolerates the DLLs shared across targets.
+if(WIN32)
+    set(_runtime_dll_targets ${PROJECT_NAME})
+    if(GECK_BUILD_TESTS AND TARGET general_tests)
+        list(APPEND _runtime_dll_targets general_tests performance_tests qt_tests)
+    endif()
+    set(_runtime_dll_genexprs "")
+    foreach(_t IN LISTS _runtime_dll_targets)
+        list(APPEND _runtime_dll_genexprs "$<TARGET_RUNTIME_DLLS:${_t}>")
+    endforeach()
+    add_custom_target(copy_runtime_dlls ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_runtime_dll_genexprs} $<TARGET_FILE_DIR:${PROJECT_NAME}>
+        COMMAND_EXPAND_LISTS
+        DEPENDS ${_runtime_dll_targets}
+        COMMENT "Staging runtime DLLs into the build tree")
+endif()
+
 ##################################################
 # Configuration summary
 ##################################################

--- a/PLAN.md
+++ b/PLAN.md
@@ -737,9 +737,13 @@ from. Keep all new readers Qt-free (vault/cli) so the server stays headless.
    (reached via stairs/elevators) report `reachableHexes: null` + a note. Optimistic on doors, so it
    under-reports rather than crying wolf. Verified: artemple/denbus1/newr1 clean (0 orphans),
    vctydwtn flags a real isolated servant/slave cluster.
-5. **Semantic render overlay** (extends the schematic): colour critters by team, mark exits,
-   highlight scripted objects, shade unreachable regions, so the agent can *see* purpose and tie it
-   to the JSON via the legend. **Phase 3.**
+5. **Semantic render overlay** (extends the schematic). **Object roles done:** a `Semantic` render
+   style (`render_map semantic:true` / CLI `--semantic`) greys the floor and colours object markers
+   by role — exit grids highlighted, critters by team (`group_id`), scripted objects (`map_scripts_pid`)
+   ringed — with a role-keyed legend that joins back to `describe_map`. **Still open:** *shading the
+   unreachable regions* `reachability`/`describe_map` identify, which needs a per-hex reachable mask
+   exposed from `MapReachability` and a hex→world tint in the renderer (the object-marker path here is
+   sprite-bounds-based and doesn't map arbitrary hexes). **Phase 3.**
 
 **Corpus angle (multiplier):** index `analyze` + these semantic facts across all shipped maps so
 the agent can query *examples* ("how do shipped towns place and wire shopkeepers?") — improving

--- a/PLAN.md
+++ b/PLAN.md
@@ -674,9 +674,12 @@ The direction instead:
 
 # Map semantics & intelligence (analysis MCP roadmap)
 
-> Status: scoping; **Phase 1 done** (ai.txt reader; `analyze` now reports per-map `critters` with
-> team + ai.txt-resolved AI, a `header` digest with player spawn / enabled elevations / darkness /
-> map script / named map variables, and an `exits` connectivity graph). Today the MCP *perceives
+> Status: **Phases 1–2 done + the `describe_map` orchestrator (capability 1) shipped.** Phase 1:
+> ai.txt reader; `analyze` reports per-map `critters` (team + ai.txt-resolved AI), a `header` digest
+> (player spawn / enabled elevations / darkness / map script / named map variables) and an `exits`
+> connectivity graph. Phase 2: `describe_script` (.ssl source + dialog) and `reachability`.
+> `describe_map` now composes analyze + reachability into one cross-referenced digest (capability 1
+> below). Remaining: the Phase-3 semantic render overlay (capability 5). Today the MCP *perceives
 > geometry* — tiles, objects,
 > clusters, palette, render, extract/generate. It cannot read the map's **semantic** layer: AI
 > packet is a raw number (no `ai.txt` reader), scripts are referenced by `scripts.lst` index/name
@@ -694,10 +697,15 @@ from. Keep all new readers Qt-free (vault/cli) so the server stays headless.
 
 **Capabilities (each notes the reader it needs):**
 
-1. **`describe_map` — purpose synthesis (orchestrator).** One structured digest: dimensions /
-   elevations, dominant biome (floor), structures (clusters), critter roster by team/role, exits +
-   reachable regions, attached scripts + hooks, darkness, map vars. Composes the tools below;
-   returns evidence, the model writes the conclusion.
+1. **`describe_map` — purpose synthesis (orchestrator). ✅ Done.** One structured digest per map:
+   the `analyze` per-map report (header — enabled elevations / darkness / player start / map script /
+   map vars; floor/biome; object `clusters` = structures; `critters` roster with ai.txt-resolved AI
+   and each one's attached `{programIndex, name}`; `exits` graph) **plus** a `reachability` field
+   (per-elevation walkable/reachable hexes + entry-orphaned objects). Composes `analyzeMaps` +
+   `analyzeReachability` (`cli::describeMap`, MCP `describe_map`, CLI `map describe-map`); returns the
+   engine's own evidence with join keys preserved (pid, script_id, ai_packet) — the model writes the
+   conclusion, no baked-in heuristics. Verified: artemple clean (0 orphans), vctydwtn surfaces the 9
+   orphaned servant/slave objects inline with the roster.
 2. **Critters + AI — `critters` tool + new `ai.txt` reader.** Per critter: name (`pro_critters.msg`),
    hex, **team (`group_id`)**, **AI packet resolved via `ai.txt`** (aggression, disposition,
    `run_away_mode`, `area_attack_mode`, `best_weapon`, `distance`, `secondary_freq`), equipped

--- a/PLAN.md
+++ b/PLAN.md
@@ -980,6 +980,27 @@ and probably not worth chasing for a map editor.
 > now half-done — the MCP server is largely a JSON-RPC shim over `gecko_cli`'s existing entry points
 > plus the read/describe tools.
 
+## MCP server hardening — done, and one deferred follow-up
+
+**Done** (a code-review pass): a **table-driven tool registry** (one `ToolSpec` list — name,
+description, schema, handler — that both `tools/call` dispatch and `tools/list` derive from, so they
+can't drift); **argument validation** (typed `requireString`/`requireInt(min,max)`/bounded
+`optInt`/strict `optBool`, surfaced as `isError` — no more negative-pid-wraps-to-huge-uint or
+negative-`maxDimension`); and **protocol edge cases** (a `ping` handler, no-id request methods no
+longer execute as notifications, `jsonrpc:"2.0"` validated → `-32600`).
+
+**Deferred — richer tool output/metadata (MCP 2025-06).** Worth doing some day, not now:
+- **`structuredContent`** on the JSON-emitting tools (analyze/describe_map/palette/proto_info/…) —
+  return the parsed object alongside the text block, so clients get typed data instead of re-parsing
+  a string.
+- **Tool annotations** — `readOnlyHint` (everything except generate/render/extract is read-only),
+  `destructiveHint`, `openWorldHint:false` (all data is local). Cheap to add to each `ToolSpec` now
+  that the registry carries per-tool metadata.
+- **`render_map` as an image/resource** — return an embedded image or a resource link rather than the
+  written path (more idiomatic; the path works fine for a local agent).
+- *(Not planned: per-call cancellation / progress notifications — the stdio loop is deliberately
+  synchronous and tool calls are short, so the threading cost isn't justified.)*
+
 ## Why it's cheap here
 
 The four-library split already makes the model, formats, and resources **Qt-free and

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -590,14 +590,9 @@ target_include_directories(gecko_app PUBLIC
 
 target_link_libraries(${PROJECT_NAME} PRIVATE gecko_app)
 
-# copy shared external libraries to the build directory for Windows builds
-if(WIN32)
-    add_custom_command(
-        TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
+# Windows runtime DLLs are staged by the single copy_runtime_dlls target (top-level CMakeLists),
+# which copies the union of every executable's runtime DLLs once. Doing it per-target here raced
+# with the test executables' identical copies into the shared output dir.
 
 # Copy resources to appropriate location based on platform. The example generation scripts ship
 # under resources/scripts so the running app can find them next to the rest of the resources.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -560,7 +560,9 @@ if(GECK_BUILD_CLI)
         cli/ScriptIntrospect.h
         cli/ScriptIntrospect.cpp
         cli/MapReachability.h
-        cli/MapReachability.cpp)
+        cli/MapReachability.cpp
+        cli/MapDescribe.h
+        cli/MapDescribe.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -32,6 +32,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -738,9 +739,13 @@ namespace {
             }
             if (line[begin] == '[') {
                 current = -1;
-                int idx = 0;
-                if (std::sscanf(line.c_str() + begin, "[Map %d]", &idx) == 1) { // "[Map NNN]"
-                    current = idx;
+                static constexpr std::string_view kMapPrefix = "[Map "; // sections are "[Map NNN]"
+                if (line.compare(begin, kMapPrefix.size(), kMapPrefix) == 0) {
+                    try {
+                        current = std::stoi(line.substr(begin + kMapPrefix.size())); // stops at the ']'
+                    } catch (const std::exception&) {
+                        current = -1;
+                    }
                 }
             } else if (current >= 0) {
                 const auto eq = line.find('=');

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -647,7 +647,25 @@ namespace {
     // Per-map header digest: player spawn, which elevations are enabled, darkness, the map script id,
     // the local-var pool size, and the map variables (MVARS) — each with its name from the .gam (the
     // .map stores only the value) so an agent reads the map's tracked state, not just a count.
-    ordered_json headerToJson(Map& map, const Gam* gam, const Lst* scriptsLst) {
+    // A script's human-readable name from scrname.msg. The display name for the script at 0-based
+    // scripts.lst programIndex is scrname.msg[programIndex + 101] — verified against the data and the
+    // engine's 1-based map script_id (the MAP_File_Format wiki's "[id + 101]" assumes id is already
+    // 0-based; with the raw 1-based header id it lands one entry too far). "" if unavailable.
+    std::string scriptDisplayName(resource::GameResources& resources, int programIndex) {
+        if (programIndex < 0) {
+            return {};
+        }
+        try {
+            if (Msg* msg = resources.repository().load<Msg>("text/english/game/scrname.msg"); msg != nullptr) {
+                return msg->message(programIndex + 101).text;
+            }
+        } catch (const std::exception& e) {
+            spdlog::debug("scriptDisplayName: scrname.msg unavailable: {}", e.what());
+        }
+        return {};
+    }
+
+    ordered_json headerToJson(Map& map, const Gam* gam, const Lst* scriptsLst, resource::GameResources& resources) {
         const auto& header = map.getMapFile().header;
         ordered_json root;
         root["version"] = header.version;
@@ -672,7 +690,8 @@ namespace {
             if (scriptsLst != nullptr && programIndex < static_cast<int>(scriptsLst->list().size())) {
                 name = scriptsLst->at(programIndex);
             }
-            root["mapScript"] = { { "programIndex", programIndex }, { "name", name } };
+            root["mapScript"] = { { "programIndex", programIndex }, { "name", name },
+                { "displayName", scriptDisplayName(resources, programIndex) } };
         } else {
             root["mapScript"] = nullptr;
         }
@@ -774,7 +793,7 @@ namespace {
         entry["adjacency"] = adjacencyToJson(usage, names, agg);
         entry["clusters"] = clustersToJson(collectClusters(map), names);
         entry["critters"] = crittersToJson(map, names, ai, scriptsLst);
-        entry["header"] = headerToJson(map, loadMapGam(resources, mapPath), scriptsLst);
+        entry["header"] = headerToJson(map, loadMapGam(resources, mapPath), scriptsLst, resources);
         entry["exits"] = exitsToJson(map, mapNames);
         return entry;
     }

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -682,15 +682,63 @@ namespace {
     // Per-map exit graph: [{hex,elevation,destMap,destHex,destElevation,orientation}] from the
     // exit-grid markers. destMap/destHex are signed (-1 = town map / unused, -2 = worldmap, else a
     // map id) — the map's connectivity, so an agent sees where each edge leads.
-    ordered_json exitsToJson(Map& map) {
+    // data/maps.txt is the engine's index -> map list: `[Map NNN]` sections each with a `map_name`
+    // (the .map filename, lowercased by the engine). An exit grid's destination map is that index,
+    // so this lets us name "destMap 3" as the actual map file. Returns {} if maps.txt isn't mounted.
+    std::map<int, std::string> loadMapNames(resource::GameResources& resources) {
+        std::map<int, std::string> names;
+        auto bytes = resources.files().readRawBytes("data/maps.txt");
+        if (!bytes) {
+            bytes = resources.files().readRawBytes("maps.txt");
+        }
+        if (!bytes) {
+            return names;
+        }
+        const std::string text(bytes->begin(), bytes->end());
+        std::istringstream stream(text);
+        std::string line;
+        int current = -1;
+        while (std::getline(stream, line)) {
+            const auto begin = line.find_first_not_of(" \t\r");
+            if (begin == std::string::npos) {
+                continue;
+            }
+            if (line[begin] == '[') {
+                current = -1;
+                int idx = 0;
+                if (std::sscanf(line.c_str() + begin, "[Map %d]", &idx) == 1) { // "[Map NNN]"
+                    current = idx;
+                }
+            } else if (current >= 0) {
+                const auto eq = line.find('=');
+                if (eq != std::string::npos && line.compare(begin, 8, "map_name") == 0) {
+                    std::string value = line.substr(eq + 1);
+                    const auto v0 = value.find_first_not_of(" \t");
+                    const auto v1 = value.find_last_not_of(" \t\r");
+                    if (v0 != std::string::npos) {
+                        value = value.substr(v0, v1 - v0 + 1);
+                        std::ranges::transform(value, value.begin(),
+                            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                        names[current] = value;
+                    }
+                }
+            }
+        }
+        return names;
+    }
+
+    ordered_json exitsToJson(Map& map, const std::map<int, std::string>& mapNames) {
         auto array = ordered_json::array();
         for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
             for (const auto& object : mapObjects) {
                 if (!object || !object->isExitGridMarker()) {
                     continue;
                 }
+                const auto destMap = static_cast<int32_t>(object->exit_map);
+                const auto it = mapNames.find(destMap);
                 array.push_back({ { "hex", object->position }, { "elevation", elevation },
-                    { "destMap", static_cast<int32_t>(object->exit_map) },
+                    { "destMap", destMap },
+                    { "destMapName", it != mapNames.end() ? ordered_json(it->second) : ordered_json(nullptr) },
                     { "destHex", static_cast<int32_t>(object->exit_position) },
                     { "destElevation", object->exit_elevation }, { "orientation", object->exit_orientation } });
             }
@@ -701,7 +749,8 @@ namespace {
     // One map's full report object, folding its floor/object/adjacency usage into `agg` as a side
     // effect (so the aggregate built afterwards has every map's totals).
     ordered_json mapToJson(const std::string& mapPath, Map& map, resource::GameResources& resources,
-        NameResolver& names, const AiTxt& ai, const Lst* scriptsLst, Aggregate& agg) {
+        NameResolver& names, const AiTxt& ai, const Lst* scriptsLst, Aggregate& agg,
+        const std::map<int, std::string>& mapNames) {
         const MapUsage usage = collectUsage(map);
         ordered_json entry;
         entry["name"] = baseName(mapPath);
@@ -712,7 +761,7 @@ namespace {
         entry["clusters"] = clustersToJson(collectClusters(map), names);
         entry["critters"] = crittersToJson(map, names, ai, scriptsLst);
         entry["header"] = headerToJson(map, loadMapGam(resources, mapPath));
-        entry["exits"] = exitsToJson(map);
+        entry["exits"] = exitsToJson(map, mapNames);
         return entry;
     }
 
@@ -724,14 +773,15 @@ namespace {
     void emitJson(const std::vector<std::string>& mapPaths, resource::GameResources& resources,
         NameResolver& names, const AiTxt& ai, std::ostream& out) {
         Aggregate agg;
-        const Lst* scriptsLst = loadScriptsLst(resources); // shared across maps (cached); names attached scripts
+        const Lst* scriptsLst = loadScriptsLst(resources);                   // shared across maps (cached); names attached scripts
+        const std::map<int, std::string> mapNames = loadMapNames(resources); // index -> .map filename (once)
         auto maps = ordered_json::array();
         for (const auto& mapPath : mapPaths) {
             const std::unique_ptr<Map> map = loadMap(resources, mapPath);
             if (!map) {
                 continue; // skipped maps simply don't appear; agg.analysed counts what did
             }
-            maps.push_back(mapToJson(mapPath, *map, resources, names, ai, scriptsLst, agg));
+            maps.push_back(mapToJson(mapPath, *map, resources, names, ai, scriptsLst, agg, mapNames));
             ++agg.analysed;
         }
 

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -647,7 +647,7 @@ namespace {
     // Per-map header digest: player spawn, which elevations are enabled, darkness, the map script id,
     // the local-var pool size, and the map variables (MVARS) — each with its name from the .gam (the
     // .map stores only the value) so an agent reads the map's tracked state, not just a count.
-    ordered_json headerToJson(Map& map, const Gam* gam) {
+    ordered_json headerToJson(Map& map, const Gam* gam, const Lst* scriptsLst) {
         const auto& header = map.getMapFile().header;
         ordered_json root;
         root["version"] = header.version;
@@ -661,7 +661,21 @@ namespace {
         }
         root["elevations"] = std::move(elevations);
         root["darkness"] = header.darkness;
+        // The header's script_id is **1-based**: the engine runs the map's SYSTEM script from
+        // scripts.lst[script_id - 1] (fallout2-ce map.cc: `script->index = scriptIndex - 1`, only
+        // when scriptIndex > 0). Resolve to that 0-based programIndex + name so describe_script can be
+        // fed it directly; null when the map has no script (script_id <= 0).
         root["scriptId"] = header.script_id;
+        if (header.script_id > 0) {
+            const int programIndex = header.script_id - 1;
+            std::string name;
+            if (scriptsLst != nullptr && programIndex < static_cast<int>(scriptsLst->list().size())) {
+                name = scriptsLst->at(programIndex);
+            }
+            root["mapScript"] = { { "programIndex", programIndex }, { "name", name } };
+        } else {
+            root["mapScript"] = nullptr;
+        }
         root["localVarCount"] = header.num_local_vars;
         auto mapVarsJson = ordered_json::array();
         const auto& mapVars = map.getMapFile().map_global_vars;
@@ -760,7 +774,7 @@ namespace {
         entry["adjacency"] = adjacencyToJson(usage, names, agg);
         entry["clusters"] = clustersToJson(collectClusters(map), names);
         entry["critters"] = crittersToJson(map, names, ai, scriptsLst);
-        entry["header"] = headerToJson(map, loadMapGam(resources, mapPath));
+        entry["header"] = headerToJson(map, loadMapGam(resources, mapPath), scriptsLst);
         entry["exits"] = exitsToJson(map, mapNames);
         return entry;
     }

--- a/src/cli/MapDescribe.cpp
+++ b/src/cli/MapDescribe.cpp
@@ -1,0 +1,68 @@
+#include "cli/MapDescribe.h"
+
+#include <sstream>
+
+#include <nlohmann/json.hpp>
+
+#include "cli/MapAnalyzer.h"
+#include "cli/MapReachability.h"
+
+namespace geck::cli {
+
+using ordered_json = nlohmann::ordered_json;
+
+int describeMap(resource::GameResources& resources, const DescribeMapOptions& options, std::ostream& out) {
+    if (options.mapPath.empty()) {
+        out << "describe_map requires a map path.\n";
+        return 2;
+    }
+
+    // The per-map analyze digest is the backbone: header (elevations / darkness / player start /
+    // map script / map vars), floor usage (biome), object clusters (structures), the critter roster
+    // with ai.txt-resolved AI + attached {programIndex, name}, and the exits graph. We run the
+    // machine-readable analyze for just this map and lift its single entry.
+    AnalyzeOptions analyzeOpts;
+    analyzeOpts.json = true;
+    analyzeOpts.maps = { options.mapPath };
+    std::ostringstream analyzeOut;
+    if (analyzeMaps(resources, analyzeOpts, analyzeOut) != 0) {
+        out << "describe_map: could not analyse " << options.mapPath
+            << " (is it a map under the mounted data?)\n";
+        return 1;
+    }
+    const ordered_json analyzeRoot = ordered_json::parse(analyzeOut.str());
+    const auto mapsIt = analyzeRoot.find("maps");
+    if (mapsIt == analyzeRoot.end() || !mapsIt->is_array() || mapsIt->empty()) {
+        out << "describe_map: no map data for " << options.mapPath << "\n";
+        return 1;
+    }
+    ordered_json digest = mapsIt->front();
+
+    // Cross-reference with reachability: which regions the player can actually walk, and which
+    // critters/items are cut off from every entry point. Best-effort — a map with no walkable
+    // entry on an elevation still produces a useful digest, so a reachability failure only nulls
+    // the field rather than failing the call.
+    ReachabilityOptions reachOpts;
+    reachOpts.mapPath = options.mapPath;
+    std::ostringstream reachOut;
+    try {
+        if (analyzeReachability(resources, reachOpts, reachOut) == 0) {
+            ordered_json reach = ordered_json::parse(reachOut.str());
+            // analyzeReachability emits { map, path, reachability: [...per elevation] }; lift the
+            // per-elevation array — name/path are already on the digest.
+            const auto it = reach.find("reachability");
+            digest["reachability"] = (it != reach.end()) ? *it : reach;
+        } else {
+            digest["reachability"] = nullptr;
+        }
+    } catch (const std::exception&) {
+        digest["reachability"] = nullptr;
+    }
+
+    // Fallout 2 text (proto/tile/critter names, AI labels) is CP-1252; `replace` keeps dump() from
+    // throwing on stray non-UTF-8 bytes (mirrors analyze/reachability).
+    out << digest.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/MapDescribe.h
+++ b/src/cli/MapDescribe.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <ostream>
+#include <string>
+
+namespace geck {
+
+namespace resource {
+    class GameResources;
+}
+
+namespace cli {
+
+    struct DescribeMapOptions {
+        std::string mapPath; // VFS path, e.g. "maps/artemple.map"
+    };
+
+    /// One structured digest for a single map, composed from the existing semantic tools: the
+    /// analyze per-map report (header digest, floor/biome, object clusters, critter roster with
+    /// ai.txt-resolved AI and attached scripts, exits graph) **plus** a `reachability` field
+    /// (per-elevation walkable/reachable hexes and any entry-orphaned objects).
+    ///
+    /// It gathers the engine's own semantic evidence in one call — cross-referencing keys are
+    /// preserved (pid, script_id, ai_packet) — so an agent can infer the map's *purpose* from the
+    /// same data a designer reads, rather than the tool baking in classification heuristics.
+    ///
+    /// Emits a JSON object to `out`; returns 0 on success, nonzero on a hard error (e.g. the map
+    /// fails to load). Reachability is best-effort: if it can't be computed the digest still emits
+    /// with `reachability: null`.
+    int describeMap(resource::GameResources& resources, const DescribeMapOptions& options, std::ostream& out);
+
+} // namespace cli
+} // namespace geck

--- a/src/cli/MapRender.cpp
+++ b/src/cli/MapRender.cpp
@@ -46,10 +46,12 @@ int renderMap(resource::GameResources& resources, const RenderOptions& options, 
     renderOptions.showRoof = options.showRoof;
     renderOptions.showObjects = options.showObjects;
     renderOptions.showBlockers = options.showBlockers;
-    renderOptions.style = options.objects ? MapRenderer::Style::Objects
-                                          : (options.schematic ? MapRenderer::Style::Schematic : MapRenderer::Style::Natural);
+    renderOptions.style = options.semantic ? MapRenderer::Style::Semantic
+        : options.objects                  ? MapRenderer::Style::Objects
+        : options.schematic                ? MapRenderer::Style::Schematic
+                                           : MapRenderer::Style::Natural;
 
-    const bool wantLegend = options.schematic || options.objects;
+    const bool wantLegend = options.schematic || options.objects || options.semantic;
     try {
         MapRenderer renderer(resources);
         MapRenderer::Legend legend;

--- a/src/cli/MapRender.h
+++ b/src/cli/MapRender.h
@@ -24,6 +24,9 @@ namespace cli {
         bool schematic = false;
         /// Objects style: muted-grey floor + category-coloured object markers, for verifying scatter.
         bool objects = false;
+        /// Semantic style: grey floor + markers coloured by role (exit grids highlighted, critters by
+        /// team, scripted objects ringed) — the map's purpose layer, paired with describe_map.
+        bool semantic = false;
         /// Schematic/objects only: also mark FLAT objects (invisible engine blockers); off by default.
         bool showBlockers = false;
     };

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -48,13 +48,14 @@ void printUsage(const char* program) {
               << "      --arg passes parameters to the script (read as args.key); --stamp pre-loads a\n"
               << "      pattern stamp the script places with api:placeStamp(name, anchorHex, variant).\n"
               << "  " << program << " map render --map <file.map> --out <file.png>\n"
-              << "      [--elevation 0|1|2] [--max-dim N] [--roof] [--schematic|--objects]\n"
+              << "      [--elevation 0|1|2] [--max-dim N] [--roof] [--schematic|--objects|--semantic]\n"
               << "      [--show-blockers] --data <dir-or-.dat> [...]\n"
               << "      Renders a map to a PNG (needs an off-screen GL context). --max-dim caps the\n"
               << "      longest side (default 1600); --roof draws the roof layer over the floor.\n"
               << "      --schematic flat-colours floor tiles by id + marks objects by category (with a\n"
               << "      colour legend); --objects mutes the floor to grey so the object markers pop\n"
-              << "      (for checking scatter); --show-blockers also marks FLAT objects.\n"
+              << "      (for checking scatter); --semantic greys the floor and colours markers by role\n"
+              << "      (exit grids, critters by team, scripted ringed); --show-blockers also marks FLAT.\n"
               << "  " << program << " map extract-pattern --map <file.map> --out <file.json> --name <name>\n"
               << "      [--pids id,id,...] [--anchor <hex>] [--radius N] [--elevation 0|1|2]\n"
               << "      [--include-floor] [--include-roof] --data <dir-or-.dat> [--data <...>]\n"
@@ -201,6 +202,10 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
     }
     if (out.render && arg == "--objects") {
         out.ren.objects = true;
+        return 1;
+    }
+    if (out.render && arg == "--semantic") {
+        out.ren.semantic = true;
         return 1;
     }
     if (out.render && arg == "--show-blockers") {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,5 +1,6 @@
 #include "cli/BundledResources.h"
 #include "cli/MapAnalyzer.h"
+#include "cli/MapDescribe.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -22,6 +23,7 @@ struct CliArgs {
     bool extract = false;
     bool describeScript = false;
     bool reachability = false;
+    bool describeMap = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -29,6 +31,7 @@ struct CliArgs {
     geck::cli::ExtractOptions ext;
     geck::cli::DescribeScriptOptions desc;
     geck::cli::ReachabilityOptions reach;
+    geck::cli::DescribeMapOptions describeMapOpts;
 };
 
 void printUsage(const char* program) {
@@ -68,13 +71,16 @@ void printUsage(const char* program) {
               << "  " << program << " map reachability --map <path> --data <dir-or-.dat> [--data <...>]\n"
               << "      Per-elevation reachability from the entry points (player start + exit grids;\n"
               << "      optimistic: doors passable): reachable/walkable hexes, exits, orphaned content.\n"
+              << "  " << program << " map describe-map --map <path> --data <dir-or-.dat> [--data <...>]\n"
+              << "      One digest composing analyze + reachability for a map (header, biome, structures,\n"
+              << "      critter roster with AI + scripts, exits, reachability), as JSON.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
 bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
-            || args[1] == "describe-script" || args[1] == "reachability");
+            || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -115,7 +121,8 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         || (out.render && (arg == "--map" || arg == "--out" || arg == "--elevation" || arg == "--max-dim"))
         || (out.extract && (arg == "--map" || arg == "--out" || arg == "--name" || arg == "--elevation" || arg == "--pids" || arg == "--anchor" || arg == "--radius"))
         || (out.describeScript && (arg == "--index" || arg == "--locale"))
-        || (out.reachability && arg == "--map");
+        || (out.reachability && arg == "--map")
+        || (out.describeMap && arg == "--map");
 
     if (valueFlag && i + 1 >= args.size()) {
         std::cerr << "error: " << arg << " needs a value\n";
@@ -268,6 +275,15 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.describeMap && arg == "--map") {
+        out.describeMapOpts.mapPath = args[i + 1];
+        return 2;
+    }
+    if (out.describeMap) {
+        std::cerr << "error: unexpected argument: " << arg << "\n";
+        printUsage(program);
+        return 0;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -291,6 +307,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.extract = args[1] == "extract-pattern";
     out.describeScript = args[1] == "describe-script";
     out.reachability = args[1] == "reachability";
+    out.describeMap = args[1] == "describe-map";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -372,6 +389,9 @@ int main(int argc, char** argv) {
     }
     if (cli.reachability) {
         return geck::cli::analyzeReachability(resources, cli.reach, std::cout);
+    }
+    if (cli.describeMap) {
+        return geck::cli::describeMap(resources, cli.describeMapOpts, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -228,6 +228,9 @@ namespace {
         if (const auto it = args.find("objects"); it != args.end() && it->is_boolean()) {
             opts.objects = it->get<bool>();
         }
+        if (const auto it = args.find("semantic"); it != args.end() && it->is_boolean()) {
+            opts.semantic = it->get<bool>();
+        }
         if (const auto it = args.find("showBlockers"); it != args.end() && it->is_boolean()) {
             opts.showBlockers = it->get<bool>();
         }
@@ -373,11 +376,14 @@ namespace {
                                  "-> colour -> count) so you can match the picture to the analyze JSON "
                                  "and read the floor-tile transitions. objects=true instead mutes the "
                                  "floor to grey so the category-coloured object markers pop (for checking "
-                                 "scatter). FLAT objects (invisible engine blockers) are hidden unless "
-                                 "showBlockers. map/out are filesystem paths — out is written there, and map "
-                                 "may be a VFS path or any file on disk (e.g. one generate just wrote). Needs "
-                                 "an off-screen GL context." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } } } },
+                                 "scatter). semantic=true also greys the floor but colours markers by "
+                                 "role — exit grids highlighted, critters by team, scripted objects ringed "
+                                 "(legend keyed by role) — the purpose layer that pairs with describe_map. "
+                                 "FLAT objects (invisible engine blockers) are hidden unless showBlockers. "
+                                 "map/out are filesystem paths — out is written there, and map may be a VFS "
+                                 "path or any file on disk (e.g. one generate just wrote). Needs an "
+                                 "off-screen GL context." },
+                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } } } },
             { { "name", "script_api" },
                 { "description", "The generation-script `api` reference (Markdown): every function a `generate` "
                                  "Luau script can call on the global `api`, with signatures, plus the non-obvious "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -45,29 +45,75 @@ namespace {
         return json{ { "content", json::array({ { { "type", "text" }, { "text", text } } }) }, { "isError", isError } };
     }
 
-    // --- typed argument access (keeps the tool bodies flat) ----------------------
+    // --- typed argument access --------------------------------------------------
+    // A bad tool argument: thrown by the require*/checked accessors and turned into an isError tool
+    // result by callTool, so the handlers can validate as straight-line code.
+    struct ToolError {
+        std::string message;
+    };
+
     std::string optString(const json& args, const char* key) {
         const auto it = args.find(key);
         return it != args.end() && it->is_string() ? it->get<std::string>() : std::string();
     }
-    int optInt(const json& args, const char* key, int fallback) {
+    // A required, non-empty string argument.
+    std::string requireString(const json& args, const char* key) {
         const auto it = args.find(key);
-        return it != args.end() && it->is_number_integer() ? it->get<int>() : fallback;
+        if (it == args.end() || !it->is_string() || it->get<std::string>().empty()) {
+            throw ToolError{ std::string("argument '") + key + "' must be a non-empty string" };
+        }
+        return it->get<std::string>();
+    }
+    // Optional integer in [min, max]: absent -> fallback (unvalidated), but a present value must be a
+    // genuine in-range integer — no silently-ignored wrong type, no negative wrapping to a huge
+    // unsigned downstream.
+    int64_t optInt(const json& args, const char* key, int64_t fallback, int64_t min, int64_t max) {
+        const auto it = args.find(key);
+        if (it == args.end()) {
+            return fallback;
+        }
+        if (!it->is_number_integer()) {
+            throw ToolError{ std::string("argument '") + key + "' must be an integer" };
+        }
+        const int64_t value = it->get<int64_t>();
+        if (value < min || value > max) {
+            throw ToolError{ std::string("argument '") + key + "' must be in ["
+                + std::to_string(min) + ", " + std::to_string(max) + "]" };
+        }
+        return value;
+    }
+    // A required integer in [min, max].
+    int64_t requireInt(const json& args, const char* key, int64_t min, int64_t max) {
+        if (args.find(key) == args.end()) {
+            throw ToolError{ std::string("argument '") + key + "' is required" };
+        }
+        return optInt(args, key, 0, min, max);
     }
     bool optBool(const json& args, const char* key, bool fallback) {
         const auto it = args.find(key);
-        return it != args.end() && it->is_boolean() ? it->get<bool>() : fallback;
+        if (it == args.end()) {
+            return fallback;
+        }
+        if (!it->is_boolean()) {
+            throw ToolError{ std::string("argument '") + key + "' must be a boolean" };
+        }
+        return it->get<bool>();
     }
-    // Collect the integer entries of an optional `key` array (non-integers ignored) into `out`.
+    // Collect the integer entries of an optional `key` array into `out`, rejecting non-integers and
+    // negatives (a negative would wrap to a huge PID).
     void parsePidArray(const json& args, const char* key, std::vector<std::uint32_t>& out) {
         const auto it = args.find(key);
-        if (it == args.end() || !it->is_array()) {
+        if (it == args.end()) {
             return;
         }
+        if (!it->is_array()) {
+            throw ToolError{ std::string("argument '") + key + "' must be an array of non-negative integers" };
+        }
         for (const auto& pid : *it) {
-            if (pid.is_number_integer()) {
-                out.push_back(static_cast<std::uint32_t>(pid.get<int64_t>()));
+            if (!pid.is_number_integer() || pid.get<int64_t>() < 0) {
+                throw ToolError{ std::string("argument '") + key + "' must contain only non-negative integers" };
             }
+            out.push_back(static_cast<std::uint32_t>(pid.get<int64_t>()));
         }
     }
 
@@ -123,12 +169,9 @@ namespace {
 
     json toolDescribeScript(resource::GameResources& resources, const json& args) {
         cli::DescribeScriptOptions opts;
-        opts.programIndex = optInt(args, "programIndex", opts.programIndex);
+        opts.programIndex = static_cast<int>(requireInt(args, "programIndex", 0, INT32_MAX));
         if (const std::string locale = optString(args, "locale"); !locale.empty()) {
             opts.locale = locale;
-        }
-        if (opts.programIndex < 0) {
-            return toolText("describe_script requires a non-negative integer 'programIndex' (a 0-based script_id from analyze)", true);
         }
         std::ostringstream oss;
         const int rc = cli::describeScript(resources, opts, oss);
@@ -137,10 +180,7 @@ namespace {
 
     json toolReachability(resource::GameResources& resources, const json& args) {
         cli::ReachabilityOptions opts;
-        opts.mapPath = optString(args, "map");
-        if (opts.mapPath.empty()) {
-            return toolText("reachability requires a 'map' path argument", true);
-        }
+        opts.mapPath = requireString(args, "map");
         std::ostringstream oss;
         int rc = 0;
         try {
@@ -153,10 +193,7 @@ namespace {
 
     json toolDescribeMap(resource::GameResources& resources, const json& args) {
         cli::DescribeMapOptions opts;
-        opts.mapPath = optString(args, "map");
-        if (opts.mapPath.empty()) {
-            return toolText("describe_map requires a 'map' path argument", true);
-        }
+        opts.mapPath = requireString(args, "map");
         std::ostringstream oss;
         int rc = 0;
         try {
@@ -168,10 +205,7 @@ namespace {
     }
 
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
-        if (!args.contains("pid") || !args["pid"].is_number_integer()) {
-            return toolText("proto_info requires an integer 'pid' argument", true);
-        }
-        const auto pid = static_cast<uint32_t>(args["pid"].get<int64_t>());
+        const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
             std::string name;
             bool flat = false;
@@ -191,12 +225,9 @@ namespace {
 
     json toolGenerate(resource::GameResources& resources, const json& args) {
         cli::GenerateOptions opts;
-        opts.scriptPath = optString(args, "script");
-        opts.outPath = optString(args, "out");
-        opts.elevation = optInt(args, "elevation", 0);
-        if (opts.scriptPath.empty() || opts.outPath.empty()) {
-            return toolText("generate requires 'script' and 'out' string arguments", true);
-        }
+        opts.scriptPath = requireString(args, "script");
+        opts.outPath = requireString(args, "out");
+        opts.elevation = static_cast<int>(optInt(args, "elevation", 0, 0, 2));
         if (const auto it = args.find("args"); it != args.end() && it->is_object()) {
             for (const auto& [key, value] : it->items()) {
                 opts.args[key] = value.is_string() ? value.get<std::string>() : value.dump();
@@ -216,10 +247,10 @@ namespace {
 
     json toolRender(resource::GameResources& resources, const json& args) {
         cli::RenderOptions opts;
-        opts.mapPath = optString(args, "map");
-        opts.outPath = optString(args, "out");
-        opts.elevation = optInt(args, "elevation", opts.elevation);
-        opts.maxDimension = static_cast<unsigned int>(optInt(args, "maxDimension", static_cast<int>(opts.maxDimension)));
+        opts.mapPath = requireString(args, "map");
+        opts.outPath = requireString(args, "out");
+        opts.elevation = static_cast<int>(optInt(args, "elevation", opts.elevation, 0, 2));
+        opts.maxDimension = static_cast<unsigned int>(optInt(args, "maxDimension", opts.maxDimension, 1, 100000));
         if (const auto it = args.find("showRoof"); it != args.end() && it->is_boolean()) {
             opts.showRoof = it->get<bool>();
         }
@@ -235,9 +266,6 @@ namespace {
         if (const auto it = args.find("showBlockers"); it != args.end() && it->is_boolean()) {
             opts.showBlockers = it->get<bool>();
         }
-        if (opts.mapPath.empty() || opts.outPath.empty()) {
-            return toolText("render_map requires 'map' and 'out' string arguments", true);
-        }
         std::ostringstream oss;
         const int rc = cli::renderMap(resources, opts, oss);
         return toolText(oss.str(), rc != 0); // rc != 0 e.g. unreadable map or no GL context
@@ -245,18 +273,15 @@ namespace {
 
     json toolExtractPattern(resource::GameResources& resources, const json& args) {
         cli::ExtractOptions opts;
-        opts.mapPath = optString(args, "map");
-        opts.outPath = optString(args, "out");
-        opts.name = optString(args, "name");
-        opts.elevation = optInt(args, "elevation", opts.elevation);
-        opts.anchorHex = optInt(args, "anchorHex", opts.anchorHex);
-        opts.radius = optInt(args, "radius", opts.radius);
+        opts.mapPath = requireString(args, "map");
+        opts.outPath = requireString(args, "out");
+        opts.name = requireString(args, "name");
+        opts.elevation = static_cast<int>(optInt(args, "elevation", opts.elevation, 0, 2));
+        opts.anchorHex = static_cast<int>(optInt(args, "anchorHex", opts.anchorHex, 0, 39999));
+        opts.radius = static_cast<int>(optInt(args, "radius", opts.radius, 0, 10000));
         opts.includeFloor = optBool(args, "includeFloor", opts.includeFloor);
         opts.includeRoof = optBool(args, "includeRoof", opts.includeRoof);
         parsePidArray(args, "pids", opts.pids);
-        if (opts.mapPath.empty() || opts.outPath.empty() || opts.name.empty()) {
-            return toolText("extract_pattern requires 'map', 'out' and 'name'", true);
-        }
         if (opts.pids.empty() && opts.anchorHex < 0) {
             return toolText("extract_pattern needs 'pids' (proto PIDs locating the structure) or 'anchorHex'", true);
         }
@@ -392,7 +417,13 @@ namespace {
         if (it == tools.end()) {
             return std::nullopt;
         }
-        return it->handler(resources, args);
+        try {
+            return it->handler(resources, args);
+        } catch (const ToolError& e) {
+            // Bad arguments are a tool-result error (the call was well-formed; the input wasn't),
+            // not a JSON-RPC protocol error.
+            return toolText(e.message, /*isError*/ true);
+        }
     }
 
     // Tool schemas advertised by tools/list.

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -296,106 +296,117 @@ namespace {
         std::function<json(resource::GameResources&, const json&)> handler;
     };
 
+    // Read-only / inspection tools (no files written). Split from the mutating tools so neither
+    // builder is over-long and so a future pass can tag this group readOnlyHint=true en masse.
+    void addReadOnlyTools(std::vector<ToolSpec>& t) {
+        t.push_back({ "list_maps",
+            "List every .map file in the mounted Fallout 2 data.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json&) { return toolListMaps(r); } });
+        t.push_back({ "analyze",
+            "Analyze ground-tile and object usage as JSON. Omit 'maps' to analyze every map, or "
+            "pass it to scope. Each object carries a 'flat' flag (structural blocker vs. decoration) "
+            "for curating a scatter palette. Each map also lists 'critters': who is on it, their team "
+            "(group_id), their AI packet resolved via ai.txt (aggression, disposition, flee/best-weapon/"
+            "distance), and the attached 'script' ({programIndex,name}) — pass that programIndex to "
+            "describe_script for the script's source and dialog.",
+            json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
+            [](resource::GameResources& r, const json& a) { return toolAnalyze(r, a); } });
+        t.push_back({ "palette",
+            "The weighted generation palette for the given maps (omit 'maps' for all), aggregated: "
+            "{ floor:[{id,name,weight}], scenery:[{pid,number,name,weight}] }. Just what a generator "
+            "script needs — floor 'id' for api:paintFloor, scenery 'number' for api:proto, 'weight' = "
+            "real placement count — without the full analyze report. scenery is scatter-eligible only "
+            "(scenery type, non-flat).",
+            json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
+            [](resource::GameResources& r, const json& a) { return toolPalette(r, a); } });
+        t.push_back({ "proto_info",
+            "Resolve a proto PID to its type, engine display name and 'flat' flag.",
+            json({ { "type", "object" }, { "properties", { { "pid", { { "type", "integer" } } } } }, { "required", json::array({ "pid" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolProtoInfo(r, a); } });
+        t.push_back({ "describe_script",
+            "Describe a Fallout 2 script by its scripts.lst program index (the 0-based script_id "
+            "analyze reports for a critter/object). Returns the filename, the .ssl source if a "
+            "script-source tree is mounted (e.g. the FRP scripts_src — hasSource flags whether it was "
+            "found), and the dialog .msg lines ([{id,text}]). Lets you read what an NPC does and says. "
+            "Optional 'locale' picks the dialog language subdir (default english). Args: programIndex, "
+            "optional locale.",
+            json({ { "type", "object" }, { "properties", { { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "programIndex" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolDescribeScript(r, a); } });
+        t.push_back({ "reachability",
+            "Per-elevation reachability for one map. Floods walkable hexes from the entry points "
+            "(player start + exit grids — you can arrive at an exit coming from the adjacent map): "
+            "'reachableHexes' of 'walkableHexes'; 'orphanedObjects' ([{pid,name,hex}], with "
+            "'orphanedObjectCount') are critters/items cut off from every entry — usually a sealed-off "
+            "area or a map bug. 'exits' lists each exit grid with 'reachableFromPlayerStart' "
+            "(walk-connected to the spawn specifically; null if the player spawns elsewhere). "
+            "OPTIMISTIC, not exact pathfinding: doors (incl. locked) are passable, so it over-estimates "
+            "rather than crying wolf. Args: map.",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolReachability(r, a); } });
+        t.push_back({ "describe_map",
+            "One structured digest for a single map, composed from analyze + reachability: the header "
+            "(elevations, darkness, player start, map script, map variables), floor usage (biome), "
+            "object 'clusters' (structures), the 'critters' roster with ai.txt-resolved AI and each "
+            "one's attached {programIndex,name} script, the 'exits' graph, and a 'reachability' field "
+            "(per-elevation walkable/reachable hexes + entry-orphaned objects). Gathers the engine's "
+            "own semantic evidence in one call — join keys (pid, script_id, ai_packet) are preserved — "
+            "so you can infer the map's purpose and follow up with describe_script on any roster entry. "
+            "Args: map.",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
+        t.push_back({ "script_api",
+            "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
+            "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "
+            "are auto-seeded and auto-batched) and the error model. Read this before writing a script "
+            "for `generate`.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources&, const json&) { return toolScriptApi(); } });
+    }
+
+    // Tools that write files or do heavy work (generation, rendering, pattern extraction).
+    void addMutatingTools(std::vector<ToolSpec>& t) {
+        t.push_back({ "generate",
+            "Run a Luau generation script against a fresh map and write a .map. Args: script (path to "
+            "the .luau), out (filesystem path for the .map — render_map/analyze can read it straight "
+            "back), optional elevation, optional args (string map), optional stamps (name -> stamp "
+            ".json path, placed by the script with api:placeStamp(name, anchorHex, variant)). Scripting "
+            "build required.",
+            json({ { "type", "object" }, { "properties", { { "script", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "args", { { "type", "object" } } }, { "stamps", { { "type", "object" } } } } }, { "required", json::array({ "script", "out" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolGenerate(r, a); } });
+        t.push_back({ "render_map",
+            "Render a map to a PNG so it can be seen, not just measured. Args: map (.map path), out "
+            "(output .png path), optional elevation, optional maxDimension (longest side in px, default "
+            "1600), optional showRoof, optional schematic. schematic=true flat-colours floor tiles by "
+            "id and marks objects by category, and returns a colour legend (id/type -> colour -> count) "
+            "so you can match the picture to the analyze JSON and read the floor-tile transitions. "
+            "objects=true instead mutes the floor to grey so the category-coloured object markers pop "
+            "(for checking scatter). semantic=true also greys the floor but colours markers by role — "
+            "exit grids highlighted, critters by team, scripted objects ringed (legend keyed by role) — "
+            "the purpose layer that pairs with describe_map. FLAT objects (invisible engine blockers) "
+            "are hidden unless showBlockers. map/out are filesystem paths — out is written there, and "
+            "map may be a VFS path or any file on disk (e.g. one generate just wrote). Needs an "
+            "off-screen GL context.",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolRender(r, a); } });
+        t.push_back({ "extract_pattern",
+            "Capture a structure from a real map into a reusable pattern stamp (JSON the editor's "
+            "pattern library reads, and generate can place). Locate it with 'pids' (proto PIDs from "
+            "analyze that make up the structure) — their bounding box, grown by 'radius' (default 2) "
+            "hexes, is the capture region, so immediate props nearby come along — or pass 'anchorHex' "
+            "directly. Objects are captured verbatim; pass includeFloor=true to capture the ground and "
+            "includeRoof=true to capture the roof layer (a tent/building roof is tiles, not an object — "
+            "without includeRoof the stamp is topless). Args: map, out, name, optional elevation, pids "
+            "(int array), anchorHex, radius, includeFloor, includeRoof.",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "name", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "pids", { { "type", "array" }, { "items", { { "type", "integer" } } } } }, { "anchorHex", { { "type", "integer" } } }, { "radius", { { "type", "integer" } } }, { "includeFloor", { { "type", "boolean" } } }, { "includeRoof", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out", "name" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolExtractPattern(r, a); } });
+    }
+
     const std::vector<ToolSpec>& toolRegistry() {
         static const std::vector<ToolSpec> tools = [] {
             std::vector<ToolSpec> t;
-            t.push_back({ "list_maps",
-                "List every .map file in the mounted Fallout 2 data.",
-                json({ { "type", "object" }, { "properties", json::object() } }),
-                [](resource::GameResources& r, const json&) { return toolListMaps(r); } });
-            t.push_back({ "analyze",
-                "Analyze ground-tile and object usage as JSON. Omit 'maps' to analyze every map, or "
-                "pass it to scope. Each object carries a 'flat' flag (structural blocker vs. decoration) "
-                "for curating a scatter palette. Each map also lists 'critters': who is on it, their team "
-                "(group_id), their AI packet resolved via ai.txt (aggression, disposition, flee/best-weapon/"
-                "distance), and the attached 'script' ({programIndex,name}) — pass that programIndex to "
-                "describe_script for the script's source and dialog.",
-                json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
-                [](resource::GameResources& r, const json& a) { return toolAnalyze(r, a); } });
-            t.push_back({ "palette",
-                "The weighted generation palette for the given maps (omit 'maps' for all), aggregated: "
-                "{ floor:[{id,name,weight}], scenery:[{pid,number,name,weight}] }. Just what a generator "
-                "script needs — floor 'id' for api:paintFloor, scenery 'number' for api:proto, 'weight' = "
-                "real placement count — without the full analyze report. scenery is scatter-eligible only "
-                "(scenery type, non-flat).",
-                json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
-                [](resource::GameResources& r, const json& a) { return toolPalette(r, a); } });
-            t.push_back({ "proto_info",
-                "Resolve a proto PID to its type, engine display name and 'flat' flag.",
-                json({ { "type", "object" }, { "properties", { { "pid", { { "type", "integer" } } } } }, { "required", json::array({ "pid" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolProtoInfo(r, a); } });
-            t.push_back({ "describe_script",
-                "Describe a Fallout 2 script by its scripts.lst program index (the 0-based script_id "
-                "analyze reports for a critter/object). Returns the filename, the .ssl source if a "
-                "script-source tree is mounted (e.g. the FRP scripts_src — hasSource flags whether it was "
-                "found), and the dialog .msg lines ([{id,text}]). Lets you read what an NPC does and says. "
-                "Optional 'locale' picks the dialog language subdir (default english). Args: programIndex, "
-                "optional locale.",
-                json({ { "type", "object" }, { "properties", { { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "programIndex" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolDescribeScript(r, a); } });
-            t.push_back({ "reachability",
-                "Per-elevation reachability for one map. Floods walkable hexes from the entry points "
-                "(player start + exit grids — you can arrive at an exit coming from the adjacent map): "
-                "'reachableHexes' of 'walkableHexes'; 'orphanedObjects' ([{pid,name,hex}], with "
-                "'orphanedObjectCount') are critters/items cut off from every entry — usually a sealed-off "
-                "area or a map bug. 'exits' lists each exit grid with 'reachableFromPlayerStart' "
-                "(walk-connected to the spawn specifically; null if the player spawns elsewhere). "
-                "OPTIMISTIC, not exact pathfinding: doors (incl. locked) are passable, so it over-estimates "
-                "rather than crying wolf. Args: map.",
-                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolReachability(r, a); } });
-            t.push_back({ "describe_map",
-                "One structured digest for a single map, composed from analyze + reachability: the header "
-                "(elevations, darkness, player start, map script, map variables), floor usage (biome), "
-                "object 'clusters' (structures), the 'critters' roster with ai.txt-resolved AI and each "
-                "one's attached {programIndex,name} script, the 'exits' graph, and a 'reachability' field "
-                "(per-elevation walkable/reachable hexes + entry-orphaned objects). Gathers the engine's "
-                "own semantic evidence in one call — join keys (pid, script_id, ai_packet) are preserved — "
-                "so you can infer the map's purpose and follow up with describe_script on any roster entry. "
-                "Args: map.",
-                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
-            t.push_back({ "generate",
-                "Run a Luau generation script against a fresh map and write a .map. Args: script (path to "
-                "the .luau), out (filesystem path for the .map — render_map/analyze can read it straight "
-                "back), optional elevation, optional args (string map), optional stamps (name -> stamp "
-                ".json path, placed by the script with api:placeStamp(name, anchorHex, variant)). Scripting "
-                "build required.",
-                json({ { "type", "object" }, { "properties", { { "script", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "args", { { "type", "object" } } }, { "stamps", { { "type", "object" } } } } }, { "required", json::array({ "script", "out" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolGenerate(r, a); } });
-            t.push_back({ "render_map",
-                "Render a map to a PNG so it can be seen, not just measured. Args: map (.map path), out "
-                "(output .png path), optional elevation, optional maxDimension (longest side in px, default "
-                "1600), optional showRoof, optional schematic. schematic=true flat-colours floor tiles by "
-                "id and marks objects by category, and returns a colour legend (id/type -> colour -> count) "
-                "so you can match the picture to the analyze JSON and read the floor-tile transitions. "
-                "objects=true instead mutes the floor to grey so the category-coloured object markers pop "
-                "(for checking scatter). semantic=true also greys the floor but colours markers by role — "
-                "exit grids highlighted, critters by team, scripted objects ringed (legend keyed by role) — "
-                "the purpose layer that pairs with describe_map. FLAT objects (invisible engine blockers) "
-                "are hidden unless showBlockers. map/out are filesystem paths — out is written there, and "
-                "map may be a VFS path or any file on disk (e.g. one generate just wrote). Needs an "
-                "off-screen GL context.",
-                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolRender(r, a); } });
-            t.push_back({ "script_api",
-                "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
-                "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "
-                "are auto-seeded and auto-batched) and the error model. Read this before writing a script "
-                "for `generate`.",
-                json({ { "type", "object" }, { "properties", json::object() } }),
-                [](resource::GameResources&, const json&) { return toolScriptApi(); } });
-            t.push_back({ "extract_pattern",
-                "Capture a structure from a real map into a reusable pattern stamp (JSON the editor's "
-                "pattern library reads, and generate can place). Locate it with 'pids' (proto PIDs from "
-                "analyze that make up the structure) — their bounding box, grown by 'radius' (default 2) "
-                "hexes, is the capture region, so immediate props nearby come along — or pass 'anchorHex' "
-                "directly. Objects are captured verbatim; pass includeFloor=true to capture the ground and "
-                "includeRoof=true to capture the roof layer (a tent/building roof is tiles, not an object — "
-                "without includeRoof the stamp is topless). Args: map, out, name, optional elevation, pids "
-                "(int array), anchorHex, radius, includeFloor, includeRoof.",
-                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "name", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "pids", { { "type", "array" }, { "items", { { "type", "integer" } } } } }, { "anchorHex", { { "type", "integer" } } }, { "radius", { { "type", "integer" } } }, { "includeFloor", { { "type", "boolean" } } }, { "includeRoof", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out", "name" }) } }),
-                [](resource::GameResources& r, const json& a) { return toolExtractPattern(r, a); } });
+            addReadOnlyTools(t);
+            addMutatingTools(t);
             return t;
         }();
         return tools;

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -251,21 +251,11 @@ namespace {
         opts.outPath = requireString(args, "out");
         opts.elevation = static_cast<int>(optInt(args, "elevation", opts.elevation, 0, 2));
         opts.maxDimension = static_cast<unsigned int>(optInt(args, "maxDimension", opts.maxDimension, 1, 100000));
-        if (const auto it = args.find("showRoof"); it != args.end() && it->is_boolean()) {
-            opts.showRoof = it->get<bool>();
-        }
-        if (const auto it = args.find("schematic"); it != args.end() && it->is_boolean()) {
-            opts.schematic = it->get<bool>();
-        }
-        if (const auto it = args.find("objects"); it != args.end() && it->is_boolean()) {
-            opts.objects = it->get<bool>();
-        }
-        if (const auto it = args.find("semantic"); it != args.end() && it->is_boolean()) {
-            opts.semantic = it->get<bool>();
-        }
-        if (const auto it = args.find("showBlockers"); it != args.end() && it->is_boolean()) {
-            opts.showBlockers = it->get<bool>();
-        }
+        opts.showRoof = optBool(args, "showRoof", opts.showRoof);
+        opts.schematic = optBool(args, "schematic", opts.schematic);
+        opts.objects = optBool(args, "objects", opts.objects);
+        opts.semantic = optBool(args, "semantic", opts.semantic);
+        opts.showBlockers = optBool(args, "showBlockers", opts.showBlockers);
         std::ostringstream oss;
         const int rc = cli::renderMap(resources, opts, oss);
         return toolText(oss.str(), rc != 0); // rc != 0 e.g. unreadable map or no GL context
@@ -434,30 +424,12 @@ namespace {
         }
         return tools;
     }
-} // namespace
 
-McpServer::McpServer(resource::GameResources& resources)
-    : _resources(resources) {
-}
-
-json McpServer::handleMessage(const json& request) {
-    const bool isNotification = !request.contains("id");
-    const json id = isNotification ? json(nullptr) : request["id"];
-    try {
+    // Route a JSON-RPC *request* (already known to have an id and jsonrpc 2.0) to its result. Kept
+    // out of McpServer::handleMessage so that stays a thin envelope (notification + version guards +
+    // try/catch) and neither function is over-complex.
+    json dispatchRequest(resource::GameResources& resources, const json& request, const json& id) {
         const std::string method = request.value("method", "");
-
-        // A notification (no id) takes no response, and we never run a request method (initialize,
-        // tools/*, ping) as one — executing a tool with no id to return its result is meaningless. So
-        // any no-id message is acknowledged silently regardless of method (e.g. notifications/initialized).
-        if (isNotification) {
-            return json(nullptr);
-        }
-
-        // Past here we owe a response, so the request must declare JSON-RPC 2.0.
-        if (request.value("jsonrpc", std::string()) != "2.0") {
-            return errorMessage(id, -32600, "Invalid Request: 'jsonrpc' must be \"2.0\"");
-        }
-
         if (method == "initialize") {
             // We speak exactly one protocol version, so negotiation is just declaring it: return
             // kProtocolVersion regardless of what the client asked for, and the client decides whether
@@ -474,12 +446,34 @@ json McpServer::handleMessage(const json& request) {
             const json params = request.contains("params") ? request["params"] : json::object();
             const std::string name = params.value("name", "");
             const json args = params.contains("arguments") ? params["arguments"] : json::object();
-            if (auto result = callTool(_resources, name, args)) {
+            if (auto result = callTool(resources, name, args)) {
                 return resultMessage(id, std::move(*result));
             }
             return errorMessage(id, -32602, "Unknown tool: " + name);
         }
         return errorMessage(id, -32601, "Method not found: " + method);
+    }
+} // namespace
+
+McpServer::McpServer(resource::GameResources& resources)
+    : _resources(resources) {
+}
+
+json McpServer::handleMessage(const json& request) {
+    const bool isNotification = !request.contains("id");
+    const json id = isNotification ? json(nullptr) : request["id"];
+    try {
+        // A notification (no id) takes no response, and we never run a request method (initialize,
+        // tools/*, ping) as one — executing a tool with no id to return its result is meaningless. So
+        // any no-id message is acknowledged silently regardless of method (e.g. notifications/initialized).
+        if (isNotification) {
+            return json(nullptr);
+        }
+        // Past here we owe a response, so the request must declare JSON-RPC 2.0.
+        if (request.value("jsonrpc", std::string()) != "2.0") {
+            return errorMessage(id, -32600, "Invalid Request: 'jsonrpc' must be \"2.0\"");
+        }
+        return dispatchRequest(_resources, request, id);
     } catch (const std::exception& e) {
         if (isNotification) {
             return json(nullptr);

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -446,8 +446,26 @@ json McpServer::handleMessage(const json& request) {
     try {
         const std::string method = request.value("method", "");
 
+        // A notification (no id) takes no response, and we never run a request method (initialize,
+        // tools/*, ping) as one — executing a tool with no id to return its result is meaningless. So
+        // any no-id message is acknowledged silently regardless of method (e.g. notifications/initialized).
+        if (isNotification) {
+            return json(nullptr);
+        }
+
+        // Past here we owe a response, so the request must declare JSON-RPC 2.0.
+        if (request.value("jsonrpc", std::string()) != "2.0") {
+            return errorMessage(id, -32600, "Invalid Request: 'jsonrpc' must be \"2.0\"");
+        }
+
         if (method == "initialize") {
+            // We speak exactly one protocol version, so negotiation is just declaring it: return
+            // kProtocolVersion regardless of what the client asked for, and the client decides whether
+            // it can proceed (per the lifecycle spec). Multi-version support would branch here.
             return resultMessage(id, { { "protocolVersion", kProtocolVersion }, { "capabilities", { { "tools", json::object() } } }, { "serverInfo", { { "name", kServerName }, { "version", kServerVersion } } } });
+        }
+        if (method == "ping") {
+            return resultMessage(id, json::object()); // MCP ping -> empty result, answered promptly
         }
         if (method == "tools/list") {
             return resultMessage(id, { { "tools", toolDefinitions() } });
@@ -460,9 +478,6 @@ json McpServer::handleMessage(const json& request) {
                 return resultMessage(id, std::move(*result));
             }
             return errorMessage(id, -32602, "Unknown tool: " + name);
-        }
-        if (isNotification) {
-            return json(nullptr); // e.g. notifications/initialized — no response
         }
         return errorMessage(id, -32601, "Method not found: " + method);
     } catch (const std::exception& e) {

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -270,138 +271,137 @@ namespace {
 
     // Dispatch a tools/call by name. Returns the tool result, or nullopt for an unknown tool
     // (which the caller turns into a JSON-RPC method error).
+    // One contract per tool: the schema advertised by tools/list and the handler run by
+    // tools/call live together, so the dispatch and the advertised surface cannot drift. Handlers
+    // take (resources, args) uniformly (each ignores what it doesn't need).
+    struct ToolSpec {
+        std::string name;
+        std::string description;
+        json inputSchema;
+        std::function<json(resource::GameResources&, const json&)> handler;
+    };
+
+    const std::vector<ToolSpec>& toolRegistry() {
+        static const std::vector<ToolSpec> tools = [] {
+            std::vector<ToolSpec> t;
+            t.push_back({ "list_maps",
+                "List every .map file in the mounted Fallout 2 data.",
+                json({ { "type", "object" }, { "properties", json::object() } }),
+                [](resource::GameResources& r, const json&) { return toolListMaps(r); } });
+            t.push_back({ "analyze",
+                "Analyze ground-tile and object usage as JSON. Omit 'maps' to analyze every map, or "
+                "pass it to scope. Each object carries a 'flat' flag (structural blocker vs. decoration) "
+                "for curating a scatter palette. Each map also lists 'critters': who is on it, their team "
+                "(group_id), their AI packet resolved via ai.txt (aggression, disposition, flee/best-weapon/"
+                "distance), and the attached 'script' ({programIndex,name}) — pass that programIndex to "
+                "describe_script for the script's source and dialog.",
+                json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
+                [](resource::GameResources& r, const json& a) { return toolAnalyze(r, a); } });
+            t.push_back({ "palette",
+                "The weighted generation palette for the given maps (omit 'maps' for all), aggregated: "
+                "{ floor:[{id,name,weight}], scenery:[{pid,number,name,weight}] }. Just what a generator "
+                "script needs — floor 'id' for api:paintFloor, scenery 'number' for api:proto, 'weight' = "
+                "real placement count — without the full analyze report. scenery is scatter-eligible only "
+                "(scenery type, non-flat).",
+                json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
+                [](resource::GameResources& r, const json& a) { return toolPalette(r, a); } });
+            t.push_back({ "proto_info",
+                "Resolve a proto PID to its type, engine display name and 'flat' flag.",
+                json({ { "type", "object" }, { "properties", { { "pid", { { "type", "integer" } } } } }, { "required", json::array({ "pid" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolProtoInfo(r, a); } });
+            t.push_back({ "describe_script",
+                "Describe a Fallout 2 script by its scripts.lst program index (the 0-based script_id "
+                "analyze reports for a critter/object). Returns the filename, the .ssl source if a "
+                "script-source tree is mounted (e.g. the FRP scripts_src — hasSource flags whether it was "
+                "found), and the dialog .msg lines ([{id,text}]). Lets you read what an NPC does and says. "
+                "Optional 'locale' picks the dialog language subdir (default english). Args: programIndex, "
+                "optional locale.",
+                json({ { "type", "object" }, { "properties", { { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "programIndex" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolDescribeScript(r, a); } });
+            t.push_back({ "reachability",
+                "Per-elevation reachability for one map. Floods walkable hexes from the entry points "
+                "(player start + exit grids — you can arrive at an exit coming from the adjacent map): "
+                "'reachableHexes' of 'walkableHexes'; 'orphanedObjects' ([{pid,name,hex}], with "
+                "'orphanedObjectCount') are critters/items cut off from every entry — usually a sealed-off "
+                "area or a map bug. 'exits' lists each exit grid with 'reachableFromPlayerStart' "
+                "(walk-connected to the spawn specifically; null if the player spawns elsewhere). "
+                "OPTIMISTIC, not exact pathfinding: doors (incl. locked) are passable, so it over-estimates "
+                "rather than crying wolf. Args: map.",
+                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolReachability(r, a); } });
+            t.push_back({ "describe_map",
+                "One structured digest for a single map, composed from analyze + reachability: the header "
+                "(elevations, darkness, player start, map script, map variables), floor usage (biome), "
+                "object 'clusters' (structures), the 'critters' roster with ai.txt-resolved AI and each "
+                "one's attached {programIndex,name} script, the 'exits' graph, and a 'reachability' field "
+                "(per-elevation walkable/reachable hexes + entry-orphaned objects). Gathers the engine's "
+                "own semantic evidence in one call — join keys (pid, script_id, ai_packet) are preserved — "
+                "so you can infer the map's purpose and follow up with describe_script on any roster entry. "
+                "Args: map.",
+                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
+            t.push_back({ "generate",
+                "Run a Luau generation script against a fresh map and write a .map. Args: script (path to "
+                "the .luau), out (filesystem path for the .map — render_map/analyze can read it straight "
+                "back), optional elevation, optional args (string map), optional stamps (name -> stamp "
+                ".json path, placed by the script with api:placeStamp(name, anchorHex, variant)). Scripting "
+                "build required.",
+                json({ { "type", "object" }, { "properties", { { "script", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "args", { { "type", "object" } } }, { "stamps", { { "type", "object" } } } } }, { "required", json::array({ "script", "out" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolGenerate(r, a); } });
+            t.push_back({ "render_map",
+                "Render a map to a PNG so it can be seen, not just measured. Args: map (.map path), out "
+                "(output .png path), optional elevation, optional maxDimension (longest side in px, default "
+                "1600), optional showRoof, optional schematic. schematic=true flat-colours floor tiles by "
+                "id and marks objects by category, and returns a colour legend (id/type -> colour -> count) "
+                "so you can match the picture to the analyze JSON and read the floor-tile transitions. "
+                "objects=true instead mutes the floor to grey so the category-coloured object markers pop "
+                "(for checking scatter). semantic=true also greys the floor but colours markers by role — "
+                "exit grids highlighted, critters by team, scripted objects ringed (legend keyed by role) — "
+                "the purpose layer that pairs with describe_map. FLAT objects (invisible engine blockers) "
+                "are hidden unless showBlockers. map/out are filesystem paths — out is written there, and "
+                "map may be a VFS path or any file on disk (e.g. one generate just wrote). Needs an "
+                "off-screen GL context.",
+                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolRender(r, a); } });
+            t.push_back({ "script_api",
+                "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
+                "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "
+                "are auto-seeded and auto-batched) and the error model. Read this before writing a script "
+                "for `generate`.",
+                json({ { "type", "object" }, { "properties", json::object() } }),
+                [](resource::GameResources&, const json&) { return toolScriptApi(); } });
+            t.push_back({ "extract_pattern",
+                "Capture a structure from a real map into a reusable pattern stamp (JSON the editor's "
+                "pattern library reads, and generate can place). Locate it with 'pids' (proto PIDs from "
+                "analyze that make up the structure) — their bounding box, grown by 'radius' (default 2) "
+                "hexes, is the capture region, so immediate props nearby come along — or pass 'anchorHex' "
+                "directly. Objects are captured verbatim; pass includeFloor=true to capture the ground and "
+                "includeRoof=true to capture the roof layer (a tent/building roof is tiles, not an object — "
+                "without includeRoof the stamp is topless). Args: map, out, name, optional elevation, pids "
+                "(int array), anchorHex, radius, includeFloor, includeRoof.",
+                json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "name", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "pids", { { "type", "array" }, { "items", { { "type", "integer" } } } } }, { "anchorHex", { { "type", "integer" } } }, { "radius", { { "type", "integer" } } }, { "includeFloor", { { "type", "boolean" } } }, { "includeRoof", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out", "name" }) } }),
+                [](resource::GameResources& r, const json& a) { return toolExtractPattern(r, a); } });
+            return t;
+        }();
+        return tools;
+    }
+
     std::optional<json> callTool(resource::GameResources& resources, const std::string& name, const json& args) {
-        if (name == "list_maps") {
-            return toolListMaps(resources);
+        const auto& tools = toolRegistry();
+        const auto it = std::ranges::find(tools, name, &ToolSpec::name);
+        if (it == tools.end()) {
+            return std::nullopt;
         }
-        if (name == "analyze") {
-            return toolAnalyze(resources, args);
-        }
-        if (name == "palette") {
-            return toolPalette(resources, args);
-        }
-        if (name == "proto_info") {
-            return toolProtoInfo(resources, args);
-        }
-        if (name == "describe_script") {
-            return toolDescribeScript(resources, args);
-        }
-        if (name == "reachability") {
-            return toolReachability(resources, args);
-        }
-        if (name == "describe_map") {
-            return toolDescribeMap(resources, args);
-        }
-        if (name == "generate") {
-            return toolGenerate(resources, args);
-        }
-        if (name == "render_map") {
-            return toolRender(resources, args);
-        }
-        if (name == "extract_pattern") {
-            return toolExtractPattern(resources, args);
-        }
-        if (name == "script_api") {
-            return toolScriptApi();
-        }
-        return std::nullopt;
+        return it->handler(resources, args);
     }
 
     // Tool schemas advertised by tools/list.
     json toolDefinitions() {
-        return json::array({
-            { { "name", "list_maps" },
-                { "description", "List every .map file in the mounted Fallout 2 data." },
-                { "inputSchema", { { "type", "object" }, { "properties", json::object() } } } },
-            { { "name", "analyze" },
-                { "description", "Analyze ground-tile and object usage as JSON. Omit 'maps' to analyze "
-                                 "every map, or pass it to scope. Each object carries a 'flat' flag "
-                                 "(structural blocker vs. decoration) for curating a scatter palette. Each "
-                                 "map also lists 'critters': who is on it, their team (group_id), their "
-                                 "AI packet resolved via ai.txt (aggression, disposition, flee/best-weapon/"
-                                 "distance), and the attached 'script' ({programIndex,name}) — pass that "
-                                 "programIndex to describe_script for the script's source and dialog." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } } } },
-            { { "name", "palette" },
-                { "description", "The weighted generation palette for the given maps (omit 'maps' for all), "
-                                 "aggregated: { floor:[{id,name,weight}], scenery:[{pid,number,name,weight}] }. "
-                                 "Just what a generator script needs — floor 'id' for api:paintFloor, scenery "
-                                 "'number' for api:proto, 'weight' = real placement count — without the full "
-                                 "analyze report. scenery is scatter-eligible only (scenery type, non-flat)." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } } } },
-            { { "name", "proto_info" },
-                { "description", "Resolve a proto PID to its type, engine display name and 'flat' flag." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "pid", { { "type", "integer" } } } } }, { "required", json::array({ "pid" }) } } } },
-            { { "name", "describe_script" },
-                { "description", "Describe a Fallout 2 script by its scripts.lst program index (the 0-based "
-                                 "script_id analyze reports for a critter/object). Returns the filename, the "
-                                 ".ssl source if a script-source tree is mounted (e.g. the FRP scripts_src — "
-                                 "hasSource flags whether it was found), and the dialog .msg lines "
-                                 "([{id,text}]). Lets you read what an NPC does and says. Optional 'locale' picks "
-                                 "the dialog language subdir (default english). Args: programIndex, optional locale." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "programIndex", { { "type", "integer" } } }, { "locale", { { "type", "string" } } } } }, { "required", json::array({ "programIndex" }) } } } },
-            { { "name", "reachability" },
-                { "description", "Per-elevation reachability for one map. Floods walkable hexes from the entry "
-                                 "points (player start + exit grids — you can arrive at an exit coming from the "
-                                 "adjacent map): 'reachableHexes' of 'walkableHexes'; 'orphanedObjects' "
-                                 "([{pid,name,hex}], with 'orphanedObjectCount') are critters/items cut off from "
-                                 "every entry — usually a sealed-off area or a map bug. 'exits' lists each exit "
-                                 "grid with 'reachableFromPlayerStart' (walk-connected to the spawn specifically; "
-                                 "null if the player spawns elsewhere). OPTIMISTIC, not exact pathfinding: doors "
-                                 "(incl. locked) are passable, so it over-estimates rather than crying wolf. Args: map." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } } } },
-            { { "name", "describe_map" },
-                { "description", "One structured digest for a single map, composed from analyze + reachability: the "
-                                 "header (elevations, darkness, player start, map script, map variables), floor usage "
-                                 "(biome), object 'clusters' (structures), the 'critters' roster with ai.txt-resolved "
-                                 "AI and each one's attached {programIndex,name} script, the 'exits' graph, and a "
-                                 "'reachability' field (per-elevation walkable/reachable hexes + entry-orphaned "
-                                 "objects). Gathers the engine's own semantic evidence in one call — join keys (pid, "
-                                 "script_id, ai_packet) are preserved — so you can infer the map's purpose and follow "
-                                 "up with describe_script on any roster entry. Args: map." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } } } },
-            { { "name", "generate" },
-                { "description", "Run a Luau generation script against a fresh map and write a .map. "
-                                 "Args: script (path to the .luau), out (filesystem path for the .map — "
-                                 "render_map/analyze can read it straight back), optional elevation, optional "
-                                 "args (string map), optional stamps (name -> stamp .json path, placed by the "
-                                 "script with api:placeStamp(name, anchorHex, variant)). Scripting build required." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "script", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "args", { { "type", "object" } } }, { "stamps", { { "type", "object" } } } } }, { "required", json::array({ "script", "out" }) } } } },
-            { { "name", "render_map" },
-                { "description", "Render a map to a PNG so it can be seen, not just measured. Args: map "
-                                 "(.map path), out (output .png path), optional elevation, optional "
-                                 "maxDimension (longest side in px, default 1600), optional showRoof, "
-                                 "optional schematic. schematic=true flat-colours floor tiles by id "
-                                 "and marks objects by category, and returns a colour legend (id/type "
-                                 "-> colour -> count) so you can match the picture to the analyze JSON "
-                                 "and read the floor-tile transitions. objects=true instead mutes the "
-                                 "floor to grey so the category-coloured object markers pop (for checking "
-                                 "scatter). semantic=true also greys the floor but colours markers by "
-                                 "role — exit grids highlighted, critters by team, scripted objects ringed "
-                                 "(legend keyed by role) — the purpose layer that pairs with describe_map. "
-                                 "FLAT objects (invisible engine blockers) are hidden unless showBlockers. "
-                                 "map/out are filesystem paths — out is written there, and map may be a VFS "
-                                 "path or any file on disk (e.g. one generate just wrote). Needs an "
-                                 "off-screen GL context." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } } } },
-            { { "name", "script_api" },
-                { "description", "The generation-script `api` reference (Markdown): every function a `generate` "
-                                 "Luau script can call on the global `api`, with signatures, plus the non-obvious "
-                                 "runtime behaviour (runs are auto-seeded and auto-batched) and the error model. "
-                                 "Read this before writing a script for `generate`." },
-                { "inputSchema", { { "type", "object" }, { "properties", json::object() } } } },
-            { { "name", "extract_pattern" },
-                { "description", "Capture a structure from a real map into a reusable pattern stamp (JSON the "
-                                 "editor's pattern library reads, and generate can place). Locate it with 'pids' "
-                                 "(proto PIDs from analyze that make up the structure) — their bounding box, grown "
-                                 "by 'radius' (default 2) hexes, is the capture region, so immediate props nearby "
-                                 "come along — or pass 'anchorHex' directly. Objects are captured verbatim; pass "
-                                 "includeFloor=true to capture the ground and includeRoof=true to capture the roof "
-                                 "layer (a tent/building roof is tiles, not an object — without includeRoof the "
-                                 "stamp is topless). Args: map, out, name, optional elevation, pids (int array), "
-                                 "anchorHex, radius, includeFloor, includeRoof." },
-                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "name", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "pids", { { "type", "array" }, { "items", { { "type", "integer" } } } } }, { "anchorHex", { { "type", "integer" } } }, { "radius", { { "type", "integer" } } }, { "includeFloor", { { "type", "boolean" } } }, { "includeRoof", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out", "name" }) } } } },
-        });
+        auto tools = json::array();
+        for (const auto& spec : toolRegistry()) {
+            tools.push_back({ { "name", spec.name }, { "description", spec.description }, { "inputSchema", spec.inputSchema } });
+        }
+        return tools;
     }
 } // namespace
 

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -1,6 +1,7 @@
 #include "mcp/McpServer.h"
 
 #include "cli/MapAnalyzer.h"
+#include "cli/MapDescribe.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -149,6 +150,22 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolDescribeMap(resource::GameResources& resources, const json& args) {
+        cli::DescribeMapOptions opts;
+        opts.mapPath = optString(args, "map");
+        if (opts.mapPath.empty()) {
+            return toolText("describe_map requires a 'map' path argument", true);
+        }
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::describeMap(resources, opts, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("describe_map failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         if (!args.contains("pid") || !args["pid"].is_number_integer()) {
             return toolText("proto_info requires an integer 'pid' argument", true);
@@ -269,6 +286,9 @@ namespace {
         if (name == "reachability") {
             return toolReachability(resources, args);
         }
+        if (name == "describe_map") {
+            return toolDescribeMap(resources, args);
+        }
         if (name == "generate") {
             return toolGenerate(resources, args);
         }
@@ -326,6 +346,16 @@ namespace {
                                  "grid with 'reachableFromPlayerStart' (walk-connected to the spawn specifically; "
                                  "null if the player spawns elsewhere). OPTIMISTIC, not exact pathfinding: doors "
                                  "(incl. locked) are passable, so it over-estimates rather than crying wolf. Args: map." },
+                { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } } } },
+            { { "name", "describe_map" },
+                { "description", "One structured digest for a single map, composed from analyze + reachability: the "
+                                 "header (elevations, darkness, player start, map script, map variables), floor usage "
+                                 "(biome), object 'clusters' (structures), the 'critters' roster with ai.txt-resolved "
+                                 "AI and each one's attached {programIndex,name} script, the 'exits' graph, and a "
+                                 "'reachability' field (per-elevation walkable/reachable hexes + entry-orphaned "
+                                 "objects). Gathers the engine's own semantic evidence in one call — join keys (pid, "
+                                 "script_id, ai_packet) are preserved — so you can infer the map's purpose and follow "
+                                 "up with describe_script on any roster entry. Args: map." },
                 { "inputSchema", { { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } } } },
             { { "name", "generate" },
                 { "description", "Run a Luau generation script against a fresh map and write a .map. "

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -290,6 +290,40 @@ namespace {
     // Semantic overlay: colour each object marker by its *role* — exit grids highlighted (and always
     // shown, though flat), critters by team (group_id), everything else by category — and ring any
     // object that carries a map script. The legend keys on the role so it joins back to describe_map.
+    struct SemanticRole {
+        sf::Color color;
+        std::string label;
+        float radius;
+    };
+
+    SemanticRole semanticRoleFor(const MapObject& mo, Pro::OBJECT_TYPE type) {
+        if (mo.isExitGridMarker()) {
+            return { sf::Color(64, 210, 235), "exit grid", 6.0f };
+        }
+        if (type == Pro::OBJECT_TYPE::CRITTER) {
+            return { distinctColor(static_cast<int>(mo.group_id)), "critter team " + std::to_string(mo.group_id), 5.0f };
+        }
+        return { categoryColor(type), Pro::typeToString(type), 5.0f };
+    }
+
+    // Exit grids are flat (engine blockers) but semantically important, so they show even when other
+    // flat objects are hidden.
+    bool isHiddenFlatObject(const MapObject& mo, bool showBlockers, resource::GameResources& resources,
+        std::unordered_map<uint32_t, bool>& flatCache) {
+        return !showBlockers && !mo.isExitGridMarker() && isFlatProto(resources, mo.pro_pid, flatCache);
+    }
+
+    void fillSemanticLegend(MapRenderer::Legend& legend,
+        const std::map<std::string, std::pair<sf::Color, int>>& roles, int scriptedCount) {
+        for (const auto& [role, colorCount] : roles) {
+            legend.objects.push_back({ role, colorCount.first, colorCount.second });
+        }
+        if (scriptedCount > 0) {
+            legend.objects.push_back({ "scripted (yellow ring)", sf::Color(245, 225, 70), scriptedCount });
+        }
+        std::ranges::sort(legend.objects, [](const auto& a, const auto& b) { return a.count > b.count; });
+    }
+
     void drawSemanticMarkers(sf::RenderTexture& target, const std::vector<std::shared_ptr<Object>>& objects,
         resource::GameResources& resources, bool showBlockers, MapRenderer::Legend* legend) {
         std::unordered_map<uint32_t, bool> flatCache;
@@ -300,43 +334,24 @@ namespace {
                 continue;
             }
             const auto mo = object->getMapObjectPtr();
-            const uint32_t pid = mo->pro_pid;
-            const bool exitGrid = mo->isExitGridMarker();
-            // Exit grids are flat (engine blockers) but semantically important, so show them even
-            // when other flat objects are hidden.
-            if (!showBlockers && !exitGrid && isFlatProto(resources, pid, flatCache)) {
+            if (isHiddenFlatObject(*mo, showBlockers, resources, flatCache)) {
                 continue;
             }
 
             const sf::FloatRect b = object->getSprite().getGlobalBounds();
             const sf::Vector2f center{ b.position.x + b.size.x / 2.0f, b.position.y + b.size.y / 2.0f };
-            const Pro::OBJECT_TYPE type = Pro::typeOfPid(pid);
+            const SemanticRole role = semanticRoleFor(*mo, Pro::typeOfPid(mo->pro_pid));
 
-            sf::Color fill;
-            std::string role;
-            float radius = 5.0f;
-            if (exitGrid) {
-                fill = sf::Color(64, 210, 235);
-                role = "exit grid";
-                radius = 6.0f;
-            } else if (type == Pro::OBJECT_TYPE::CRITTER) {
-                fill = distinctColor(static_cast<int>(mo->group_id));
-                role = "critter team " + std::to_string(mo->group_id);
-            } else {
-                fill = categoryColor(type);
-                role = Pro::typeToString(type);
-            }
-
-            sf::CircleShape marker(radius);
-            marker.setOrigin({ radius, radius });
+            sf::CircleShape marker(role.radius);
+            marker.setOrigin({ role.radius, role.radius });
             marker.setPosition(center);
-            marker.setFillColor(fill);
+            marker.setFillColor(role.color);
             marker.setOutlineColor(sf::Color(20, 20, 20, 200));
             marker.setOutlineThickness(1.0f);
             target.draw(marker);
 
-            if (mo->map_scripts_pid >= 0) { // has an attached map script
-                const float ringRadius = radius + 3.0f;
+            if (mo->map_scripts_pid >= 0) { // has an attached map script — ring it
+                const float ringRadius = role.radius + 3.0f;
                 sf::CircleShape ring(ringRadius);
                 ring.setOrigin({ ringRadius, ringRadius });
                 ring.setPosition(center);
@@ -347,18 +362,12 @@ namespace {
                 ++scriptedCount;
             }
 
-            auto& entry = roles[role];
-            entry.first = fill;
+            auto& entry = roles[role.label];
+            entry.first = role.color;
             ++entry.second;
         }
         if (legend != nullptr) {
-            for (const auto& [role, colorCount] : roles) {
-                legend->objects.push_back({ role, colorCount.first, colorCount.second });
-            }
-            if (scriptedCount > 0) {
-                legend->objects.push_back({ "scripted (yellow ring)", sf::Color(245, 225, 70), scriptedCount });
-            }
-            std::ranges::sort(legend->objects, [](const auto& a, const auto& b) { return a.count > b.count; });
+            fillSemanticLegend(*legend, roles, scriptedCount);
         }
     }
 } // namespace

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -286,6 +286,81 @@ namespace {
             std::ranges::sort(legend->objects, [](const auto& a, const auto& b) { return a.count > b.count; });
         }
     }
+
+    // Semantic overlay: colour each object marker by its *role* — exit grids highlighted (and always
+    // shown, though flat), critters by team (group_id), everything else by category — and ring any
+    // object that carries a map script. The legend keys on the role so it joins back to describe_map.
+    void drawSemanticMarkers(sf::RenderTexture& target, const std::vector<std::shared_ptr<Object>>& objects,
+        resource::GameResources& resources, bool showBlockers, MapRenderer::Legend* legend) {
+        std::unordered_map<uint32_t, bool> flatCache;
+        std::map<std::string, std::pair<sf::Color, int>> roles; // role -> {colour, count}
+        int scriptedCount = 0;
+        for (const auto& object : objects) {
+            if (!object || !object->hasMapObject()) {
+                continue;
+            }
+            const auto mo = object->getMapObjectPtr();
+            const uint32_t pid = mo->pro_pid;
+            const bool exitGrid = mo->isExitGridMarker();
+            // Exit grids are flat (engine blockers) but semantically important, so show them even
+            // when other flat objects are hidden.
+            if (!showBlockers && !exitGrid && isFlatProto(resources, pid, flatCache)) {
+                continue;
+            }
+
+            const sf::FloatRect b = object->getSprite().getGlobalBounds();
+            const sf::Vector2f center{ b.position.x + b.size.x / 2.0f, b.position.y + b.size.y / 2.0f };
+            const Pro::OBJECT_TYPE type = Pro::typeOfPid(pid);
+
+            sf::Color fill;
+            std::string role;
+            float radius = 5.0f;
+            if (exitGrid) {
+                fill = sf::Color(64, 210, 235);
+                role = "exit grid";
+                radius = 6.0f;
+            } else if (type == Pro::OBJECT_TYPE::CRITTER) {
+                fill = distinctColor(static_cast<int>(mo->group_id));
+                role = "critter team " + std::to_string(mo->group_id);
+            } else {
+                fill = categoryColor(type);
+                role = Pro::typeToString(type);
+            }
+
+            sf::CircleShape marker(radius);
+            marker.setOrigin({ radius, radius });
+            marker.setPosition(center);
+            marker.setFillColor(fill);
+            marker.setOutlineColor(sf::Color(20, 20, 20, 200));
+            marker.setOutlineThickness(1.0f);
+            target.draw(marker);
+
+            if (mo->map_scripts_pid >= 0) { // has an attached map script
+                const float ringRadius = radius + 3.0f;
+                sf::CircleShape ring(ringRadius);
+                ring.setOrigin({ ringRadius, ringRadius });
+                ring.setPosition(center);
+                ring.setFillColor(sf::Color::Transparent);
+                ring.setOutlineColor(sf::Color(245, 225, 70));
+                ring.setOutlineThickness(1.5f);
+                target.draw(ring);
+                ++scriptedCount;
+            }
+
+            auto& entry = roles[role];
+            entry.first = fill;
+            ++entry.second;
+        }
+        if (legend != nullptr) {
+            for (const auto& [role, colorCount] : roles) {
+                legend->objects.push_back({ role, colorCount.first, colorCount.second });
+            }
+            if (scriptedCount > 0) {
+                legend->objects.push_back({ "scripted (yellow ring)", sf::Color(245, 225, 70), scriptedCount });
+            }
+            std::ranges::sort(legend->objects, [](const auto& a, const auto& b) { return a.count > b.count; });
+        }
+    }
 } // namespace
 
 MapRenderer::MapRenderer(resource::GameResources& resources)
@@ -293,7 +368,7 @@ MapRenderer::MapRenderer(resource::GameResources& resources)
 }
 
 sf::Image MapRenderer::renderToImage(Map& map, const Options& options, Legend* legend) {
-    if (options.style == Style::Schematic || options.style == Style::Objects) {
+    if (options.style == Style::Schematic || options.style == Style::Objects || options.style == Style::Semantic) {
         return renderSchematic(map, options, legend);
     }
     return renderNatural(map, options);
@@ -364,7 +439,8 @@ sf::Image MapRenderer::renderSchematic(Map& map, const Options& options, Legend*
     const std::vector<Tile> noTiles;
     const std::vector<Tile>& tiles = tilesIt != allTiles.end() ? tilesIt->second : noTiles;
 
-    const std::unordered_map<uint16_t, sf::Color> floorColor = options.style == Style::Objects
+    const bool semantic = options.style == Style::Semantic;
+    const std::unordered_map<uint16_t, sf::Color> floorColor = (options.style == Style::Objects || semantic)
         ? uniformFloorColors(tiles)
         : assignFloorColors(tiles, legend);
 
@@ -393,7 +469,11 @@ sf::Image MapRenderer::renderSchematic(Map& map, const Options& options, Legend*
     const std::unique_ptr<sf::RenderTexture> target = makeTarget(computeFrame(bounds, options.maxDimension));
     target->clear(options.background);
     target->draw(floor);
-    drawObjectMarkers(*target, objects, _resources, options.showBlockers, legend);
+    if (semantic) {
+        drawSemanticMarkers(*target, objects, _resources, options.showBlockers, legend);
+    } else {
+        drawObjectMarkers(*target, objects, _resources, options.showBlockers, legend);
+    }
     target->display();
     return target->getTexture().copyToImage();
 }

--- a/src/rendering/MapRenderer.h
+++ b/src/rendering/MapRenderer.h
@@ -34,6 +34,11 @@ public:
         /// Like Schematic but the floor is one muted grey, so the category-coloured object markers
         /// pop — for verifying object scatter/clumping without the per-id floor rainbow drowning them.
         Objects,
+        /// Semantic overlay (grey floor): object markers coloured by *role* rather than category —
+        /// exit grids highlighted, critters coloured by team (group_id), and scripted objects ringed —
+        /// so the map's purpose layer (where you leave, where the NPCs/teams are, what's scripted) is
+        /// visible. The Legend maps each role to its colour. Pairs with describe_map's JSON evidence.
+        Semantic,
     };
 
     struct Options {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,24 +158,9 @@ endif()
 add_test(NAME qt_tests COMMAND qt_tests)
 
 
-# copy shared external libraries to the build directory for Windows builds
-if(WIN32)
-    add_custom_command(
-        TARGET general_tests POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:general_tests> $<TARGET_FILE_DIR:general_tests>
-        COMMAND_EXPAND_LISTS
-    )
-    add_custom_command(
-        TARGET performance_tests POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:performance_tests> $<TARGET_FILE_DIR:performance_tests>
-        COMMAND_EXPAND_LISTS
-    )
-    add_custom_command(
-        TARGET qt_tests POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:qt_tests> $<TARGET_FILE_DIR:qt_tests>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
+# Windows runtime DLLs for the test executables are staged by copy_runtime_dlls (top-level
+# CMakeLists), which copies the union of every executable's DLLs once — doing it per-target here
+# raced with gecko's identical copies into the shared output dir.
 
 # general_tests / performance_tests resolve fixtures by absolute path
 # (GECK_TEST_DATA_DIR via test_support), so no tests/data copy is needed for them.

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -121,4 +121,22 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
         // A negative entry in a pid array would have wrapped too.
         CHECK(call("extract_pattern", { { "map", "m" }, { "out", "o" }, { "name", "n" }, { "pids", json::array({ -1 }) } }, 24)["result"]["isError"] == true);
     }
+
+    SECTION("ping is answered promptly with an empty result") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 30 }, { "method", "ping" } });
+        CHECK(resp["id"] == 30);
+        CHECK(resp["result"].is_object());
+        CHECK(!resp.contains("error"));
+    }
+
+    SECTION("a request method sent as a notification (no id) does not run and gets no response") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "method", "tools/call" },
+            { "params", { { "name", "list_maps" }, { "arguments", json::object() } } } });
+        CHECK(resp.is_null());
+    }
+
+    SECTION("a request that isn't JSON-RPC 2.0 is rejected with -32600") {
+        const json resp = server.handleMessage({ { "id", 31 }, { "method", "tools/list" } });
+        CHECK(resp["error"]["code"] == -32600);
+    }
 }

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -105,4 +105,20 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             { "params", { { "name", "describe_map" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
+
+    SECTION("bad argument types and out-of-range numbers are tool errors, not silent casts") {
+        auto call = [&](const char* tool, json toolArgs, int id) {
+            return server.handleMessage({ { "jsonrpc", "2.0" }, { "id", id }, { "method", "tools/call" },
+                { "params", { { "name", tool }, { "arguments", std::move(toolArgs) } } } });
+        };
+        // A negative pid would have wrapped to a huge uint32; a string pid was silently ignored.
+        CHECK(call("proto_info", { { "pid", -5 } }, 20)["result"]["isError"] == true);
+        CHECK(call("proto_info", { { "pid", "nope" } }, 21)["result"]["isError"] == true);
+        // A negative maxDimension would have become an enormous unsigned value.
+        CHECK(call("render_map", { { "map", "m.map" }, { "out", "o.png" }, { "maxDimension", -1 } }, 22)["result"]["isError"] == true);
+        // A non-string required arg used to slip through as an empty string.
+        CHECK(call("render_map", { { "map", 123 }, { "out", "o.png" } }, 23)["result"]["isError"] == true);
+        // A negative entry in a pid array would have wrapped too.
+        CHECK(call("extract_pattern", { { "map", "m" }, { "out", "o" }, { "name", "n" }, { "pids", json::array({ -1 }) } }, 24)["result"]["isError"] == true);
+    }
 }

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -97,6 +97,12 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
     SECTION("reachability without a map is a tool error") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 11 }, { "method", "tools/call" },
             { "params", { { "name", "reachability" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("describe_map without a map is a tool error") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 12 }, { "method", "tools/call" },
+            { "params", { { "name", "describe_map" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
 }


### PR DESCRIPTION
The MCP map-intelligence capstone (PLAN "Map semantics & intelligence" capability 1).

`describe_map` gathers a map's semantic evidence in **one call** by composing the existing tools rather than baking in classification heuristics:
- the machine-readable **analyze** per-map report — header (enabled elevations / darkness / player start / map script / map vars), floor/biome, object **clusters** (structures), **critters** roster with ai.txt-resolved AI + each one's attached `{programIndex, name}` script, and the **exits** graph;
- folded together with **reachability** — per-elevation walkable/reachable hexes + entry-**orphaned** objects.

Join keys (`pid`, `script_id`, `ai_packet`) are preserved so an agent can infer the map's purpose from the same evidence a designer reads, then drill in with `describe_script` on any roster entry.

**Surface:** MCP tool `describe_map` (arg `map`), CLI `map describe-map --map <path>`, core `cli::describeMap`.

**Verified** on the mounted data: `artemple` is clean (0 orphans); `vctydwtn` surfaces its 9 orphaned servant/slave objects inline with the 46-critter roster. 238 tests pass + a new `describe_map` MCP dispatch test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)