### PR TITLE
maps.txt → vault (MapsTxt) + friendly map names (map.msg) + roadmap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -109,6 +109,49 @@ blind rectangle:
 The primitive (`placeExitGridRect`) and the directional-art mapping are the reusable foundation;
 the follow-up is feeding them terrain-derived locations instead of a centred rectangle.
 
+### Unified exit-grid tool + polygonal drawing (UX)
+
+Exit-grid authoring is split across **two toolbar buttons** (place-single vs the rectangular
+"mark exits" drag). Fold them into **one tool with a mode dropdown**:
+- **Place single** — the existing per-hex `placeExitGridAtPosition` (also closes the no-UI-trigger
+  gap for `EditorMode::PlaceExitGrid` noted above).
+- **Draw region** — replace the axis-aligned rectangle fill (`selectExitGridsInArea`) with a
+  **polygonal / freehand** path: the user clicks vertices (or drags) and every hex on the outline /
+  inside the polygon becomes an exit-grid MISC object, so the diagonal iso-edge runs that real maps
+  use are authorable — directly resolving the rectangle-only limitation above.
+
+While drawing, render each prospective hex with its **MISC exit marker texture at the correct
+orientation**, tinted by destination kind: **green for an inter-map exit**, **brown for a world-map
+exit** (the `-2`/`-1` sentinels; cf. the `ExitGrid::RECT_*` directional art), so the author sees the
+region forming with engine-accurate art before committing. One destination per region — the
+properties dialog (now name-annotated via `MapNameResolver`) still sets it.
+
+### Map metadata editing (maps.txt / map.msg in the editor)
+
+The editor can now *read* a map's friendly name and its exits' destinations (`MapNameResolver`:
+`maps.txt` → `MapsTxt`, plus `map.msg` display names, surfaced in the exit-grid dialog). Next: let
+the user **edit** that metadata.
+
+**Surface — where it lives** (decision needed):
+- **In the existing Map Info panel** *(recommended for the per-map fields)* — the current map's
+  `lookup_name`, display name, music, and yes/no flags (saved / pipboy_active / automap) sit
+  naturally beside the map properties the panel already shows. Lowest friction, no new surface.
+- **A new tab in the Map Info panel** — if the field set grows (ambient_sfx list, per-elevation
+  names, random start points), a "Map Registry" tab keeps the basic panel uncluttered.
+- **A dedicated panel/dialog** — only if editing the *whole* `maps.txt` / `map.msg` table (every
+  map, not just the current one) becomes a goal; heavier, likely out of scope for v1.
+
+Recommendation: per-map fields in the **Map Info panel** (or a tab there); defer a full-table editor.
+
+**Editability — the DAT problem.** `maps.txt` and the `*.msg` files usually live **inside
+`master.dat`**, which the editor reads but must not rewrite. So before editing, **copy the file out
+to the native filesystem** (a writable data root / the configured game data dir) and edit *that*
+copy, which then shadows the archive entry (the VFS already layers loose files over the DAT). Flow:
+on first edit, if the path resolves from a DAT, materialize it to the loose data dir, then read/write
+the loose copy. Needs (a) a "writable data root" setting, (b) a VFS helper to tell whether a path is
+archive-backed, and (c) a `maps.txt` *writer* — or, to preserve comments/ordering, keep the raw text
+and patch only the touched keys rather than re-serializing `MapsTxt`.
+
 ---
 
 ## SSL Script Editing Integration

--- a/PLAN.md
+++ b/PLAN.md
@@ -753,6 +753,55 @@ generation, not just analysis.
 `critters` tool + header/globals + exits-as-graph. Phase 2 (medium): reachability flood-fill +
 `describe_script`. Phase 3 (synthesis): `describe_map` digest + semantic render overlay.
 
+## Next capabilities (post-`describe_map`)
+
+These extend the roadmap above and all follow one **data-fidelity + layering rule**: parse engine
+data in the **vault** library (a `format/…` object + a `reader/…`, like `MapsTxt` and `AiTxt`),
+never inline in the cli/MCP layer. The MCP composes the structured objects into JSON; it does no
+file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set this precedent.)
+
+6. **`engine_reference` — ground answers in the engine source.** A read-only MCP tool that searches
+   a mounted `fallout2-ce` checkout (grep + bounded file read) and returns `file:line` + snippets.
+   The map-script 1-based rule (`scriptIndex - 1`) and the `scrname.msg[programIndex + 101]` /
+   `map.msg[map*3 + elev + 200]` index formulas were all answered by *reading the engine*; this tool
+   lets a **shell-less** MCP agent do the same instead of guessing format details. Config: an
+   engine-source path (like `--data`); cap results (top-N matches, small snippets) so it can't flood
+   context. *Lower priority when the agent already has filesystem/grep tools — then just mounting the
+   source is enough; this earns its keep specifically for headless/sandboxed agents.*
+
+7. **Whole-game map-connectivity graph — `map_graph`.** Walk every shipped map, collect the exit
+   grids (already `{destMap, destMapName, destHex, destElevation}`) into a directed map→map graph;
+   cross with `reachability` to flag one-way edges and unreachable maps. The foundation is in
+   (`exitsToJson` + `MapsTxt`). Answers "how is the world wired" and, spatially, "can the player get
+   from the first map to map X" — bounded, buildable, high value.
+
+8. **Corpus / world index — evidence, not a solver.** Join, across all maps, the connectivity graph
+   + each map's scripts (`describe_script` source/dialog) + the quest/gvar data (below) into one
+   queryable index, so the agent can *reason* about progression ("which script sets the gvar that
+   gates map Y?"). Deliberately **not** a computed "critical path to the ending": `.ssl` is
+   imperative quest logic and static extraction of a win-path would be brittle and over-claim. The
+   MCP supplies ground truth; the model infers the route. (Expands the "Corpus angle" note above.)
+
+### Data-extraction roadmap (engine data files → vault readers)
+
+Surveyed from `fallout2-ce` (`configRead` / `messageListLoad`). Each becomes a vault reader + object,
+then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority order:
+
+- **`map.msg` display names** *(high value, low effort — the obvious next step).* `mapGetName` =
+  `map.msg[mapIndex*3 + elevation + 200]`; city names = `map.msg[1500 + city]`. Gives each map (and
+  every `destMap` exit) a friendly per-elevation name ("Arroyo", "Temple of Trials") alongside the
+  `.map` filename `MapsTxt` already resolves. Pairs directly with `MapsTxt`.
+- **`data/quests.txt` + `game/quests.msg`** *(the progression spine).* Each quest's location, the
+  **gvar** that tracks it, and its description text — this is what turns capability 8 from a map
+  graph into a *quest* graph, since the gvar links a quest to the scripts that set it.
+- **`data/city.txt`** — worldmap areas/towns and their map entrances; bridges the worldmap to the
+  per-map exit graph (capability 7).
+- **`data/worldmap.txt`** — worldmap tiles, terrain and random-encounter tables (the macro layer).
+- **`data/endgame.txt` / `enddeath.txt`** — ending slides and their gvar/condition triggers: the
+  literal "how the game ends" for the corpus angle.
+- **`data/party.txt`** (companions), **`holodisk.txt`**, **`karmavar.txt`** — lore/state, lower
+  priority.
+
 ---
 
 # Selection type toolbar — combinable layers & non-destructive switching

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,6 +310,7 @@ add_library(vault STATIC
 
     # Parser superclass
     reader/FileParser.h
+    reader/TextParsing.h
     reader/ReaderFactory.h
     reader/ReaderFactory.cpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,6 +395,9 @@ add_library(gecko_resource STATIC
 
     resource/ResourceInitializer.h
     resource/ResourceInitializer.cpp
+
+    resource/MapNameResolver.h
+    resource/MapNameResolver.cpp
 )
 add_library(gecko::resource ALIAS gecko_resource)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -280,6 +280,9 @@ add_library(vault STATIC
     # AI (ai.txt — critter AI packets)
     format/ai/AiPacket.h
 
+    # Maps (maps.txt — the engine's index->map registry)
+    format/maps/MapsTxt.h
+
     # PRO
     format/pro/Pro.h
     format/pro/Pro.cpp
@@ -333,6 +336,9 @@ add_library(vault STATIC
 
     reader/ai/AiTxtReader.h
     reader/ai/AiTxtReader.cpp
+
+    reader/maps/MapsTxtReader.h
+    reader/maps/MapsTxtReader.cpp
 
     reader/pro/ProReader.h
     reader/pro/ProReader.cpp

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -10,12 +10,11 @@
 #include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
 #include "format/map/Tile.h"
-#include "format/maps/MapsTxt.h"
 #include "format/msg/Msg.h"
 #include "format/pro/Pro.h"
 #include "reader/ai/AiTxtReader.h"
-#include "reader/maps/MapsTxtReader.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 #include "resource/ResourcePaths.h"
 #include "util/ProHelper.h"
 
@@ -714,41 +713,12 @@ namespace {
         return root;
     }
 
-    // data/maps.txt is the engine's index -> map registry; parse it into a MapsTxt (vault) once so an
-    // exit's bare destination index can be named. Empty MapsTxt when the file isn't mounted.
-    MapsTxt loadMapsTxt(resource::GameResources& resources) {
-        for (const char* path : { "data/maps.txt", "maps.txt" }) {
-            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
-                return parseMapsTxt(std::string(bytes->begin(), bytes->end()));
-            }
-        }
-        return MapsTxt{};
-    }
-
-    // A map's friendly per-elevation name from map.msg, via the engine's mapGetName formula
-    // (map.cc): map.msg[mapIndex*3 + elevation + 200]. mapIndex is the maps.txt index — an exit's
-    // destMap, or MapsTxt::findByName for the map being analysed. "" when map.msg isn't mounted or the
-    // index is out of range, so the caller reports null rather than a guess.
-    std::string mapDisplayName(resource::GameResources& resources, int mapIndex, int elevation) {
-        if (mapIndex < 0 || elevation < 0) {
-            return {};
-        }
-        try {
-            if (Msg* msg = resources.repository().load<Msg>("text/english/game/map.msg"); msg != nullptr) {
-                return msg->message(mapIndex * 3 + elevation + 200).text;
-            }
-        } catch (const std::exception& e) {
-            spdlog::debug("mapDisplayName: map.msg unavailable: {}", e.what());
-        }
-        return {};
-    }
-
     // Per-map exit graph: [{hex,elevation,destMap,destMapName,destMapDisplayName,destHex,
     // destElevation,orientation}] from the exit-grid markers. destMap/destHex are signed (-1 = town
-    // map / unused, -2 = worldmap, else a map id); destMapName resolves it to the .map filename via
-    // maps.txt and destMapDisplayName to the friendly map.msg name at the destination elevation (both
-    // null when unknown). The map's connectivity, so an agent sees where each edge leads.
-    ordered_json exitsToJson(Map& map, const MapsTxt& mapsTxt, resource::GameResources& resources) {
+    // map / unused, -2 = worldmap, else a map id); destMapName is the .map filename and
+    // destMapDisplayName the friendly map.msg name at the destination elevation (both null when
+    // unknown). The map's connectivity, so an agent sees where each edge leads.
+    ordered_json exitsToJson(Map& map, const resource::MapNameResolver& mapNames) {
         auto array = ordered_json::array();
         for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
             for (const auto& object : mapObjects) {
@@ -756,11 +726,11 @@ namespace {
                     continue;
                 }
                 const auto destMap = static_cast<int32_t>(object->exit_map);
-                const MapInfo* dest = mapsTxt.find(destMap);
-                const std::string display = mapDisplayName(resources, destMap, object->exit_elevation);
+                const std::string file = mapNames.fileNameOf(destMap);
+                const std::string display = mapNames.displayName(destMap, object->exit_elevation);
                 array.push_back({ { "hex", object->position }, { "elevation", elevation },
                     { "destMap", destMap },
-                    { "destMapName", dest != nullptr ? ordered_json(dest->mapName) : ordered_json(nullptr) },
+                    { "destMapName", file.empty() ? ordered_json(nullptr) : ordered_json(file) },
                     { "destMapDisplayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
                     { "destHex", static_cast<int32_t>(object->exit_position) },
                     { "destElevation", object->exit_elevation }, { "orientation", object->exit_orientation } });
@@ -770,25 +740,24 @@ namespace {
     }
 
     // The shared, per-run inputs every map's JSON needs: engine resources, the name/tile resolver,
-    // ai.txt, scripts.lst and maps.txt. Bundled so mapToJson takes a handful of arguments, not a dozen.
+    // ai.txt, scripts.lst and the map-name resolver. Bundled so mapToJson takes a handful of
+    // arguments, not a dozen.
     struct AnalyzeContext {
         resource::GameResources& resources;
         NameResolver& names;
         const AiTxt& ai;
         const Lst* scriptsLst;
-        const MapsTxt& mapsTxt;
+        const resource::MapNameResolver& mapNames;
     };
 
-    // The analysed map's own friendly name (map.msg at elevation 0) — found by matching its filename
-    // to a maps.txt section. null when the map isn't in the registry or map.msg isn't mounted.
+    // The analysed map's own friendly name (map.msg at elevation 0), found by matching its filename to
+    // a maps.txt section. null when the map isn't in the registry or map.msg isn't mounted.
     ordered_json selfDisplayName(const std::string& mapPath, const AnalyzeContext& ctx) {
-        std::string file = baseName(mapPath);
-        std::ranges::transform(file, file.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        const MapInfo* self = ctx.mapsTxt.findByName(file);
-        if (self == nullptr) {
+        const int index = ctx.mapNames.indexOf(baseName(mapPath));
+        if (index < 0) {
             return nullptr;
         }
-        const std::string display = mapDisplayName(ctx.resources, self->index, 0);
+        const std::string display = ctx.mapNames.displayName(index, 0);
         return display.empty() ? ordered_json(nullptr) : ordered_json(display);
     }
 
@@ -806,7 +775,7 @@ namespace {
         entry["clusters"] = clustersToJson(collectClusters(map), ctx.names);
         entry["critters"] = crittersToJson(map, ctx.names, ctx.ai, ctx.scriptsLst);
         entry["header"] = headerToJson(map, loadMapGam(ctx.resources, mapPath), ctx.scriptsLst, ctx.resources);
-        entry["exits"] = exitsToJson(map, ctx.mapsTxt, ctx.resources);
+        entry["exits"] = exitsToJson(map, ctx.mapNames);
         return entry;
     }
 
@@ -818,9 +787,9 @@ namespace {
     void emitJson(const std::vector<std::string>& mapPaths, resource::GameResources& resources,
         NameResolver& names, const AiTxt& ai, std::ostream& out) {
         Aggregate agg;
-        const Lst* scriptsLst = loadScriptsLst(resources); // shared across maps (cached); names attached scripts
-        const MapsTxt mapsTxt = loadMapsTxt(resources);    // the engine's index -> map registry (once)
-        const AnalyzeContext ctx{ resources, names, ai, scriptsLst, mapsTxt };
+        const Lst* scriptsLst = loadScriptsLst(resources);   // shared across maps (cached); names attached scripts
+        const resource::MapNameResolver mapNames(resources); // maps.txt + map.msg, loaded once
+        const AnalyzeContext ctx{ resources, names, ai, scriptsLst, mapNames };
         auto maps = ordered_json::array();
         for (const auto& mapPath : mapPaths) {
             const std::unique_ptr<Map> map = loadMap(resources, mapPath);

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -725,11 +725,30 @@ namespace {
         return MapsTxt{};
     }
 
-    // Per-map exit graph: [{hex,elevation,destMap,destMapName,destHex,destElevation,orientation}] from
-    // the exit-grid markers. destMap/destHex are signed (-1 = town map / unused, -2 = worldmap, else a
-    // map id); destMapName resolves that id to its .map filename via maps.txt (null when unknown). The
-    // map's connectivity, so an agent sees where each edge leads.
-    ordered_json exitsToJson(Map& map, const MapsTxt& mapsTxt) {
+    // A map's friendly per-elevation name from map.msg, via the engine's mapGetName formula
+    // (map.cc): map.msg[mapIndex*3 + elevation + 200]. mapIndex is the maps.txt index — an exit's
+    // destMap, or MapsTxt::findByName for the map being analysed. "" when map.msg isn't mounted or the
+    // index is out of range, so the caller reports null rather than a guess.
+    std::string mapDisplayName(resource::GameResources& resources, int mapIndex, int elevation) {
+        if (mapIndex < 0 || elevation < 0) {
+            return {};
+        }
+        try {
+            if (Msg* msg = resources.repository().load<Msg>("text/english/game/map.msg"); msg != nullptr) {
+                return msg->message(mapIndex * 3 + elevation + 200).text;
+            }
+        } catch (const std::exception& e) {
+            spdlog::debug("mapDisplayName: map.msg unavailable: {}", e.what());
+        }
+        return {};
+    }
+
+    // Per-map exit graph: [{hex,elevation,destMap,destMapName,destMapDisplayName,destHex,
+    // destElevation,orientation}] from the exit-grid markers. destMap/destHex are signed (-1 = town
+    // map / unused, -2 = worldmap, else a map id); destMapName resolves it to the .map filename via
+    // maps.txt and destMapDisplayName to the friendly map.msg name at the destination elevation (both
+    // null when unknown). The map's connectivity, so an agent sees where each edge leads.
+    ordered_json exitsToJson(Map& map, const MapsTxt& mapsTxt, resource::GameResources& resources) {
         auto array = ordered_json::array();
         for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
             for (const auto& object : mapObjects) {
@@ -738,9 +757,11 @@ namespace {
                 }
                 const auto destMap = static_cast<int32_t>(object->exit_map);
                 const MapInfo* dest = mapsTxt.find(destMap);
+                const std::string display = mapDisplayName(resources, destMap, object->exit_elevation);
                 array.push_back({ { "hex", object->position }, { "elevation", elevation },
                     { "destMap", destMap },
                     { "destMapName", dest != nullptr ? ordered_json(dest->mapName) : ordered_json(nullptr) },
+                    { "destMapDisplayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
                     { "destHex", static_cast<int32_t>(object->exit_position) },
                     { "destElevation", object->exit_elevation }, { "orientation", object->exit_orientation } });
             }
@@ -758,6 +779,19 @@ namespace {
         const MapsTxt& mapsTxt;
     };
 
+    // The analysed map's own friendly name (map.msg at elevation 0) — found by matching its filename
+    // to a maps.txt section. null when the map isn't in the registry or map.msg isn't mounted.
+    ordered_json selfDisplayName(const std::string& mapPath, const AnalyzeContext& ctx) {
+        std::string file = baseName(mapPath);
+        std::ranges::transform(file, file.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        const MapInfo* self = ctx.mapsTxt.findByName(file);
+        if (self == nullptr) {
+            return nullptr;
+        }
+        const std::string display = mapDisplayName(ctx.resources, self->index, 0);
+        return display.empty() ? ordered_json(nullptr) : ordered_json(display);
+    }
+
     // One map's full report object, folding its floor/object/adjacency usage into `agg` as a side
     // effect (so the aggregate built afterwards has every map's totals).
     ordered_json mapToJson(const std::string& mapPath, Map& map, const AnalyzeContext& ctx, Aggregate& agg) {
@@ -765,13 +799,14 @@ namespace {
         ordered_json entry;
         entry["name"] = baseName(mapPath);
         entry["path"] = mapPath;
+        entry["displayName"] = selfDisplayName(mapPath, ctx);
         entry["floor"] = floorsToJson(usage, ctx.names, agg);
         entry["objects"] = objectsToJson(usage, ctx.names, agg);
         entry["adjacency"] = adjacencyToJson(usage, ctx.names, agg);
         entry["clusters"] = clustersToJson(collectClusters(map), ctx.names);
         entry["critters"] = crittersToJson(map, ctx.names, ctx.ai, ctx.scriptsLst);
         entry["header"] = headerToJson(map, loadMapGam(ctx.resources, mapPath), ctx.scriptsLst, ctx.resources);
-        entry["exits"] = exitsToJson(map, ctx.mapsTxt);
+        entry["exits"] = exitsToJson(map, ctx.mapsTxt, ctx.resources);
         return entry;
     }
 

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -10,9 +10,11 @@
 #include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
 #include "format/map/Tile.h"
+#include "format/maps/MapsTxt.h"
 #include "format/msg/Msg.h"
 #include "format/pro/Pro.h"
 #include "reader/ai/AiTxtReader.h"
+#include "reader/maps/MapsTxtReader.h"
 #include "resource/GameResources.h"
 #include "resource/ResourcePaths.h"
 #include "util/ProHelper.h"
@@ -32,7 +34,6 @@
 #include <optional>
 #include <ostream>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -713,59 +714,22 @@ namespace {
         return root;
     }
 
-    // Per-map exit graph: [{hex,elevation,destMap,destHex,destElevation,orientation}] from the
-    // exit-grid markers. destMap/destHex are signed (-1 = town map / unused, -2 = worldmap, else a
-    // map id) — the map's connectivity, so an agent sees where each edge leads.
-    // data/maps.txt is the engine's index -> map list: `[Map NNN]` sections each with a `map_name`
-    // (the .map filename, lowercased by the engine). An exit grid's destination map is that index,
-    // so this lets us name "destMap 3" as the actual map file. Returns {} if maps.txt isn't mounted.
-    std::map<int, std::string> loadMapNames(resource::GameResources& resources) {
-        std::map<int, std::string> names;
-        auto bytes = resources.files().readRawBytes("data/maps.txt");
-        if (!bytes) {
-            bytes = resources.files().readRawBytes("maps.txt");
-        }
-        if (!bytes) {
-            return names;
-        }
-        const std::string text(bytes->begin(), bytes->end());
-        std::istringstream stream(text);
-        std::string line;
-        int current = -1;
-        while (std::getline(stream, line)) {
-            const auto begin = line.find_first_not_of(" \t\r");
-            if (begin == std::string::npos) {
-                continue;
-            }
-            if (line[begin] == '[') {
-                current = -1;
-                static constexpr std::string_view kMapPrefix = "[Map "; // sections are "[Map NNN]"
-                if (line.compare(begin, kMapPrefix.size(), kMapPrefix) == 0) {
-                    try {
-                        current = std::stoi(line.substr(begin + kMapPrefix.size())); // stops at the ']'
-                    } catch (const std::exception&) {
-                        current = -1;
-                    }
-                }
-            } else if (current >= 0) {
-                const auto eq = line.find('=');
-                if (eq != std::string::npos && line.compare(begin, 8, "map_name") == 0) {
-                    std::string value = line.substr(eq + 1);
-                    const auto v0 = value.find_first_not_of(" \t");
-                    const auto v1 = value.find_last_not_of(" \t\r");
-                    if (v0 != std::string::npos) {
-                        value = value.substr(v0, v1 - v0 + 1);
-                        std::ranges::transform(value, value.begin(),
-                            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-                        names[current] = value;
-                    }
-                }
+    // data/maps.txt is the engine's index -> map registry; parse it into a MapsTxt (vault) once so an
+    // exit's bare destination index can be named. Empty MapsTxt when the file isn't mounted.
+    MapsTxt loadMapsTxt(resource::GameResources& resources) {
+        for (const char* path : { "data/maps.txt", "maps.txt" }) {
+            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+                return parseMapsTxt(std::string(bytes->begin(), bytes->end()));
             }
         }
-        return names;
+        return MapsTxt{};
     }
 
-    ordered_json exitsToJson(Map& map, const std::map<int, std::string>& mapNames) {
+    // Per-map exit graph: [{hex,elevation,destMap,destMapName,destHex,destElevation,orientation}] from
+    // the exit-grid markers. destMap/destHex are signed (-1 = town map / unused, -2 = worldmap, else a
+    // map id); destMapName resolves that id to its .map filename via maps.txt (null when unknown). The
+    // map's connectivity, so an agent sees where each edge leads.
+    ordered_json exitsToJson(Map& map, const MapsTxt& mapsTxt) {
         auto array = ordered_json::array();
         for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
             for (const auto& object : mapObjects) {
@@ -773,10 +737,10 @@ namespace {
                     continue;
                 }
                 const auto destMap = static_cast<int32_t>(object->exit_map);
-                const auto it = mapNames.find(destMap);
+                const MapInfo* dest = mapsTxt.find(destMap);
                 array.push_back({ { "hex", object->position }, { "elevation", elevation },
                     { "destMap", destMap },
-                    { "destMapName", it != mapNames.end() ? ordered_json(it->second) : ordered_json(nullptr) },
+                    { "destMapName", dest != nullptr ? ordered_json(dest->mapName) : ordered_json(nullptr) },
                     { "destHex", static_cast<int32_t>(object->exit_position) },
                     { "destElevation", object->exit_elevation }, { "orientation", object->exit_orientation } });
             }
@@ -784,22 +748,30 @@ namespace {
         return array;
     }
 
+    // The shared, per-run inputs every map's JSON needs: engine resources, the name/tile resolver,
+    // ai.txt, scripts.lst and maps.txt. Bundled so mapToJson takes a handful of arguments, not a dozen.
+    struct AnalyzeContext {
+        resource::GameResources& resources;
+        NameResolver& names;
+        const AiTxt& ai;
+        const Lst* scriptsLst;
+        const MapsTxt& mapsTxt;
+    };
+
     // One map's full report object, folding its floor/object/adjacency usage into `agg` as a side
     // effect (so the aggregate built afterwards has every map's totals).
-    ordered_json mapToJson(const std::string& mapPath, Map& map, resource::GameResources& resources,
-        NameResolver& names, const AiTxt& ai, const Lst* scriptsLst, Aggregate& agg,
-        const std::map<int, std::string>& mapNames) {
+    ordered_json mapToJson(const std::string& mapPath, Map& map, const AnalyzeContext& ctx, Aggregate& agg) {
         const MapUsage usage = collectUsage(map);
         ordered_json entry;
         entry["name"] = baseName(mapPath);
         entry["path"] = mapPath;
-        entry["floor"] = floorsToJson(usage, names, agg);
-        entry["objects"] = objectsToJson(usage, names, agg);
-        entry["adjacency"] = adjacencyToJson(usage, names, agg);
-        entry["clusters"] = clustersToJson(collectClusters(map), names);
-        entry["critters"] = crittersToJson(map, names, ai, scriptsLst);
-        entry["header"] = headerToJson(map, loadMapGam(resources, mapPath), scriptsLst, resources);
-        entry["exits"] = exitsToJson(map, mapNames);
+        entry["floor"] = floorsToJson(usage, ctx.names, agg);
+        entry["objects"] = objectsToJson(usage, ctx.names, agg);
+        entry["adjacency"] = adjacencyToJson(usage, ctx.names, agg);
+        entry["clusters"] = clustersToJson(collectClusters(map), ctx.names);
+        entry["critters"] = crittersToJson(map, ctx.names, ctx.ai, ctx.scriptsLst);
+        entry["header"] = headerToJson(map, loadMapGam(ctx.resources, mapPath), ctx.scriptsLst, ctx.resources);
+        entry["exits"] = exitsToJson(map, ctx.mapsTxt);
         return entry;
     }
 
@@ -811,15 +783,16 @@ namespace {
     void emitJson(const std::vector<std::string>& mapPaths, resource::GameResources& resources,
         NameResolver& names, const AiTxt& ai, std::ostream& out) {
         Aggregate agg;
-        const Lst* scriptsLst = loadScriptsLst(resources);                   // shared across maps (cached); names attached scripts
-        const std::map<int, std::string> mapNames = loadMapNames(resources); // index -> .map filename (once)
+        const Lst* scriptsLst = loadScriptsLst(resources); // shared across maps (cached); names attached scripts
+        const MapsTxt mapsTxt = loadMapsTxt(resources);    // the engine's index -> map registry (once)
+        const AnalyzeContext ctx{ resources, names, ai, scriptsLst, mapsTxt };
         auto maps = ordered_json::array();
         for (const auto& mapPath : mapPaths) {
             const std::unique_ptr<Map> map = loadMap(resources, mapPath);
             if (!map) {
                 continue; // skipped maps simply don't appear; agg.analysed counts what did
             }
-            maps.push_back(mapToJson(mapPath, *map, resources, names, ai, scriptsLst, agg, mapNames));
+            maps.push_back(mapToJson(mapPath, *map, ctx, agg));
             ++agg.analysed;
         }
 

--- a/src/format/maps/MapsTxt.h
+++ b/src/format/maps/MapsTxt.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace geck {
+
+/// One `[Map NNN]` section of Fallout 2's `data/maps.txt` — the engine's index→map registry that an
+/// exit grid's destination map number indexes into (so a `destMap` of 3 is `[Map 003]`). Mirrors the
+/// fields the engine reads in `wmConfigInit` (fallout2-ce worldmap.cc).
+struct MapInfo {
+    int index = -1;             ///< the NNN in `[Map NNN]`
+    std::string lookupName;     ///< lookup_name — the engine's internal area key
+    std::string mapName;        ///< map_name — the .map filename (the engine lowercases it)
+    std::string music;          ///< music track name
+    bool saved = false;         ///< saved — map state persists across visits
+    bool deadBodiesAge = false; ///< dead_bodies_age
+    bool pipboyActive = false;  ///< pipboy_active
+    bool automap = false;       ///< automap
+    /// ambient_sfx — sound-effect name → percent chance pairs.
+    std::vector<std::pair<std::string, int>> ambientSfx;
+};
+
+/// Parsed `data/maps.txt`: the ordered list of map sections, looked up by their `[Map NNN]` index.
+struct MapsTxt {
+    std::vector<MapInfo> maps;
+
+    /// The section with the given index, or nullptr if absent.
+    const MapInfo* find(int index) const {
+        for (const auto& map : maps) {
+            if (map.index == index) {
+                return &map;
+            }
+        }
+        return nullptr;
+    }
+};
+
+} // namespace geck

--- a/src/format/maps/MapsTxt.h
+++ b/src/format/maps/MapsTxt.h
@@ -12,7 +12,7 @@ namespace geck {
 struct MapInfo {
     int index = -1;             ///< the NNN in `[Map NNN]`
     std::string lookupName;     ///< lookup_name — the engine's internal area key
-    std::string mapName;        ///< map_name — the .map filename (the engine lowercases it)
+    std::string mapName;        ///< map_name normalized to a lowercase, loadable "<name>.map" filename
     std::string music;          ///< music track name
     bool saved = false;         ///< saved — map state persists across visits
     bool deadBodiesAge = false; ///< dead_bodies_age
@@ -30,6 +30,17 @@ struct MapsTxt {
     const MapInfo* find(int index) const {
         for (const auto& map : maps) {
             if (map.index == index) {
+                return &map;
+            }
+        }
+        return nullptr;
+    }
+
+    /// The section whose map_name matches `mapName`, or nullptr. `mapName` must be a lowercase .map
+    /// filename (as the reader stores it) — e.g. the basename of the map being analysed, lowercased.
+    const MapInfo* findByName(const std::string& mapName) const {
+        for (const auto& map : maps) {
+            if (map.mapName == mapName) {
                 return &map;
             }
         }

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <format>
 #include <functional>
 #include <optional>
 #include <sstream>
@@ -77,8 +78,7 @@ namespace {
         }
         const int64_t value = it->get<int64_t>();
         if (value < min || value > max) {
-            throw ToolError{ std::string("argument '") + key + "' must be in ["
-                + std::to_string(min) + ", " + std::to_string(max) + "]" };
+            throw ToolError{ std::format("argument '{}' must be in [{}, {}]", key, min, max) };
         }
         return value;
     }

--- a/src/reader/TextParsing.h
+++ b/src/reader/TextParsing.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace geck::text {
+
+/// Trim leading and trailing ASCII whitespace (space, tab, CR, LF). Returns "" for all-whitespace.
+inline std::string trim(const std::string& s) {
+    const auto begin = s.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) {
+        return {};
+    }
+    const auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(begin, end - begin + 1);
+}
+
+/// ASCII-lowercase a copy of the string.
+inline std::string toLower(std::string s) {
+    std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+} // namespace geck::text

--- a/src/reader/ai/AiTxtReader.cpp
+++ b/src/reader/ai/AiTxtReader.cpp
@@ -1,26 +1,15 @@
 #include "reader/ai/AiTxtReader.h"
 
-#include <algorithm>
-#include <cctype>
+#include "reader/TextParsing.h"
+
 #include <sstream>
 
 namespace geck {
 
 namespace {
 
-    std::string trim(const std::string& s) {
-        const auto begin = s.find_first_not_of(" \t\r\n");
-        if (begin == std::string::npos) {
-            return {};
-        }
-        const auto end = s.find_last_not_of(" \t\r\n");
-        return s.substr(begin, end - begin + 1);
-    }
-
-    std::string toLower(std::string s) {
-        std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        return s;
-    }
+    using geck::text::toLower;
+    using geck::text::trim;
 
     int parseIntOr(const std::string& value, int fallback) {
         try {

--- a/src/reader/maps/MapsTxtReader.cpp
+++ b/src/reader/maps/MapsTxtReader.cpp
@@ -1,7 +1,7 @@
 #include "reader/maps/MapsTxtReader.h"
 
-#include <algorithm>
-#include <cctype>
+#include "reader/TextParsing.h"
+
 #include <sstream>
 #include <utility>
 
@@ -9,19 +9,8 @@ namespace geck {
 
 namespace {
 
-    std::string trim(const std::string& s) {
-        const auto begin = s.find_first_not_of(" \t\r\n");
-        if (begin == std::string::npos) {
-            return {};
-        }
-        const auto end = s.find_last_not_of(" \t\r\n");
-        return s.substr(begin, end - begin + 1);
-    }
-
-    std::string toLower(std::string s) {
-        std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        return s;
-    }
+    using geck::text::toLower;
+    using geck::text::trim;
 
     // The engine treats the first word as a yes/no flag (wmYesNoStrs); be lenient about 1/true too.
     bool parseYesNo(const std::string& value) {

--- a/src/reader/maps/MapsTxtReader.cpp
+++ b/src/reader/maps/MapsTxtReader.cpp
@@ -1,0 +1,134 @@
+#include "reader/maps/MapsTxtReader.h"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <utility>
+
+namespace geck {
+
+namespace {
+
+    std::string trim(const std::string& s) {
+        const auto begin = s.find_first_not_of(" \t\r\n");
+        if (begin == std::string::npos) {
+            return {};
+        }
+        const auto end = s.find_last_not_of(" \t\r\n");
+        return s.substr(begin, end - begin + 1);
+    }
+
+    std::string toLower(std::string s) {
+        std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    }
+
+    // The engine treats the first word as a yes/no flag (wmYesNoStrs); be lenient about 1/true too.
+    bool parseYesNo(const std::string& value) {
+        const std::string v = toLower(trim(value));
+        return v == "yes" || v == "1" || v == "true";
+    }
+
+    // ambient_sfx is "name:chance, name:chance, …"; a missing/garbage chance is left at 0.
+    std::vector<std::pair<std::string, int>> parseAmbientSfx(const std::string& value) {
+        std::vector<std::pair<std::string, int>> out;
+        std::istringstream items(value);
+        std::string item;
+        while (std::getline(items, item, ',')) {
+            const std::string entry = trim(item);
+            if (entry.empty()) {
+                continue;
+            }
+            const auto colon = entry.find(':');
+            std::string name = colon == std::string::npos ? entry : trim(entry.substr(0, colon));
+            int chance = 0;
+            if (colon != std::string::npos) {
+                try {
+                    chance = std::stoi(trim(entry.substr(colon + 1)));
+                } catch (const std::exception&) {
+                    chance = 0;
+                }
+            }
+            if (!name.empty()) {
+                out.emplace_back(std::move(name), chance);
+            }
+        }
+        return out;
+    }
+
+    void applyField(MapInfo& map, const std::string& key, const std::string& value) {
+        if (key == "lookup_name") {
+            map.lookupName = value;
+        } else if (key == "map_name") {
+            map.mapName = toLower(value); // the engine lowercases the filename
+        } else if (key == "music") {
+            map.music = value;
+        } else if (key == "saved") {
+            map.saved = parseYesNo(value);
+        } else if (key == "dead_bodies_age") {
+            map.deadBodiesAge = parseYesNo(value);
+        } else if (key == "pipboy_active") {
+            map.pipboyActive = parseYesNo(value);
+        } else if (key == "automap") {
+            map.automap = parseYesNo(value);
+        } else if (key == "ambient_sfx") {
+            map.ambientSfx = parseAmbientSfx(value);
+        }
+    }
+
+    // "[Map NNN]" section name (the text inside the brackets) -> NNN, or -1 if it isn't a map section.
+    int parseSectionIndex(const std::string& section) {
+        if (toLower(section).rfind("map", 0) != 0) {
+            return -1;
+        }
+        try {
+            return std::stoi(section.substr(3)); // stoi skips the leading space and stops at the ']'
+        } catch (const std::exception&) {
+            return -1;
+        }
+    }
+
+} // namespace
+
+MapsTxt parseMapsTxt(std::istream& in) {
+    MapsTxt out;
+    MapInfo current;
+    bool inSection = false;
+    const auto flush = [&] {
+        if (inSection && current.index >= 0) {
+            out.maps.push_back(current);
+        }
+    };
+
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string trimmed = trim(line);
+        if (trimmed.empty() || trimmed.front() == ';') {
+            continue;
+        }
+        if (trimmed.front() == '[' && trimmed.back() == ']') {
+            flush();
+            current = MapInfo{};
+            current.index = parseSectionIndex(trim(trimmed.substr(1, trimmed.size() - 2)));
+            inSection = true;
+            continue;
+        }
+        if (!inSection) {
+            continue; // a stray key before the first section
+        }
+        const auto eq = trimmed.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        applyField(current, toLower(trim(trimmed.substr(0, eq))), trim(trimmed.substr(eq + 1)));
+    }
+    flush();
+    return out;
+}
+
+MapsTxt parseMapsTxt(const std::string& text) {
+    std::istringstream in(text);
+    return parseMapsTxt(in);
+}
+
+} // namespace geck

--- a/src/reader/maps/MapsTxtReader.cpp
+++ b/src/reader/maps/MapsTxtReader.cpp
@@ -60,7 +60,14 @@ namespace {
         if (key == "lookup_name") {
             map.lookupName = value;
         } else if (key == "map_name") {
-            map.mapName = toLower(value); // the engine lowercases the filename
+            // maps.txt stores the bare name ("arcaves"); the engine lowercases it and appends ".map"
+            // when loading. Normalize to the loadable "<name>.map" so mapName is a real filename that
+            // matches a map path's basename (and can be handed back to load/analyze).
+            std::string name = toLower(value);
+            if (name.find('.') == std::string::npos) {
+                name += ".map";
+            }
+            map.mapName = name;
         } else if (key == "music") {
             map.music = value;
         } else if (key == "saved") {

--- a/src/reader/maps/MapsTxtReader.h
+++ b/src/reader/maps/MapsTxtReader.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include "format/maps/MapsTxt.h"
+
+namespace geck {
+
+/// Parse Fallout 2's `data/maps.txt` — an INI file with one `[Map NNN]` section per map and
+/// `key=value` lines (`;` begins a full-line comment). Reads the fields the engine reads in
+/// `wmConfigInit` (fallout2-ce worldmap.cc): lookup_name, map_name, music, the yes/no flags and
+/// ambient_sfx. Never throws — returns whatever parsed (an empty MapsTxt for empty/garbage input),
+/// so a missing file just means destination maps are reported as bare indices.
+MapsTxt parseMapsTxt(std::istream& in);
+MapsTxt parseMapsTxt(const std::string& text);
+
+} // namespace geck

--- a/src/resource/MapNameResolver.cpp
+++ b/src/resource/MapNameResolver.cpp
@@ -1,0 +1,61 @@
+#include "resource/MapNameResolver.h"
+
+#include "format/msg/Msg.h"
+#include "reader/maps/MapsTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cctype>
+
+namespace geck::resource {
+
+namespace {
+
+    MapsTxt loadMapsTxt(GameResources& resources) {
+        for (const char* path : { "data/maps.txt", "maps.txt" }) {
+            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+                return parseMapsTxt(std::string(bytes->begin(), bytes->end()));
+            }
+        }
+        return MapsTxt{};
+    }
+
+    std::string toLower(std::string s) {
+        std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    }
+
+} // namespace
+
+MapNameResolver::MapNameResolver(GameResources& resources)
+    : _resources(resources)
+    , _mapsTxt(loadMapsTxt(resources)) {
+}
+
+std::string MapNameResolver::fileNameOf(int mapIndex) const {
+    const MapInfo* info = _mapsTxt.find(mapIndex);
+    return info != nullptr ? info->mapName : std::string{};
+}
+
+std::string MapNameResolver::displayName(int mapIndex, int elevation) const {
+    if (mapIndex < 0 || elevation < 0) {
+        return {};
+    }
+    try {
+        if (Msg* msg = _resources.repository().load<Msg>("text/english/game/map.msg"); msg != nullptr) {
+            return msg->message(mapIndex * 3 + elevation + 200).text;
+        }
+    } catch (const std::exception& e) {
+        spdlog::debug("MapNameResolver: map.msg unavailable: {}", e.what());
+    }
+    return {};
+}
+
+int MapNameResolver::indexOf(const std::string& mapFileName) const {
+    const MapInfo* info = _mapsTxt.findByName(toLower(mapFileName));
+    return info != nullptr ? info->index : -1;
+}
+
+} // namespace geck::resource

--- a/src/resource/MapNameResolver.h
+++ b/src/resource/MapNameResolver.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "format/maps/MapsTxt.h"
+
+#include <string>
+
+namespace geck::resource {
+
+class GameResources;
+
+/// Resolves Fallout 2 map identifiers to names, from the mounted game data:
+///  - the **.map filename** for a map index, via the vault `MapsTxt` reader (`data/maps.txt`);
+///  - the **friendly display name** for `(index, elevation)`, via the engine's mapGetName formula
+///    `map.msg[index*3 + elevation + 200]` (fallout2-ce map.cc).
+///
+/// Shared by the headless analyze/describe_map path and the editor's exit-grid dialog so the index↔
+/// name rules live in one place. `maps.txt` is read once at construction; `map.msg` is loaded through
+/// the repository cache on demand. Degrades to empty strings when the data isn't mounted.
+class MapNameResolver {
+public:
+    explicit MapNameResolver(GameResources& resources);
+
+    const MapsTxt& mapsTxt() const { return _mapsTxt; }
+
+    /// The .map filename for a maps.txt index, or "" when the index is unknown or negative
+    /// (e.g. the -1 town-map / -2 worldmap exit sentinels).
+    std::string fileNameOf(int mapIndex) const;
+
+    /// The friendly map.msg name for `(mapIndex, elevation)`, or "" when unavailable.
+    std::string displayName(int mapIndex, int elevation) const;
+
+    /// The maps.txt index for a .map filename (basename, any case), or -1 if absent.
+    int indexOf(const std::string& mapFileName) const;
+
+private:
+    GameResources& _resources;
+    MapsTxt _mapsTxt;
+};
+
+} // namespace geck::resource

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -88,6 +88,7 @@ EditorWidget::EditorWidget(resource::GameResources& resources, std::unique_ptr<M
     _tilePlacementManager = std::make_unique<TilePlacementManager>(*this);
     _exitGridPlacementManager = std::make_unique<ExitGridPlacementManager>(
         *this,
+        _resources,
         [this](const QString& m) {
             if (auto* mw = getMainWindow())
                 mw->showStatusMessage(m);

--- a/src/ui/dialogs/ExitGridPropertiesDialog.cpp
+++ b/src/ui/dialogs/ExitGridPropertiesDialog.cpp
@@ -4,6 +4,7 @@
 #include "ui/GameEnums.h"
 #include "util/Constants.h"
 #include "editor/HexagonGrid.h"
+#include "resource/MapNameResolver.h"
 
 #include <QApplication>
 #include <QStyle>
@@ -14,7 +15,7 @@ namespace geck {
 
 using namespace ui::constants;
 
-ExitGridPropertiesDialog::ExitGridPropertiesDialog(QWidget* parent)
+ExitGridPropertiesDialog::ExitGridPropertiesDialog(QWidget* parent, const resource::MapNameResolver* names)
     : QDialog(parent)
     , _mainLayout(nullptr)
     , _formLayout(nullptr)
@@ -23,7 +24,9 @@ ExitGridPropertiesDialog::ExitGridPropertiesDialog(QWidget* parent)
     , _positionSpinBox(nullptr)
     , _elevationComboBox(nullptr)
     , _orientationComboBox(nullptr)
-    , _statusLabel(nullptr) {
+    , _mapNameLabel(nullptr)
+    , _statusLabel(nullptr)
+    , _names(names) {
 
     setWindowTitle("Exit Grid Properties");
     setModal(true);
@@ -33,8 +36,9 @@ ExitGridPropertiesDialog::ExitGridPropertiesDialog(QWidget* parent)
     setupUI();
 }
 
-ExitGridPropertiesDialog::ExitGridPropertiesDialog(const ExitGridProperties& properties, QWidget* parent)
-    : ExitGridPropertiesDialog(parent) {
+ExitGridPropertiesDialog::ExitGridPropertiesDialog(const ExitGridProperties& properties, QWidget* parent,
+    const resource::MapNameResolver* names)
+    : ExitGridPropertiesDialog(parent, names) {
     setProperties(properties);
 }
 
@@ -79,6 +83,13 @@ void ExitGridPropertiesDialog::setupFormLayout() {
     _mapIdSpinBox->setToolTip("Destination map ID (-2 = worldmap, 0-999999 = specific map)");
     _formLayout->addRow("Destination Map ID:", _mapIdSpinBox);
 
+    // Resolved destination-map name (filename · friendly map.msg name), shown under the map ID when a
+    // MapNameResolver is supplied; stays hidden otherwise (e.g. no game data mounted).
+    _mapNameLabel = new QLabel(this);
+    _mapNameLabel->setStyleSheet(ui::theme::styles::mutedText());
+    _mapNameLabel->hide();
+    _formLayout->addRow("", _mapNameLabel);
+
     // Position input (hex coordinate)
     _positionSpinBox = new QSpinBox(this);
     _positionSpinBox->setRange(0, HexagonGrid::POSITION_COUNT - 1);
@@ -114,6 +125,12 @@ void ExitGridPropertiesDialog::setupFormLayout() {
         this, &ExitGridPropertiesDialog::validateInput);
     connect(_orientationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
         this, &ExitGridPropertiesDialog::validateInput);
+
+    // Keep the resolved destination-map name in sync with the map ID and elevation
+    connect(_mapIdSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, &ExitGridPropertiesDialog::updateMapName);
+    connect(_elevationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+        this, &ExitGridPropertiesDialog::updateMapName);
 }
 
 void ExitGridPropertiesDialog::setupButtonBox() {
@@ -159,6 +176,7 @@ void ExitGridPropertiesDialog::updateUI() {
     }
 
     updateMapControlsEnabled();
+    updateMapName();
 
     // Run validation to enable/disable the OK button
     validateInput();
@@ -189,6 +207,34 @@ void ExitGridPropertiesDialog::accept() {
 
 void ExitGridPropertiesDialog::onPositionChanged() {
     validateInput();
+}
+
+void ExitGridPropertiesDialog::updateMapName() {
+    if (_names == nullptr) {
+        return; // no resolver (e.g. no game data mounted) -> leave the label hidden
+    }
+
+    const int mapId = _mapIdSpinBox->value();
+    QString text;
+    if (mapId == -2) { // ExitGrid::WORLD_MAP_EXIT, as the spin box represents it
+        text = "→ world map";
+    } else if (mapId == -1) { // ExitGrid::TOWN_MAP_EXIT
+        text = "→ town map";
+    } else {
+        const int elevation = _elevationComboBox->currentData().toInt();
+        const std::string file = _names->fileNameOf(mapId);
+        const std::string display = _names->displayName(mapId, elevation);
+        if (file.empty() && display.empty()) {
+            text = QString("→ map %1 (not in maps.txt)").arg(mapId);
+        } else {
+            text = "→ " + QString::fromStdString(file.empty() ? ("map " + std::to_string(mapId)) : file);
+            if (!display.empty()) {
+                text += " · " + QString::fromStdString(display);
+            }
+        }
+    }
+    _mapNameLabel->setText(text);
+    _mapNameLabel->show();
 }
 
 void ExitGridPropertiesDialog::validateInput() {

--- a/src/ui/dialogs/ExitGridPropertiesDialog.h
+++ b/src/ui/dialogs/ExitGridPropertiesDialog.h
@@ -14,6 +14,10 @@
 
 namespace geck {
 
+namespace resource {
+    class MapNameResolver;
+}
+
 /**
  * @brief Properties dialog for exit grid configuration
  *
@@ -22,6 +26,10 @@ namespace geck {
  * - Player spawn position (hex coordinate)
  * - Destination elevation level
  * - Player orientation/direction
+ *
+ * When a MapNameResolver is supplied, the destination map ID is annotated with the resolved .map
+ * filename and friendly map.msg name (from maps.txt / map.msg), so the editor shows "arcaves.map ·
+ * Temple: Foyer" instead of a bare number.
  */
 class ExitGridPropertiesDialog : public QDialog {
     Q_OBJECT
@@ -34,8 +42,9 @@ public:
         uint32_t exitOrientation = 0; // Player direction (0-5)
     };
 
-    explicit ExitGridPropertiesDialog(QWidget* parent = nullptr);
-    explicit ExitGridPropertiesDialog(const ExitGridProperties& properties, QWidget* parent = nullptr);
+    explicit ExitGridPropertiesDialog(QWidget* parent = nullptr, const resource::MapNameResolver* names = nullptr);
+    explicit ExitGridPropertiesDialog(const ExitGridProperties& properties, QWidget* parent = nullptr,
+        const resource::MapNameResolver* names = nullptr);
     ~ExitGridPropertiesDialog() = default;
 
     ExitGridProperties getProperties() const;
@@ -47,6 +56,7 @@ public slots:
 private slots:
     void onPositionChanged();
     void validateInput();
+    void updateMapName();
     void onExitToWorldmapToggled(bool checked);
     void onTownMapToggled(bool checked);
 
@@ -71,8 +81,14 @@ private:
     QComboBox* _elevationComboBox;
     QComboBox* _orientationComboBox;
 
+    // Resolved destination-map name shown under the map ID (filename · friendly name)
+    QLabel* _mapNameLabel;
+
     // Status
     QLabel* _statusLabel;
+
+    // Resolves a map ID to its .map filename + map.msg name (not owned; may be null)
+    const resource::MapNameResolver* _names;
 
     // Properties
     ExitGridProperties _properties;

--- a/src/ui/tools/ExitGridPlacementManager.cpp
+++ b/src/ui/tools/ExitGridPlacementManager.cpp
@@ -10,6 +10,7 @@
 #include "editor/HexagonGrid.h"
 #include "selection/SelectionManager.h"
 #include "selection/SelectionState.h"
+#include "resource/MapNameResolver.h"
 
 #include <QApplication>
 #include <QMessageBox>
@@ -17,8 +18,10 @@
 
 namespace geck {
 
-ExitGridPlacementManager::ExitGridPlacementManager(ExitGridContext& context, std::function<void(const QString&)> showStatus)
+ExitGridPlacementManager::ExitGridPlacementManager(ExitGridContext& context, resource::GameResources& resources,
+    std::function<void(const QString&)> showStatus)
     : _context(context)
+    , _resources(resources)
     , _showStatus(std::move(showStatus)) {
 }
 
@@ -200,7 +203,10 @@ std::shared_ptr<MapObject> ExitGridPlacementManager::createExitGridObject(int he
 }
 
 bool ExitGridPlacementManager::showPropertiesDialog(ExitGridPropertiesDialog::ExitGridProperties& properties, const ExitGridPropertiesDialog::ExitGridProperties* existing) {
-    ExitGridPropertiesDialog dialog(existing ? *existing : ExitGridPropertiesDialog::ExitGridProperties{}, _context.getDialogParent());
+    // maps.txt is small; build the resolver per dialog so it reflects the currently-mounted data.
+    const resource::MapNameResolver mapNames(_resources);
+    ExitGridPropertiesDialog dialog(existing ? *existing : ExitGridPropertiesDialog::ExitGridProperties{},
+        _context.getDialogParent(), &mapNames);
 
     if (!existing) {
         ExitGridPropertiesDialog::ExitGridProperties defaults;

--- a/src/ui/tools/ExitGridPlacementManager.h
+++ b/src/ui/tools/ExitGridPlacementManager.h
@@ -15,6 +15,10 @@ namespace geck {
 class Map;
 struct MapObject;
 
+namespace resource {
+    class GameResources;
+}
+
 /**
  * @brief Manages exit grid placement operations for the map editor
  *
@@ -26,7 +30,8 @@ struct MapObject;
  */
 class ExitGridPlacementManager {
 public:
-    ExitGridPlacementManager(ExitGridContext& context, std::function<void(const QString&)> showStatus);
+    ExitGridPlacementManager(ExitGridContext& context, resource::GameResources& resources,
+        std::function<void(const QString&)> showStatus);
     ~ExitGridPlacementManager() = default;
 
     // Exit grid placement operations
@@ -62,6 +67,7 @@ private:
     bool showPropertiesDialog(ExitGridPropertiesDialog::ExitGridProperties& properties, const ExitGridPropertiesDialog::ExitGridProperties* existing = nullptr);
 
     ExitGridContext& _context;
+    resource::GameResources& _resources;
     std::function<void(const QString&)> _showStatus;
 
     // State

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(general_tests
     general/test_message_enum_utils.cpp
     general/test_reading_gam.cpp
     general/test_ai_txt.cpp
+    general/test_maps_txt.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/general/test_maps_txt.cpp
+++ b/tests/general/test_maps_txt.cpp
@@ -1,0 +1,71 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/maps/MapsTxt.h"
+#include "reader/maps/MapsTxtReader.h"
+
+using namespace geck;
+
+namespace {
+// A trimmed-down maps.txt in the real format: two `[Map NNN]` sections with the engine's keys
+// (including the irrelevant ones that must be ignored), a comment, and a non-map section that must
+// be dropped. map_name is upper-cased here to prove the reader lowercases it like the engine.
+constexpr const char* kMapsTxt = R"(; Fallout 2 maps
+[Map 000]
+lookup_name=Desert Encounter
+map_name=DESERT1.MAP
+music=07Desert
+ambient_sfx=brmnwind:35, coyote:10
+saved=No
+dead_bodies_age=Yes
+pipboy_active=Yes
+automap=No
+random_start_point_0=elevation:0, tile_num:20100
+
+[Map 003]
+lookup_name=Temple
+map_name=ARTEMPLE.MAP
+saved=Yes
+automap=Yes
+
+[NotAMap]
+map_name=ignored.map
+)";
+} // namespace
+
+TEST_CASE("parseMapsTxt reads map sections keyed by their [Map NNN] index", "[maps]") {
+    const MapsTxt maps = parseMapsTxt(std::string{ kMapsTxt });
+
+    // Two map sections; the trailing non-map section is dropped.
+    CHECK(maps.maps.size() == 2);
+
+    const MapInfo* desert = maps.find(0);
+    REQUIRE(desert != nullptr);
+    CHECK(desert->lookupName == "Desert Encounter");
+    CHECK(desert->mapName == "desert1.map"); // lowercased like the engine
+    CHECK(desert->music == "07Desert");
+    CHECK(desert->saved == false);
+    CHECK(desert->deadBodiesAge == true);
+    CHECK(desert->pipboyActive == true);
+    CHECK(desert->automap == false);
+    REQUIRE(desert->ambientSfx.size() == 2);
+    CHECK(desert->ambientSfx[0] == std::pair<std::string, int>{ "brmnwind", 35 });
+    CHECK(desert->ambientSfx[1] == std::pair<std::string, int>{ "coyote", 10 });
+
+    const MapInfo* temple = maps.find(3);
+    REQUIRE(temple != nullptr);
+    CHECK(temple->index == 3);
+    CHECK(temple->mapName == "artemple.map");
+    CHECK(temple->lookupName == "Temple");
+    CHECK(temple->saved == true);
+    CHECK(temple->automap == true);
+    CHECK(temple->deadBodiesAge == false); // default when the key is absent
+
+    // An index with no section resolves to nullptr (caller falls back to the bare number).
+    CHECK(maps.find(1) == nullptr);
+    CHECK(maps.find(999) == nullptr);
+}
+
+TEST_CASE("parseMapsTxt tolerates empty / section-less input", "[maps]") {
+    CHECK(parseMapsTxt(std::string{}).maps.empty());
+    CHECK(parseMapsTxt(std::string{ "map_name=stray.map\n" }).maps.empty()); // keys before any [section]
+}

--- a/tests/general/test_maps_txt.cpp
+++ b/tests/general/test_maps_txt.cpp
@@ -23,7 +23,7 @@ random_start_point_0=elevation:0, tile_num:20100
 
 [Map 003]
 lookup_name=Temple
-map_name=ARTEMPLE.MAP
+map_name=artemple
 saved=Yes
 automap=Yes
 
@@ -54,7 +54,7 @@ TEST_CASE("parseMapsTxt reads map sections keyed by their [Map NNN] index", "[ma
     const MapInfo* temple = maps.find(3);
     REQUIRE(temple != nullptr);
     CHECK(temple->index == 3);
-    CHECK(temple->mapName == "artemple.map");
+    CHECK(temple->mapName == "artemple.map"); // bare "artemple" normalized to a loadable filename
     CHECK(temple->lookupName == "Temple");
     CHECK(temple->saved == true);
     CHECK(temple->automap == true);
@@ -63,6 +63,12 @@ TEST_CASE("parseMapsTxt reads map sections keyed by their [Map NNN] index", "[ma
     // An index with no section resolves to nullptr (caller falls back to the bare number).
     CHECK(maps.find(1) == nullptr);
     CHECK(maps.find(999) == nullptr);
+
+    // Reverse lookup by .map filename (used to find the analysed map's own index for map.msg).
+    REQUIRE(maps.findByName("artemple.map") != nullptr);
+    CHECK(maps.findByName("artemple.map")->index == 3);
+    CHECK(maps.findByName("desert1.map") == maps.find(0));
+    CHECK(maps.findByName("nosuch.map") == nullptr);
 }
 
 TEST_CASE("parseMapsTxt tolerates empty / section-less input", "[maps]") {


### PR DESCRIPTION
## Summary
Follow-up to the merged map-intelligence PR (#70), addressing the review directives.

- **`maps.txt` parsing moved into the vault library** (the architectural ask). New
  `format/maps/MapsTxt.h` (`MapInfo`) + `reader/maps/MapsTxtReader` (`parseMapsTxt`, mirroring
  `AiTxtReader`), with a unit test. `analyze`/`describe_map` resolve an exit's `destMapName` through
  the structured object; `mapToJson`'s inputs are bundled into an `AnalyzeContext` (fixes the
  8-param Sonar smell).
- **Friendly map names from `map.msg`** (the next roadmap item). The engine's
  `mapGetName = map.msg[mapIndex*3 + elevation + 200]`: every map now carries a `displayName`
  ("Temple Entrance") and each exit a `destMapDisplayName` ("Temple: Foyer", "Village"). The
  `map.msg` cross-check also caught a real bug — `maps.txt` stores `map_name` without the extension,
  so the analysed map's own name resolved to null; the reader now normalizes to a loadable
  `<name>.map`, which also makes `destMapName` a real filename. `MapsTxt::findByName` added.
- **PLAN: post-`describe_map` roadmap** from a fallout2-ce data-file survey — `engine_reference`,
  whole-game `map_graph`, corpus/world index, and a prioritized data-extraction list. States the
  data-fidelity + vault-layering rule.
- **SonarCloud:** the inline parser's `S134`/`S107` are gone with the refactor; the one valid
  `S6185` is fixed. Remaining findings are intentional (boundary catches) or false positives.

## Verification
- 240 tests pass (incl. the new maps.txt test).
- artemple → "Temple Entrance"; exits → `arcaves.map`/"Temple: Foyer" and `arvillag.map`/"Village";
  denbus1 → "Businesses".

🤖 Generated with [Claude Code](https://claude.com/claude-code)