### PR TITLE
World model: exit graph (map_graph) + worldmap layer (city.txt / worldmap.txt)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -835,9 +835,11 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
    the quest's gvar → name via `gvars`, then `describe_script` for the scripts that touch it).
    Deliberately still **not** a computed "critical path to the ending": `.ssl` is imperative quest
    logic and static extraction of a win-path would be brittle. The MCP supplies ground truth; the
-   model infers the route. The `endings` tool (endgame.txt: gvar==value → ending slide) now supplies
-   the win-conditions too, so the start→objectives→ending loop is readable end to end; a game-start
-   marker (fold into world_map) is the small remaining piece.
+   model infers the route. The `endings` tool (endgame.txt: gvar==value → ending slide) supplies the
+   win-conditions, `world_map.start` marks the entry map (artemple.map / Arroyo), and `find_gvar` gives
+   the causal link — a quest's gvar → the .ssl scripts that set it (the action that advances it) vs
+   check it — so the start→objectives→ending loop is readable end to end (quest → gvar → find_gvar →
+   describe_script).
 
 ### Data-extraction roadmap (engine data files → vault readers)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -823,9 +823,10 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
 7b. **Worldmap layer — `world_map` (city.txt). ✅ Done.** The inter-city layer `map_graph` doesn't
    cover: a vault `CityTxt` reader (`data/city.txt`) → areas (name, `world_pos`, size, known-at-start,
    the maps each contains via its entrances) + the straight-line distance between every pair of areas.
-   This is the actual "map of the world + distances between places." **Follow-ups:** `worldmap.msg`
-   for localized area names; `worldmap.txt` for terrain + random-encounter tables (so distances can be
-   terrain-weighted travel cost, not just straight-line) — the big, complex one.
+   This is the actual "map of the world + distances between places." Terrain types + encounter group
+   tables are now also covered (`worldmap.txt` → `world_encounters`). **Remaining:** the `worldmap.txt`
+   `[Tile NN]` sub-tile grid (per-position terrain → terrain-weighted travel cost, geographic
+   encounter placement) and `worldmap.msg` localized names.
 
 8. **Corpus / world index — evidence, not a solver.** Join, across all maps, the connectivity graph
    + each map's scripts (`describe_script` source/dialog) + the quest/gvar data (below) into one
@@ -848,11 +849,14 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
   graph into a *quest* graph, since the gvar links a quest to the scripts that set it.
 - **`data/city.txt`** ✅ **done** — `CityTxt` vault reader + the `world_map` tool (areas, world
   positions, sizes, the maps each area contains, pairwise distances). The inter-city layer.
-- **`data/worldmap.txt`** *(follow-up, large)* — worldmap tiles, terrain and random-encounter tables.
-  Lets the `world_map` distances become terrain-weighted travel cost instead of straight-line, and
-  surfaces the encounter tables. Complex (big encounter/tile tables) — its own effort.
-- **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain names to enrich `world_map`
-  (city.txt's `area_name` is the internal label).
+- **`data/worldmap.txt`** ✅ **partly done** — `WorldmapTxt` vault reader + the `world_encounters`
+  tool cover the `[Data]` terrain types and the `[Encounter: NAME]` group tables (region-prefixed, so
+  they map to areas). **Still deferred (large):** the `[Tile NN]` sub-tile grid (per-position terrain
+  + encounter placement), which would let `world_map` distances become terrain-weighted travel cost
+  and place encounters geographically.
+- **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain/encounter names to enrich
+  `world_map` / `world_encounters` (city.txt `area_name` and the encounter section names are the
+  internal labels).
 - **`data/endgame.txt` / `enddeath.txt`** — ending slides and their gvar/condition triggers: the
   literal "how the game ends" for the corpus angle.
 - **`data/party.txt`** (companions), **`holodisk.txt`**, **`karmavar.txt`** — lore/state, lower

--- a/PLAN.md
+++ b/PLAN.md
@@ -828,12 +828,15 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
    `[Tile NN]` sub-tile grid (per-position terrain → terrain-weighted travel cost, geographic
    encounter placement) and `worldmap.msg` localized names.
 
-8. **Corpus / world index — evidence, not a solver.** Join, across all maps, the connectivity graph
-   + each map's scripts (`describe_script` source/dialog) + the quest/gvar data (below) into one
-   queryable index, so the agent can *reason* about progression ("which script sets the gvar that
-   gates map Y?"). Deliberately **not** a computed "critical path to the ending": `.ssl` is
-   imperative quest logic and static extraction of a win-path would be brittle and over-claim. The
-   MCP supplies ground truth; the model infers the route. (Expands the "Corpus angle" note above.)
+8. **Corpus / world index — evidence, not a solver.** The evidence layer now largely exists: the
+   `map_graph`↔`world_map` join (`area`/`mapFile`/`lookupName`), the `quests` tool (each quest's area +
+   tracking gvar + thresholds + text) and the `gvars` dictionary (gvar index → `GVAR_*` name) — so an
+   agent can already *reason* about progression ("which script sets the gvar that gates quest Y?": read
+   the quest's gvar → name via `gvars`, then `describe_script` for the scripts that touch it).
+   Deliberately still **not** a computed "critical path to the ending": `.ssl` is imperative quest
+   logic and static extraction of a win-path would be brittle. The MCP supplies ground truth; the
+   model infers the route. **Remaining for the full loop:** an `endings` tool (endgame.txt: gvar==value
+   → ending) so the agent has the win-conditions, and a game-start marker.
 
 ### Data-extraction roadmap (engine data files → vault readers)
 
@@ -844,9 +847,15 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
   `map.msg[mapIndex*3 + elevation + 200]`; city names = `map.msg[1500 + city]`. Gives each map (and
   every `destMap` exit) a friendly per-elevation name ("Arroyo", "Temple of Trials") alongside the
   `.map` filename `MapsTxt` already resolves. Pairs directly with `MapsTxt`.
-- **`data/quests.txt` + `game/quests.msg`** *(the progression spine).* Each quest's location, the
-  **gvar** that tracks it, and its description text — this is what turns capability 8 from a map
-  graph into a *quest* graph, since the gvar links a quest to the scripts that set it.
+- **`data/quests.txt` + `game/quests.msg`** ✅ **done** — `QuestsTxt` vault reader + the `quests` tool:
+  each quest's area (map.msg location name), tracking **gvar** (index + `GVAR_*` name + default via
+  vault13.gam), display/completed thresholds, and quests.msg description. The progression spine.
+- **`data/vault13.gam` global variables** ✅ **done** — the `gvars` tool (gvar index → `GVAR_*` name +
+  default), reusing the `Gam` reader (fixed to read negative-default gvars, which were shifting
+  ordinals). The dictionary that makes quests and scripts legible.
+- **map_graph ↔ world_map join** ✅ **done** — `MapsTxt::findByLookupName` + `MapNameResolver`; world_map
+  entrances carry `mapFile` and map_graph nodes carry `area` + `lookupName`, so the world layer and the
+  exit-grid layer cross-reference in both directions.
 - **`data/city.txt`** ✅ **done** — `CityTxt` vault reader + the `world_map` tool (areas, world
   positions, sizes, the maps each area contains, pairwise distances). The inter-city layer.
 - **`data/worldmap.txt`** ✅ **partly done** — `WorldmapTxt` vault reader + the `world_encounters`
@@ -857,8 +866,10 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
 - **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain/encounter names to enrich
   `world_map` / `world_encounters` (city.txt `area_name` and the encounter section names are the
   internal labels).
-- **`data/endgame.txt` / `enddeath.txt`** — ending slides and their gvar/condition triggers: the
-  literal "how the game ends" for the corpus angle.
+- **`data/endgame.txt` / `enddeath.txt`** *(next — the win-condition table)* — ending slides keyed by
+  `gvar==value`. Now that the `gvars` dictionary exists, an `endings` tool can render each condition
+  human-readably ("how the game / each town ends"). `enddeath.txt` lives in master.dat (a VFS path,
+  not loose). This is the natural next step to close the start→objectives→ending loop.
 - **`data/party.txt`** (companions), **`holodisk.txt`**, **`karmavar.txt`** — lore/state, lower
   priority.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -812,11 +812,20 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
    context. *Lower priority when the agent already has filesystem/grep tools — then just mounting the
    source is enough; this earns its keep specifically for headless/sandboxed agents.*
 
-7. **Whole-game map-connectivity graph — `map_graph`.** Walk every shipped map, collect the exit
-   grids (already `{destMap, destMapName, destHex, destElevation}`) into a directed map→map graph;
-   cross with `reachability` to flag one-way edges and unreachable maps. The foundation is in
-   (`exitsToJson` + `MapsTxt`). Answers "how is the world wired" and, spatially, "can the player get
-   from the first map to map X" — bounded, buildable, high value.
+7. **Exit-grid connectivity graph — `map_graph`. ✅ Done.** Walks every map's exit grids into a
+   directed map→map graph (`{destMap, destMapName, destHex, destElevation}` + a per-edge hex count),
+   with stats flagging dead-ends and maps with no incoming edge. **Scope correction:** this is only
+   the exit-grid layer — how a *location's* maps link (intramap elevation changes + intermap edges
+   within a town) and where they hand off to the world map (`kind=worldmap`). It is **not** inter-city
+   travel; cities are crossed on the world map, so the graph is connected only within a location.
+   Follow-up: cross with `reachability` to flag one-way edges.
+
+7b. **Worldmap layer — `world_map` (city.txt). ✅ Done.** The inter-city layer `map_graph` doesn't
+   cover: a vault `CityTxt` reader (`data/city.txt`) → areas (name, `world_pos`, size, known-at-start,
+   the maps each contains via its entrances) + the straight-line distance between every pair of areas.
+   This is the actual "map of the world + distances between places." **Follow-ups:** `worldmap.msg`
+   for localized area names; `worldmap.txt` for terrain + random-encounter tables (so distances can be
+   terrain-weighted travel cost, not just straight-line) — the big, complex one.
 
 8. **Corpus / world index — evidence, not a solver.** Join, across all maps, the connectivity graph
    + each map's scripts (`describe_script` source/dialog) + the quest/gvar data (below) into one
@@ -837,9 +846,13 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
 - **`data/quests.txt` + `game/quests.msg`** *(the progression spine).* Each quest's location, the
   **gvar** that tracks it, and its description text — this is what turns capability 8 from a map
   graph into a *quest* graph, since the gvar links a quest to the scripts that set it.
-- **`data/city.txt`** — worldmap areas/towns and their map entrances; bridges the worldmap to the
-  per-map exit graph (capability 7).
-- **`data/worldmap.txt`** — worldmap tiles, terrain and random-encounter tables (the macro layer).
+- **`data/city.txt`** ✅ **done** — `CityTxt` vault reader + the `world_map` tool (areas, world
+  positions, sizes, the maps each area contains, pairwise distances). The inter-city layer.
+- **`data/worldmap.txt`** *(follow-up, large)* — worldmap tiles, terrain and random-encounter tables.
+  Lets the `world_map` distances become terrain-weighted travel cost instead of straight-line, and
+  surfaces the encounter tables. Complex (big encounter/tile tables) — its own effort.
+- **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain names to enrich `world_map`
+  (city.txt's `area_name` is the internal label).
 - **`data/endgame.txt` / `enddeath.txt`** — ending slides and their gvar/condition triggers: the
   literal "how the game ends" for the corpus angle.
 - **`data/party.txt`** (companions), **`holodisk.txt`**, **`karmavar.txt`** — lore/state, lower

--- a/PLAN.md
+++ b/PLAN.md
@@ -835,8 +835,9 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
    the quest's gvar → name via `gvars`, then `describe_script` for the scripts that touch it).
    Deliberately still **not** a computed "critical path to the ending": `.ssl` is imperative quest
    logic and static extraction of a win-path would be brittle. The MCP supplies ground truth; the
-   model infers the route. **Remaining for the full loop:** an `endings` tool (endgame.txt: gvar==value
-   → ending) so the agent has the win-conditions, and a game-start marker.
+   model infers the route. The `endings` tool (endgame.txt: gvar==value → ending slide) now supplies
+   the win-conditions too, so the start→objectives→ending loop is readable end to end; a game-start
+   marker (fold into world_map) is the small remaining piece.
 
 ### Data-extraction roadmap (engine data files → vault readers)
 
@@ -866,10 +867,12 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
 - **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain/encounter names to enrich
   `world_map` / `world_encounters` (city.txt `area_name` and the encounter section names are the
   internal labels).
-- **`data/endgame.txt` / `enddeath.txt`** *(next — the win-condition table)* — ending slides keyed by
-  `gvar==value`. Now that the `gvars` dictionary exists, an `endings` tool can render each condition
-  human-readably ("how the game / each town ends"). `enddeath.txt` lives in master.dat (a VFS path,
-  not loose). This is the natural next step to close the start→objectives→ending loop.
+- **`data/endgame.txt`** ✅ **done** — `EndgameTxt` vault reader + the `endings` tool: each ending slide
+  keyed by `gvar == value` (gvar resolved to its `GVAR_ENDGAME_MOVIE_*` name + a readable condition),
+  the slide art, and the narrator/subtitle base name. Slides sharing a gvar at different values are a
+  location's branching outcomes (e.g. Gecko has 5). Closes the start→objectives→ending loop with quests
+  + gvars. **Follow-ups:** `enddeath.txt` death endings (in master.dat) and the narration subtitle text
+  (`text/<lang>/cuts/<narrator>.txt`).
 - **`data/party.txt`** (companions), **`holodisk.txt`**, **`karmavar.txt`** — lore/state, lower
   priority.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -861,11 +861,12 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
   exit-grid layer cross-reference in both directions.
 - **`data/city.txt`** ✅ **done** — `CityTxt` vault reader + the `world_map` tool (areas, world
   positions, sizes, the maps each area contains, pairwise distances). The inter-city layer.
-- **`data/worldmap.txt`** ✅ **partly done** — `WorldmapTxt` vault reader + the `world_encounters`
-  tool cover the `[Data]` terrain types and the `[Encounter: NAME]` group tables (region-prefixed, so
-  they map to areas). **Still deferred (large):** the `[Tile NN]` sub-tile grid (per-position terrain
-  + encounter placement), which would let `world_map` distances become terrain-weighted travel cost
-  and place encounters geographically.
+- **`data/worldmap.txt`** ✅ **done** — `WorldmapTxt` vault reader + the `world_encounters` tool
+  (`[Data]` terrain types — `difficulty`, not "weight" — and `[Encounter: NAME]` group tables) **and**
+  the `[Tile NN]` sub-tile grid: `WorldmapTxt::terrainAt(x,y)` mirrors the engine's
+  `wmFindCurSubTileFromPos`, so `world_map` now reports each area's `terrain` and a terrain-weighted
+  `travelCost` between areas. **Follow-up (minor):** per-position *encounter* placement (the subtile
+  encounter chances) is still unparsed — only the terrain field is kept.
 - **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain/encounter names to enrich
   `world_map` / `world_encounters` (city.txt `area_name` and the encounter section names are the
   internal labels).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -610,7 +610,9 @@ if(GECK_BUILD_CLI)
         cli/Quests.h
         cli/Quests.cpp
         cli/Endings.h
-        cli/Endings.cpp)
+        cli/Endings.cpp
+        cli/GvarRefs.h
+        cli/GvarRefs.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,6 +317,7 @@ add_library(vault STATIC
     # Parser superclass
     reader/FileParser.h
     reader/TextParsing.h
+    reader/IniParser.h
     reader/ReaderFactory.h
     reader/ReaderFactory.cpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,6 +283,9 @@ add_library(vault STATIC
     # Maps (maps.txt — the engine's index->map registry)
     format/maps/MapsTxt.h
 
+    # City (city.txt — worldmap areas / locations)
+    format/city/CityTxt.h
+
     # PRO
     format/pro/Pro.h
     format/pro/Pro.cpp
@@ -340,6 +343,9 @@ add_library(vault STATIC
 
     reader/maps/MapsTxtReader.h
     reader/maps/MapsTxtReader.cpp
+
+    reader/city/CityTxtReader.h
+    reader/city/CityTxtReader.cpp
 
     reader/pro/ProReader.h
     reader/pro/ProReader.cpp
@@ -574,7 +580,9 @@ if(GECK_BUILD_CLI)
         cli/MapDescribe.h
         cli/MapDescribe.cpp
         cli/MapGraph.h
-        cli/MapGraph.cpp)
+        cli/MapGraph.cpp
+        cli/WorldMap.h
+        cli/WorldMap.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,9 @@ add_library(vault STATIC
     # Worldmap (worldmap.txt — terrain types + encounter tables)
     format/worldmap/WorldmapTxt.h
 
+    # Quests (quests.txt — the quest registry)
+    format/quests/QuestsTxt.h
+
     # PRO
     format/pro/Pro.h
     format/pro/Pro.cpp
@@ -353,6 +356,9 @@ add_library(vault STATIC
 
     reader/worldmap/WorldmapTxtReader.h
     reader/worldmap/WorldmapTxtReader.cpp
+
+    reader/quests/QuestsTxtReader.h
+    reader/quests/QuestsTxtReader.cpp
 
     reader/pro/ProReader.h
     reader/pro/ProReader.cpp
@@ -591,7 +597,12 @@ if(GECK_BUILD_CLI)
         cli/WorldMap.h
         cli/WorldMap.cpp
         cli/WorldEncounters.h
-        cli/WorldEncounters.cpp)
+        cli/WorldEncounters.cpp
+        cli/ConfigLoad.h
+        cli/GlobalVars.h
+        cli/GlobalVars.cpp
+        cli/Quests.h
+        cli/Quests.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -286,6 +286,9 @@ add_library(vault STATIC
     # City (city.txt — worldmap areas / locations)
     format/city/CityTxt.h
 
+    # Worldmap (worldmap.txt — terrain types + encounter tables)
+    format/worldmap/WorldmapTxt.h
+
     # PRO
     format/pro/Pro.h
     format/pro/Pro.cpp
@@ -346,6 +349,9 @@ add_library(vault STATIC
 
     reader/city/CityTxtReader.h
     reader/city/CityTxtReader.cpp
+
+    reader/worldmap/WorldmapTxtReader.h
+    reader/worldmap/WorldmapTxtReader.cpp
 
     reader/pro/ProReader.h
     reader/pro/ProReader.cpp
@@ -582,7 +588,9 @@ if(GECK_BUILD_CLI)
         cli/MapGraph.h
         cli/MapGraph.cpp
         cli/WorldMap.h
-        cli/WorldMap.cpp)
+        cli/WorldMap.cpp
+        cli/WorldEncounters.h
+        cli/WorldEncounters.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -572,7 +572,9 @@ if(GECK_BUILD_CLI)
         cli/MapReachability.h
         cli/MapReachability.cpp
         cli/MapDescribe.h
-        cli/MapDescribe.cpp)
+        cli/MapDescribe.cpp
+        cli/MapGraph.h
+        cli/MapGraph.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -292,6 +292,9 @@ add_library(vault STATIC
     # Quests (quests.txt — the quest registry)
     format/quests/QuestsTxt.h
 
+    # Endgame (endgame.txt — the ending slideshow win-condition table)
+    format/endgame/EndgameTxt.h
+
     # PRO
     format/pro/Pro.h
     format/pro/Pro.cpp
@@ -359,6 +362,9 @@ add_library(vault STATIC
 
     reader/quests/QuestsTxtReader.h
     reader/quests/QuestsTxtReader.cpp
+
+    reader/endgame/EndgameTxtReader.h
+    reader/endgame/EndgameTxtReader.cpp
 
     reader/pro/ProReader.h
     reader/pro/ProReader.cpp
@@ -602,7 +608,9 @@ if(GECK_BUILD_CLI)
         cli/GlobalVars.h
         cli/GlobalVars.cpp
         cli/Quests.h
-        cli/Quests.cpp)
+        cli/Quests.cpp
+        cli/Endings.h
+        cli/Endings.cpp)
     target_link_libraries(gecko_cli PUBLIC gecko::editing nlohmann_json::nlohmann_json)
 
     add_executable(gecko-cli cli/main.cpp)

--- a/src/cli/ConfigLoad.h
+++ b/src/cli/ConfigLoad.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <initializer_list>
+#include <string>
+
+#include "resource/GameResources.h"
+
+namespace geck::cli {
+
+/// Load a Fallout text config (maps.txt / city.txt / worldmap.txt / quests.txt …) by trying each
+/// candidate VFS path in turn and parsing the first that exists with `parse` (a callable taking the
+/// file text and returning T). Returns a default-constructed T when none is mounted, so callers
+/// degrade gracefully. One place for the "data/<x> then <x>, read bytes, parse" idiom the world
+/// tools share.
+template <typename T, typename Parse>
+T loadConfig(resource::GameResources& resources, std::initializer_list<const char*> paths, Parse parse) {
+    for (const char* path : paths) {
+        if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+            return parse(std::string(bytes->begin(), bytes->end()));
+        }
+    }
+    return T{};
+}
+
+} // namespace geck::cli

--- a/src/cli/Endings.cpp
+++ b/src/cli/Endings.cpp
@@ -1,0 +1,61 @@
+#include "cli/Endings.h"
+
+#include "cli/ConfigLoad.h"
+#include "cli/GlobalVars.h" // loadGameGam
+#include "format/endgame/EndgameTxt.h"
+#include "format/gam/Gam.h"
+#include "reader/endgame/EndgameTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    // GVAR_* name for a gvar index, or "" when out of range / no dictionary.
+    std::string gvarNameOf(Gam* gam, int gvar) {
+        if (gam == nullptr || gvar < 0 || static_cast<std::size_t>(gvar) >= gam->gvarCount()) {
+            return {};
+        }
+        return gam->gvarKey(gvar);
+    }
+
+} // namespace
+
+int buildEndings(resource::GameResources& resources, std::ostream& out) {
+    const EndgameTxt endgame = loadConfig<EndgameTxt>(resources, { "data/endgame.txt", "endgame.txt" },
+        [](const std::string& text) { return parseEndgameTxt(text); });
+    if (endgame.endings.empty()) {
+        out << "{\"endings\":[],\"stats\":{\"endings\":0}}\n";
+        return 1;
+    }
+
+    Gam* gam = loadGameGam(resources); // gvar name dictionary (may be null)
+
+    auto array = ordered_json::array();
+    for (const Ending& ending : endgame.endings) {
+        const std::string name = gvarNameOf(gam, ending.gvar);
+        const std::string condition = (name.empty() ? ("gvar " + std::to_string(ending.gvar)) : name)
+            + " == " + std::to_string(ending.value);
+        array.push_back({ { "gvar", ending.gvar },
+            { "gvarName", name.empty() ? ordered_json(nullptr) : ordered_json(name) },
+            { "value", ending.value }, { "condition", condition },
+            { "art", ending.art }, { "narrator", ending.narrator },
+            { "direction", ending.direction } });
+    }
+
+    ordered_json root;
+    root["endings"] = std::move(array);
+    root["stats"] = { { "endings", endgame.endings.size() } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/Endings.h
+++ b/src/cli/Endings.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// The endgame slideshow's win-condition table, from data/endgame.txt: each slide with the global
+/// variable + value that triggers it ('gvar' + 'gvarName' via vault13.gam + 'value', plus a readable
+/// 'condition' string), the slide image ('art'), and the narrator/subtitle base name ('narrator').
+/// Slides sharing a gvar at different values are a location's branching outcomes — so this is "what
+/// world state must be reached for each ending." Closes the start→objectives→ending loop with the
+/// quests and gvars tools. Emits a JSON object to `out`; returns 0 on success, non-zero if
+/// endgame.txt isn't mounted.
+int buildEndings(resource::GameResources& resources, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/GlobalVars.cpp
+++ b/src/cli/GlobalVars.cpp
@@ -1,0 +1,49 @@
+#include "cli/GlobalVars.h"
+
+#include "format/gam/Gam.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <ostream>
+
+namespace geck::cli {
+
+namespace {
+    using ordered_json = nlohmann::ordered_json;
+}
+
+Gam* loadGameGam(resource::GameResources& resources) {
+    for (const char* path : { "data/vault13.gam", "vault13.gam" }) {
+        try {
+            if (Gam* gam = resources.repository().load<Gam>(path); gam != nullptr) {
+                return gam;
+            }
+        } catch (const std::exception&) {
+            // try the next candidate path
+        }
+    }
+    return nullptr;
+}
+
+int buildGlobalVars(resource::GameResources& resources, std::ostream& out) {
+    Gam* gam = loadGameGam(resources);
+    if (gam == nullptr || gam->gvarCount() == 0) {
+        out << "{\"gvars\":[],\"stats\":{\"count\":0}}\n";
+        return 1;
+    }
+
+    auto gvars = ordered_json::array();
+    for (std::size_t i = 0; i < gam->gvarCount(); ++i) {
+        gvars.push_back({ { "index", i }, { "name", gam->gvarKey(i) }, { "default", gam->gvarValue(i) } });
+    }
+
+    ordered_json root;
+    root["gvars"] = std::move(gvars);
+    root["stats"] = { { "count", gam->gvarCount() } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/GlobalVars.h
+++ b/src/cli/GlobalVars.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace geck {
+class Gam;
+}
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// Load data/vault13.gam (the GAME_GLOBAL_VARS dictionary) through the repository cache, or nullptr
+/// if it isn't mounted. Shared by the gvars tool and the quests tool (gvar name/default resolution).
+Gam* loadGameGam(resource::GameResources& resources);
+
+/// The global-variable dictionary, from data/vault13.gam: every GVAR by index → name + default
+/// value. Global variables are the engine's progression state machine, so this lets an agent decode
+/// a gvar index (from quests, scripts, or endings) to its GVAR_* name. Emits a JSON object to `out`;
+/// returns 0 on success, non-zero if vault13.gam isn't mounted.
+int buildGlobalVars(resource::GameResources& resources, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/GvarRefs.cpp
+++ b/src/cli/GvarRefs.cpp
@@ -6,6 +6,8 @@
 #include <nlohmann/json.hpp>
 
 #include <cctype>
+#include <filesystem>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -48,10 +50,11 @@ namespace {
         int lineNo = 0;
         while (std::getline(stream, line)) {
             ++lineNo;
-            if (!referencesWord(line, gvarName)) {
+            const std::string code = line.substr(0, line.find("//")); // ignore // line comments
+            if (!referencesWord(code, gvarName)) {
                 continue;
             }
-            const bool isSet = line.find("set_global_var") != std::string::npos;
+            const bool isSet = code.find("set_global_var") != std::string::npos;
             if (isSet) {
                 ++setters;
             }
@@ -63,6 +66,22 @@ namespace {
             }
         }
         return true;
+    }
+
+    // The source text of `path` if it is a scannable script (.ssl/.h) and readable, else nullopt.
+    // Headers are included because many gvars are only touched via macro aliases defined there.
+    std::optional<std::string> readScript(resource::GameResources& resources, const std::filesystem::path& path) {
+        std::string ext = path.extension().string();
+        std::ranges::transform(ext, ext.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (ext != ".ssl" && ext != ".h") {
+            return std::nullopt;
+        }
+        const auto bytes = resources.files().readRawBytes(path);
+        if (!bytes.has_value()) {
+            return std::nullopt;
+        }
+        return std::string(bytes->begin(), bytes->end());
     }
 
 } // namespace
@@ -77,21 +96,16 @@ int findGvarRefs(resource::GameResources& resources, const std::string& gvarName
     int setters = 0;
     std::set<std::string> scripts;
     bool capped = false;
+    bool scannedAny = false; // did we read at least one source file?
 
     try {
         for (const auto& path : resources.files().list("*")) {
-            std::string ext = path.extension().string();
-            std::ranges::transform(ext, ext.begin(),
-                [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-            if (ext != ".ssl") {
+            const auto text = readScript(resources, path);
+            if (!text.has_value()) {
                 continue;
             }
-            const auto bytes = resources.files().readRawBytes(path);
-            if (!bytes.has_value()) {
-                continue;
-            }
-            if (!scanScript(std::string(bytes->begin(), bytes->end()), gvarName, baseName(path.generic_string()),
-                    refs, setters, scripts)) {
+            scannedAny = true;
+            if (!scanScript(*text, gvarName, baseName(path.generic_string()), refs, setters, scripts)) {
                 capped = true;
                 break;
             }
@@ -103,7 +117,9 @@ int findGvarRefs(resource::GameResources& resources, const std::string& gvarName
     if (refs.empty()) {
         out << "{\"gvar\":" << ordered_json(gvarName).dump()
             << ",\"refs\":[],\"stats\":{\"refs\":0,\"setters\":0,\"scripts\":0}}\n";
-        return 1; // unused, or no .ssl source tree mounted
+        // scanned sources but found nothing = a valid "unused" answer (success); nothing scanned =
+        // no source tree mounted (error, so the MCP flags isError).
+        return scannedAny ? 0 : 1;
     }
 
     ordered_json root;

--- a/src/cli/GvarRefs.cpp
+++ b/src/cli/GvarRefs.cpp
@@ -1,0 +1,118 @@
+#include "cli/GvarRefs.h"
+
+#include "reader/TextParsing.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cctype>
+#include <set>
+#include <sstream>
+#include <string>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    constexpr std::size_t kMaxRefs = 400; // cap output so a common gvar can't flood the response
+
+    std::string baseName(const std::string& path) {
+        const auto slash = path.find_last_of("/\\");
+        return slash == std::string::npos ? path : path.substr(slash + 1);
+    }
+
+    bool isWordChar(char c) {
+        return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_';
+    }
+
+    // Does `name` occur in `line` as a whole identifier (not a substring of a longer name)?
+    bool referencesWord(const std::string& line, const std::string& name) {
+        for (auto pos = line.find(name); pos != std::string::npos; pos = line.find(name, pos + 1)) {
+            const bool leftOk = pos == 0 || !isWordChar(line[pos - 1]);
+            const bool rightOk = pos + name.size() >= line.size() || !isWordChar(line[pos + name.size()]);
+            if (leftOk && rightOk) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Scan one script's text for whole-word references to `gvarName`, appending one ref per matching
+    // line. Returns false once the global cap is reached.
+    bool scanScript(const std::string& text, const std::string& gvarName, const std::string& script,
+        ordered_json& refs, int& setters, std::set<std::string>& scripts) {
+        std::istringstream stream(text);
+        std::string line;
+        int lineNo = 0;
+        while (std::getline(stream, line)) {
+            ++lineNo;
+            if (!referencesWord(line, gvarName)) {
+                continue;
+            }
+            const bool isSet = line.find("set_global_var") != std::string::npos;
+            if (isSet) {
+                ++setters;
+            }
+            scripts.insert(script);
+            refs.push_back({ { "script", script }, { "line", lineNo },
+                { "kind", isSet ? "set" : "get" }, { "text", geck::text::trim(line) } });
+            if (refs.size() >= kMaxRefs) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+} // namespace
+
+int findGvarRefs(resource::GameResources& resources, const std::string& gvarName, std::ostream& out) {
+    if (gvarName.empty()) {
+        out << "{\"gvar\":\"\",\"refs\":[],\"stats\":{\"refs\":0,\"setters\":0,\"scripts\":0}}\n";
+        return 1; // an empty name would match every line
+    }
+
+    auto refs = ordered_json::array();
+    int setters = 0;
+    std::set<std::string> scripts;
+    bool capped = false;
+
+    try {
+        for (const auto& path : resources.files().list("*")) {
+            std::string ext = path.extension().string();
+            std::ranges::transform(ext, ext.begin(),
+                [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            if (ext != ".ssl") {
+                continue;
+            }
+            const auto bytes = resources.files().readRawBytes(path);
+            if (!bytes.has_value()) {
+                continue;
+            }
+            if (!scanScript(std::string(bytes->begin(), bytes->end()), gvarName, baseName(path.generic_string()),
+                    refs, setters, scripts)) {
+                capped = true;
+                break;
+            }
+        }
+    } catch (const std::exception&) {
+        // no data / source tree mounted -> empty result below
+    }
+
+    if (refs.empty()) {
+        out << "{\"gvar\":" << ordered_json(gvarName).dump()
+            << ",\"refs\":[],\"stats\":{\"refs\":0,\"setters\":0,\"scripts\":0}}\n";
+        return 1; // unused, or no .ssl source tree mounted
+    }
+
+    ordered_json root;
+    root["gvar"] = gvarName;
+    root["refs"] = std::move(refs);
+    root["stats"] = { { "refs", root["refs"].size() }, { "setters", setters },
+        { "scripts", scripts.size() }, { "capped", capped } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/GvarRefs.h
+++ b/src/cli/GvarRefs.h
@@ -9,16 +9,19 @@ class GameResources;
 
 namespace geck::cli {
 
-/// Find where a global variable is used in the mounted .ssl script sources: every script that reads
-/// or writes `gvarName`, with the line number, the source line, and whether it is a 'set'
+/// Find where a global variable is used in the mounted .ssl / .h script sources: every script that
+/// reads or writes `gvarName`, with the line number, the source line, and whether it is a 'set'
 /// (set_global_var — the in-game action that advances/gates a quest) or a 'get' (a condition check).
+/// Headers are scanned too because many gvars are only ever touched through macro aliases there
+/// (e.g. caravan.h `#define set_caravan_brahmin(x) set_global_var(GVAR_CARAVAN_BRAHMIN_TOTAL,x)`);
+/// `//` line comments are ignored.
 ///
 /// This is the causal link the other tools point to: a quest's gvar (from `quests`) → the scripts
 /// that change it → `describe_script` for the dialogue/logic behind it. Needs a script-source tree
 /// (e.g. the FRP `scripts_src`) mounted as a --data path — compiled .int scripts carry no names.
 ///
-/// Emits a JSON object to `out`; returns 0 on success, non-zero if no sources are mounted or the gvar
-/// is never referenced.
+/// Emits a JSON object to `out`. Returns 0 on success — including the valid "gvar is unused" case when
+/// sources were scanned — and non-zero only when no .ssl/.h source tree is mounted.
 int findGvarRefs(resource::GameResources& resources, const std::string& gvarName, std::ostream& out);
 
 } // namespace geck::cli

--- a/src/cli/GvarRefs.h
+++ b/src/cli/GvarRefs.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// Find where a global variable is used in the mounted .ssl script sources: every script that reads
+/// or writes `gvarName`, with the line number, the source line, and whether it is a 'set'
+/// (set_global_var — the in-game action that advances/gates a quest) or a 'get' (a condition check).
+///
+/// This is the causal link the other tools point to: a quest's gvar (from `quests`) → the scripts
+/// that change it → `describe_script` for the dialogue/logic behind it. Needs a script-source tree
+/// (e.g. the FRP `scripts_src`) mounted as a --data path — compiled .int scripts carry no names.
+///
+/// Emits a JSON object to `out`; returns 0 on success, non-zero if no sources are mounted or the gvar
+/// is never referenced.
+int findGvarRefs(resource::GameResources& resources, const std::string& gvarName, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -253,19 +253,9 @@ namespace {
         if (!options.maps.empty()) {
             return options.maps;
         }
-        const auto allFiles = files.list("*");
-        std::vector<std::string> mapPaths;
-        for (const auto& path : allFiles) {
-            std::string ext = path.extension().string();
-            std::ranges::transform(ext, ext.begin(),
-                [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-            if (ext == ".map") {
-                mapPaths.push_back(path.generic_string());
-            }
-        }
-        std::ranges::sort(mapPaths);
+        std::vector<std::string> mapPaths = listMapPaths(files);
         if (mapPaths.empty()) {
-            out << "No .map files found among " << allFiles.size() << " mounted files.\n";
+            out << "No .map files found in the mounted data.\n";
         }
         return mapPaths;
     }
@@ -720,21 +710,15 @@ namespace {
     // unknown). The map's connectivity, so an agent sees where each edge leads.
     ordered_json exitsToJson(Map& map, const resource::MapNameResolver& mapNames) {
         auto array = ordered_json::array();
-        for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
-            for (const auto& object : mapObjects) {
-                if (!object || !object->isExitGridMarker()) {
-                    continue;
-                }
-                const auto destMap = static_cast<int32_t>(object->exit_map);
-                const std::string file = mapNames.fileNameOf(destMap);
-                const std::string display = mapNames.displayName(destMap, object->exit_elevation);
-                array.push_back({ { "hex", object->position }, { "elevation", elevation },
-                    { "destMap", destMap },
-                    { "destMapName", file.empty() ? ordered_json(nullptr) : ordered_json(file) },
-                    { "destMapDisplayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
-                    { "destHex", static_cast<int32_t>(object->exit_position) },
-                    { "destElevation", object->exit_elevation }, { "orientation", object->exit_orientation } });
-            }
+        for (const MapExit& exit : collectMapExits(map)) {
+            const std::string file = mapNames.fileNameOf(exit.destMap);
+            const std::string display = mapNames.displayName(exit.destMap, exit.destElevation);
+            array.push_back({ { "hex", exit.srcHex }, { "elevation", exit.srcElevation },
+                { "destMap", exit.destMap },
+                { "destMapName", file.empty() ? ordered_json(nullptr) : ordered_json(file) },
+                { "destMapDisplayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
+                { "destHex", exit.destHex },
+                { "destElevation", exit.destElevation }, { "orientation", exit.orientation } });
         }
         return array;
     }
@@ -814,6 +798,37 @@ namespace {
     }
 
 } // namespace
+
+std::vector<MapExit> collectMapExits(Map& map) {
+    std::vector<MapExit> exits;
+    for (const auto& [elevation, mapObjects] : map.getMapFile().map_objects) {
+        for (const auto& object : mapObjects) {
+            if (!object || !object->isExitGridMarker()) {
+                continue;
+            }
+            exits.push_back({ static_cast<int>(object->position), static_cast<int>(elevation),
+                static_cast<int>(object->exit_map), static_cast<int>(object->exit_position),
+                static_cast<int>(object->exit_elevation), static_cast<int>(object->exit_orientation) });
+        }
+    }
+    return exits;
+}
+
+std::vector<std::string> listMapPaths(const resource::DataFileSystem& files) {
+    // List everything and keep the .map files, case-insensitively — more robust than a glob against
+    // the raw VFS keys (whose case and leading "/" depend on the DAT/mount).
+    std::vector<std::string> mapPaths;
+    for (const auto& path : files.list("*")) {
+        std::string ext = path.extension().string();
+        std::ranges::transform(ext, ext.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (ext == ".map") {
+            mapPaths.push_back(path.generic_string());
+        }
+    }
+    std::ranges::sort(mapPaths);
+    return mapPaths;
+}
 
 int analyzeMaps(resource::GameResources& resources, const AnalyzeOptions& options, std::ostream& out) {
     const std::vector<std::string> mapPaths = collectMapPaths(resources.files(), options, out);

--- a/src/cli/MapAnalyzer.h
+++ b/src/cli/MapAnalyzer.h
@@ -4,11 +4,35 @@
 #include <string>
 #include <vector>
 
+namespace geck {
+class Map;
+}
+
 namespace geck::resource {
 class GameResources;
+class DataFileSystem;
 }
 
 namespace geck::cli {
+
+// One exit-grid marker's link: where it sits (srcHex on srcElevation) and where it leads (destMap is
+// a maps.txt index, or the -1 town / -2 worldmap sentinels). The raw data behind analyze's `exits`
+// and the map_graph connectivity tool.
+struct MapExit {
+    int srcHex = 0;
+    int srcElevation = 0;
+    int destMap = 0;
+    int destHex = 0;
+    int destElevation = 0;
+    int orientation = 0;
+};
+
+// Every exit-grid marker in the map, across elevations. Shared by analyze (named per-exit JSON) and
+// the map_graph tool (cross-map connectivity).
+std::vector<MapExit> collectMapExits(Map& map);
+
+// All ".map" paths under the mounted data (sorted, case-insensitive match), e.g. "maps/arroyo.map".
+std::vector<std::string> listMapPaths(const resource::DataFileSystem& files);
 
 struct AnalyzeOptions {
     // Maps to analyse (VFS paths, e.g. "maps/arroyo.map"). Empty = every map under maps/ in the

--- a/src/cli/MapGraph.cpp
+++ b/src/cli/MapGraph.cpp
@@ -1,8 +1,11 @@
 #include "cli/MapGraph.h"
 
+#include "cli/ConfigLoad.h"
 #include "cli/MapAnalyzer.h" // collectMapExits, listMapPaths, MapExit
 #include "cli/MapLoad.h"     // loadMap
+#include "format/city/CityTxt.h"
 #include "format/map/Map.h"
+#include "reader/city/CityTxtReader.h"
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 
@@ -51,6 +54,21 @@ namespace {
 
     using Nodes = std::map<std::string, NodeInfo>;
     using Edges = std::map<std::pair<std::string, std::string>, EdgeInfo>;
+
+    // .map filename -> owning worldmap area name, from city.txt entrances (resolved lookup_name ->
+    // file). Gives each map_graph node its area, the reverse of world_map's area.maps[].mapFile.
+    std::map<std::string, std::string> mapToArea(const CityTxt& city, const resource::MapNameResolver& names) {
+        std::map<std::string, std::string> areaOf;
+        for (const CityArea& area : city.areas) {
+            for (const CityEntrance& entrance : area.entrances) {
+                const std::string file = names.fileNameOfLookup(entrance.map);
+                if (!file.empty()) {
+                    areaOf.emplace(file, area.name); // first area wins if a map is shared
+                }
+            }
+        }
+        return areaOf;
+    }
 
     // Classify one exit's destination and fold it into the node/edge maps.
     void addExit(const resource::MapNameResolver& names, const std::string& fromFile, const MapExit& exit,
@@ -139,10 +157,16 @@ namespace {
             { "deadEnds", std::move(deadEnds) }, { "noIncoming", std::move(noIncoming) } };
     }
 
-    ordered_json graphToJson(const Nodes& nodes, const Edges& edges, int analysed) {
+    ordered_json graphToJson(const Nodes& nodes, const Edges& edges, int analysed,
+        const resource::MapNameResolver& names, const std::map<std::string, std::string>& areaOf) {
         auto nodesJson = ordered_json::array();
         for (const auto& [file, info] : nodes) {
-            nodesJson.push_back({ { "file", file }, { "displayName", orNull(info.displayName) }, { "analysed", info.analysed } });
+            const std::string lookupName = names.lookupNameOf(file); // maps.txt key (world_map's entrance name)
+            const auto area = areaOf.find(file);                     // owning city.txt area (the reverse join)
+            nodesJson.push_back({ { "file", file }, { "displayName", orNull(info.displayName) },
+                { "lookupName", orNull(lookupName) },
+                { "area", area != areaOf.end() ? ordered_json(area->second) : ordered_json(nullptr) },
+                { "analysed", info.analysed } });
         }
         auto edgesJson = ordered_json::array();
         for (const auto& [key, info] : edges) {
@@ -168,10 +192,13 @@ int buildMapGraph(resource::GameResources& resources, const MapGraphOptions& opt
         return 1;
     }
 
+    const CityTxt city = loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
+        [](const std::string& text) { return parseCityTxt(text); });
+    const std::map<std::string, std::string> areaOf = mapToArea(city, names);
     Nodes nodes;
     Edges edges;
     const int analysed = buildGraph(resources, names, mapPaths, nodes, edges);
-    out << graphToJson(nodes, edges, analysed).dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    out << graphToJson(nodes, edges, analysed, names, areaOf).dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
     return 0;
 }
 

--- a/src/cli/MapGraph.cpp
+++ b/src/cli/MapGraph.cpp
@@ -1,0 +1,178 @@
+#include "cli/MapGraph.h"
+
+#include "cli/MapAnalyzer.h" // collectMapExits, listMapPaths, MapExit
+#include "cli/MapLoad.h"     // loadMap
+#include "format/map/Map.h"
+#include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    std::string baseName(const std::string& path) {
+        const auto slash = path.find_last_of("/\\");
+        return slash == std::string::npos ? path : path.substr(slash + 1);
+    }
+
+    ordered_json orNull(const std::string& s) {
+        return s.empty() ? ordered_json(nullptr) : ordered_json(s);
+    }
+
+    // A map node: its friendly name, and whether we actually loaded it (vs only seeing it as an exit
+    // destination of another map).
+    struct NodeInfo {
+        std::string displayName;
+        bool analysed = false;
+    };
+
+    // An aggregated edge between two maps: how many exit hexes form it, the raw destination index, the
+    // destination's friendly name, and what kind of target it is (map / worldmap / townmap / unknown —
+    // an index with no maps.txt entry).
+    struct EdgeInfo {
+        int destMap = 0;
+        std::string toName;
+        std::string kind;
+        int exits = 0;
+    };
+
+    using Nodes = std::map<std::string, NodeInfo>;
+    using Edges = std::map<std::pair<std::string, std::string>, EdgeInfo>;
+
+    // Classify one exit's destination and fold it into the node/edge maps.
+    void addExit(const resource::MapNameResolver& names, const std::string& fromFile, const MapExit& exit,
+        Nodes& nodes, Edges& edges) {
+        std::string toKey;
+        std::string kind;
+        std::string toName;
+        if (exit.destMap == -2) { // ExitGrid::WORLD_MAP_EXIT
+            toKey = "<world map>";
+            kind = "worldmap";
+        } else if (exit.destMap == -1) { // ExitGrid::TOWN_MAP_EXIT
+            toKey = "<town map>";
+            kind = "townmap";
+        } else {
+            const std::string toFile = names.fileNameOf(exit.destMap);
+            toName = names.displayName(exit.destMap, exit.destElevation);
+            if (toFile.empty()) {
+                toKey = "<map " + std::to_string(exit.destMap) + ">";
+                kind = "unknown"; // a destination index with no maps.txt entry
+            } else {
+                toKey = toFile;
+                kind = "map";
+                NodeInfo& toNode = nodes[toFile]; // destinations are nodes too, even if not analysed
+                if (toNode.displayName.empty()) {
+                    toNode.displayName = toName;
+                }
+            }
+        }
+        EdgeInfo& edge = edges[{ fromFile, toKey }];
+        edge.destMap = exit.destMap;
+        edge.kind = kind;
+        if (edge.toName.empty()) {
+            edge.toName = toName;
+        }
+        ++edge.exits;
+    }
+
+    // Load each map and fold its exit grids into the node/edge maps; returns how many maps loaded.
+    int buildGraph(resource::GameResources& resources, const resource::MapNameResolver& names,
+        const std::vector<std::string>& mapPaths, Nodes& nodes, Edges& edges) {
+        int analysed = 0;
+        for (const auto& mapPath : mapPaths) {
+            const std::unique_ptr<Map> map = loadMap(resources, mapPath);
+            if (!map) {
+                continue; // unreadable maps simply don't appear as source nodes
+            }
+            const std::string fromFile = baseName(mapPath);
+            const int fromIndex = names.indexOf(fromFile);
+            NodeInfo& fromNode = nodes[fromFile];
+            fromNode.analysed = true;
+            if (fromNode.displayName.empty() && fromIndex >= 0) {
+                fromNode.displayName = names.displayName(fromIndex, 0);
+            }
+            ++analysed;
+            for (const MapExit& exit : collectMapExits(*map)) {
+                addExit(names, fromFile, exit, nodes, edges);
+            }
+        }
+        return analysed;
+    }
+
+    // Structural insight: which analysed maps have no outgoing / no incoming *map* edge.
+    ordered_json graphStats(const Nodes& nodes, const Edges& edges, int analysed) {
+        std::set<std::string> hasOutgoing;
+        std::set<std::string> hasIncoming;
+        for (const auto& [key, edge] : edges) {
+            if (edge.kind == "map") {
+                hasOutgoing.insert(key.first);
+                hasIncoming.insert(key.second);
+            }
+        }
+        auto deadEnds = ordered_json::array();   // analysed maps with no exit to another map
+        auto noIncoming = ordered_json::array(); // analysed maps no other map exits to (entry points / orphans)
+        for (const auto& [file, info] : nodes) {
+            if (!info.analysed) {
+                continue;
+            }
+            if (!hasOutgoing.contains(file)) {
+                deadEnds.push_back(file);
+            }
+            if (!hasIncoming.contains(file)) {
+                noIncoming.push_back(file);
+            }
+        }
+        return { { "maps", analysed }, { "nodes", nodes.size() }, { "edges", edges.size() },
+            { "deadEnds", std::move(deadEnds) }, { "noIncoming", std::move(noIncoming) } };
+    }
+
+    ordered_json graphToJson(const Nodes& nodes, const Edges& edges, int analysed) {
+        auto nodesJson = ordered_json::array();
+        for (const auto& [file, info] : nodes) {
+            nodesJson.push_back({ { "file", file }, { "displayName", orNull(info.displayName) }, { "analysed", info.analysed } });
+        }
+        auto edgesJson = ordered_json::array();
+        for (const auto& [key, info] : edges) {
+            edgesJson.push_back({ { "from", key.first }, { "to", key.second }, { "kind", info.kind },
+                { "destMap", info.destMap }, { "toName", orNull(info.toName) }, { "exits", info.exits } });
+        }
+        ordered_json root;
+        root["nodes"] = std::move(nodesJson);
+        root["edges"] = std::move(edgesJson);
+        root["stats"] = graphStats(nodes, edges, analysed);
+        return root;
+    }
+
+} // namespace
+
+int buildMapGraph(resource::GameResources& resources, const MapGraphOptions& options, std::ostream& out) {
+    const resource::MapNameResolver names(resources);
+
+    std::vector<std::string> mapPaths = options.maps.empty() ? listMapPaths(resources.files()) : options.maps;
+    std::ranges::sort(mapPaths);
+    if (mapPaths.empty()) {
+        out << "{\"nodes\":[],\"edges\":[],\"stats\":{\"maps\":0,\"nodes\":0,\"edges\":0}}\n";
+        return 1;
+    }
+
+    Nodes nodes;
+    Edges edges;
+    const int analysed = buildGraph(resources, names, mapPaths, nodes, edges);
+    out << graphToJson(nodes, edges, analysed).dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/MapGraph.h
+++ b/src/cli/MapGraph.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+struct MapGraphOptions {
+    // Maps to include (VFS paths, e.g. "maps/arroyo.map"). Empty = every map in the mounted data.
+    std::vector<std::string> maps;
+};
+
+/// The exit-grid connectivity graph: nodes are maps, edges are the exit-grid links between them
+/// (aggregated, with a hex count per edge), resolved to names via maps.txt / map.msg
+/// (`MapNameResolver`). Edges to the -2 world map / -1 town map and to maps absent from maps.txt are
+/// kept and tagged by `kind`. `stats` flags dead-ends (no outgoing map edge) and maps with no
+/// incoming map edge (a location's entry points / orphans).
+///
+/// IMPORTANT: this is only the exit-grid layer — how a location's maps link to each other (intramap
+/// elevation changes + intermap edges within a town) and where they hand off to the world map. It is
+/// NOT the inter-city travel graph: cities are reached across the world map, so this graph is
+/// connected only within a location. The world layer (areas, world positions, distances between
+/// places, which maps an area contains) is data/city.txt — a separate reader.
+///
+/// A per-map exit pass (no full analyze), so it scales to every shipped map. Emits a JSON object to
+/// `out`; returns 0 on success, non-zero if no maps were found.
+int buildMapGraph(resource::GameResources& resources, const MapGraphOptions& options, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/Quests.cpp
+++ b/src/cli/Quests.cpp
@@ -1,0 +1,78 @@
+#include "cli/Quests.h"
+
+#include "cli/ConfigLoad.h"
+#include "cli/GlobalVars.h" // loadGameGam
+#include "format/gam/Gam.h"
+#include "format/msg/Msg.h"
+#include "format/quests/QuestsTxt.h"
+#include "reader/quests/QuestsTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    // Message `index` from the .msg at `path`, or "" if unavailable. quests.txt indexes map.msg
+    // (location names, the 1500+ range) and quests.msg (descriptions) directly by these ids.
+    std::string msgText(resource::GameResources& resources, const char* path, int index) {
+        if (index < 0) {
+            return {};
+        }
+        try {
+            if (Msg* msg = resources.repository().load<Msg>(path); msg != nullptr) {
+                return msg->message(index).text;
+            }
+        } catch (const std::exception& e) {
+            spdlog::debug("quests: {} unavailable: {}", path, e.what());
+        }
+        return {};
+    }
+
+    ordered_json orNull(const std::string& s) {
+        return s.empty() ? ordered_json(nullptr) : ordered_json(s);
+    }
+
+} // namespace
+
+int buildQuests(resource::GameResources& resources, std::ostream& out) {
+    const QuestsTxt quests = loadConfig<QuestsTxt>(resources, { "data/quests.txt", "quests.txt" },
+        [](const std::string& text) { return parseQuestsTxt(text); });
+    if (quests.quests.empty()) {
+        out << "{\"quests\":[],\"stats\":{\"quests\":0}}\n";
+        return 1;
+    }
+
+    Gam* gam = loadGameGam(resources); // gvar name/default dictionary (may be null)
+
+    auto array = ordered_json::array();
+    for (const Quest& quest : quests.quests) {
+        ordered_json gvarName = nullptr;
+        ordered_json gvarStart = nullptr;
+        if (gam != nullptr && quest.gvar >= 0 && static_cast<std::size_t>(quest.gvar) < gam->gvarCount()) {
+            gvarName = gam->gvarKey(quest.gvar);
+            gvarStart = gam->gvarValue(quest.gvar);
+        }
+        array.push_back({ { "location", quest.location },
+            { "area", orNull(msgText(resources, "text/english/game/map.msg", quest.location)) },
+            { "gvar", quest.gvar }, { "gvarName", gvarName }, { "gvarStart", gvarStart },
+            { "displayThreshold", quest.displayThreshold }, { "completedThreshold", quest.completedThreshold },
+            { "description", orNull(msgText(resources, "text/english/game/quests.msg", quest.description)) } });
+    }
+
+    ordered_json root;
+    root["quests"] = std::move(array);
+    root["stats"] = { { "quests", quests.quests.size() } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/Quests.h
+++ b/src/cli/Quests.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// The quest registry from data/quests.txt, the "what the player has to do" layer. Each quest with:
+/// its 'area' (the location name from map.msg), the global variable that tracks it ('gvar' index +
+/// 'gvarName' GVAR_* + 'gvarStart' default, resolved via vault13.gam), the 'displayThreshold' /
+/// 'completedThreshold' gvar values that gate it, and the 'description' from quests.msg. An agent can
+/// join 'area' to world_map area names, 'gvarName' to scripts (which set/check it), and read the
+/// description for the objective. Emits a JSON object to `out`; returns 0 on success, non-zero if
+/// quests.txt isn't mounted.
+int buildQuests(resource::GameResources& resources, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/WorldEncounters.cpp
+++ b/src/cli/WorldEncounters.cpp
@@ -19,7 +19,7 @@ namespace {
     ordered_json terrainsToJson(const WorldmapTxt& world) {
         auto terrains = ordered_json::array();
         for (const auto& terrain : world.terrains) {
-            terrains.push_back({ { "name", terrain.name }, { "shortName", terrain.shortName }, { "weight", terrain.weight } });
+            terrains.push_back({ { "name", terrain.name }, { "shortName", terrain.shortName }, { "difficulty", terrain.difficulty } });
         }
         return terrains;
     }

--- a/src/cli/WorldEncounters.cpp
+++ b/src/cli/WorldEncounters.cpp
@@ -1,0 +1,65 @@
+#include "cli/WorldEncounters.h"
+
+#include "format/worldmap/WorldmapTxt.h"
+#include "reader/worldmap/WorldmapTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+
+#include <ostream>
+#include <string>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    WorldmapTxt loadWorldmapTxt(resource::GameResources& resources) {
+        for (const char* path : { "data/worldmap.txt", "worldmap.txt" }) {
+            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+                return parseWorldmapTxt(std::string(bytes->begin(), bytes->end()));
+            }
+        }
+        return WorldmapTxt{};
+    }
+
+    ordered_json terrainsToJson(const WorldmapTxt& world) {
+        auto terrains = ordered_json::array();
+        for (const auto& terrain : world.terrains) {
+            terrains.push_back({ { "name", terrain.name }, { "shortName", terrain.shortName }, { "weight", terrain.weight } });
+        }
+        return terrains;
+    }
+
+    ordered_json encountersToJson(const WorldmapTxt& world) {
+        auto encounters = ordered_json::array();
+        for (const auto& encounter : world.encounters) {
+            auto entries = ordered_json::array();
+            for (const auto& entry : encounter.entries) {
+                entries.push_back({ { "pid", entry.pid }, { "ratioPercent", entry.ratioPercent },
+                    { "dead", entry.dead }, { "script", entry.script }, { "items", entry.items } });
+            }
+            encounters.push_back({ { "name", encounter.name }, { "entries", std::move(entries) } });
+        }
+        return encounters;
+    }
+
+} // namespace
+
+int buildWorldEncounters(resource::GameResources& resources, std::ostream& out) {
+    const WorldmapTxt world = loadWorldmapTxt(resources);
+    if (world.terrains.empty() && world.encounters.empty()) {
+        out << "{\"terrains\":[],\"encounters\":[],\"stats\":{\"terrains\":0,\"encounters\":0}}\n";
+        return 1;
+    }
+
+    ordered_json root;
+    root["terrains"] = terrainsToJson(world);
+    root["encounters"] = encountersToJson(world);
+    root["stats"] = { { "terrains", world.terrains.size() }, { "encounters", world.encounters.size() } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/WorldEncounters.cpp
+++ b/src/cli/WorldEncounters.cpp
@@ -1,5 +1,6 @@
 #include "cli/WorldEncounters.h"
 
+#include "cli/ConfigLoad.h"
 #include "format/worldmap/WorldmapTxt.h"
 #include "reader/worldmap/WorldmapTxtReader.h"
 #include "resource/GameResources.h"
@@ -14,15 +15,6 @@ namespace geck::cli {
 namespace {
 
     using ordered_json = nlohmann::ordered_json;
-
-    WorldmapTxt loadWorldmapTxt(resource::GameResources& resources) {
-        for (const char* path : { "data/worldmap.txt", "worldmap.txt" }) {
-            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
-                return parseWorldmapTxt(std::string(bytes->begin(), bytes->end()));
-            }
-        }
-        return WorldmapTxt{};
-    }
 
     ordered_json terrainsToJson(const WorldmapTxt& world) {
         auto terrains = ordered_json::array();
@@ -48,7 +40,8 @@ namespace {
 } // namespace
 
 int buildWorldEncounters(resource::GameResources& resources, std::ostream& out) {
-    const WorldmapTxt world = loadWorldmapTxt(resources);
+    const WorldmapTxt world = loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
+        [](const std::string& text) { return parseWorldmapTxt(text); });
     if (world.terrains.empty() && world.encounters.empty()) {
         out << "{\"terrains\":[],\"encounters\":[],\"stats\":{\"terrains\":0,\"encounters\":0}}\n";
         return 1;

--- a/src/cli/WorldEncounters.h
+++ b/src/cli/WorldEncounters.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// The worldmap's terrain types and random-encounter group tables, from data/worldmap.txt: each
+/// terrain type (name, short name, draw weight) and each `[Encounter: NAME]` group with its spawn
+/// entries (proto pid, ratio, dead flag, script, carried items). The shipped encounter names are
+/// region-prefixed (ARRO_*, KLA_*, …) — the worldmap's "location sections" (which encounters belong
+/// to which area). Pids are raw — resolve them with proto_info. Emits a JSON object to `out`; returns
+/// 0 on success, non-zero if worldmap.txt isn't mounted.
+int buildWorldEncounters(resource::GameResources& resources, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -2,12 +2,15 @@
 
 #include "cli/ConfigLoad.h"
 #include "format/city/CityTxt.h"
+#include "format/worldmap/WorldmapTxt.h"
 #include "reader/city/CityTxtReader.h"
+#include "reader/worldmap/WorldmapTxtReader.h"
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <ostream>
@@ -19,7 +22,7 @@ namespace {
 
     using ordered_json = nlohmann::ordered_json;
 
-    ordered_json areasToJson(const CityTxt& city, const resource::MapNameResolver& names) {
+    ordered_json areasToJson(const CityTxt& city, const resource::MapNameResolver& names, const WorldmapTxt& world) {
         auto areas = ordered_json::array();
         for (const auto& area : city.areas) {
             auto maps = ordered_json::array();
@@ -30,11 +33,31 @@ namespace {
                 maps.push_back({ { "map", entrance.map }, { "on", entrance.on },
                     { "mapFile", mapFile.empty() ? ordered_json(nullptr) : ordered_json(mapFile) } });
             }
+            const std::string terrain = world.terrainAt(area.worldX, area.worldY); // "" if no tile grid
             areas.push_back({ { "index", area.index }, { "name", area.name },
                 { "worldPos", { { "x", area.worldX }, { "y", area.worldY } } },
-                { "size", area.size }, { "knownAtStart", area.startOn }, { "maps", std::move(maps) } });
+                { "size", area.size }, { "knownAtStart", area.startOn },
+                { "terrain", terrain.empty() ? ordered_json(nullptr) : ordered_json(terrain) },
+                { "maps", std::move(maps) } });
         }
         return areas;
+    }
+
+    // Terrain-weighted travel cost: sample the straight line between two areas every subtile and sum
+    // the terrain difficulty crossed. An approximation of the engine's path cost (it walks the real
+    // route), but it reflects that mountains/ocean cost more to cross than open desert.
+    double travelCost(const WorldmapTxt& world, int ax, int ay, int bx, int by) {
+        const double dx = bx - ax;
+        const double dy = by - ay;
+        const int steps = std::max(1, static_cast<int>(std::sqrt(dx * dx + dy * dy) / WM_SUBTILE_SIZE));
+        double cost = 0.0;
+        for (int i = 0; i <= steps; ++i) {
+            const double t = static_cast<double>(i) / steps;
+            const int px = static_cast<int>(std::lround(ax + dx * t));
+            const int py = static_cast<int>(std::lround(ay + dy * t));
+            cost += world.difficultyOf(world.terrainAt(px, py));
+        }
+        return cost;
     }
 
     // Where a new game begins. The engine hard-codes the first map (fallout2-ce main.cc:
@@ -56,9 +79,10 @@ namespace {
             { "area", area.empty() ? ordered_json(nullptr) : ordered_json(area) } };
     }
 
-    // Straight-line distance (in worldmap units) between every pair of areas. Terrain-weighted travel
-    // cost would need worldmap.txt; this is the as-the-crow-flies "distance between places".
-    ordered_json distancesToJson(const CityTxt& city) {
+    // Distance between every pair of areas: straight-line (as-the-crow-flies worldmap units) plus, when
+    // the [Tile NN] terrain grid is present, a terrain-weighted travelCost (null otherwise).
+    ordered_json distancesToJson(const CityTxt& city, const WorldmapTxt& world) {
+        const bool hasGrid = world.numHorizontalTiles > 0 && !world.tiles.empty();
         auto distances = ordered_json::array();
         const auto& areas = city.areas;
         for (std::size_t i = 0; i < areas.size(); ++i) {
@@ -66,8 +90,14 @@ namespace {
                 const double dx = static_cast<double>(areas[i].worldX - areas[j].worldX);
                 const double dy = static_cast<double>(areas[i].worldY - areas[j].worldY);
                 const double dist = std::round(std::sqrt(dx * dx + dy * dy) * 10.0) / 10.0;
+                ordered_json travel = nullptr;
+                if (hasGrid) {
+                    const double cost = travelCost(world, areas[i].worldX, areas[i].worldY, areas[j].worldX, areas[j].worldY);
+                    travel = std::round(cost * 10.0) / 10.0;
+                }
                 distances.push_back({ { "from", areas[i].index }, { "to", areas[j].index },
-                    { "fromName", areas[i].name }, { "toName", areas[j].name }, { "distance", dist } });
+                    { "fromName", areas[i].name }, { "toName", areas[j].name }, { "distance", dist },
+                    { "travelCost", travel } });
             }
         }
         return distances;
@@ -90,11 +120,15 @@ int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
         }
     }
 
+    // worldmap.txt is optional here: it enriches areas with terrain + adds terrain-weighted travelCost.
+    const WorldmapTxt world = loadConfig<WorldmapTxt>(resources, { "data/worldmap.txt", "worldmap.txt" },
+        [](const std::string& text) { return parseWorldmapTxt(text); });
+
     const resource::MapNameResolver names(resources); // resolves entrance lookup_names -> .map files
     ordered_json root;
     root["start"] = startToJson(city, names);
-    root["areas"] = areasToJson(city, names);
-    root["distances"] = distancesToJson(city);
+    root["areas"] = areasToJson(city, names, world);
+    root["distances"] = distancesToJson(city, world);
     root["stats"] = { { "areas", city.areas.size() }, { "knownAtStart", knownAtStart } };
     out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
     return 0;

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -1,0 +1,84 @@
+#include "cli/WorldMap.h"
+
+#include "format/city/CityTxt.h"
+#include "reader/city/CityTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+namespace geck::cli {
+
+namespace {
+
+    using ordered_json = nlohmann::ordered_json;
+
+    CityTxt loadCityTxt(resource::GameResources& resources) {
+        for (const char* path : { "data/city.txt", "city.txt" }) {
+            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+                return parseCityTxt(std::string(bytes->begin(), bytes->end()));
+            }
+        }
+        return CityTxt{};
+    }
+
+    ordered_json areasToJson(const CityTxt& city) {
+        auto areas = ordered_json::array();
+        for (const auto& area : city.areas) {
+            auto maps = ordered_json::array();
+            for (const auto& entrance : area.entrances) {
+                maps.push_back({ { "map", entrance.map }, { "on", entrance.on } });
+            }
+            areas.push_back({ { "index", area.index }, { "name", area.name },
+                { "worldPos", { { "x", area.worldX }, { "y", area.worldY } } },
+                { "size", area.size }, { "knownAtStart", area.startOn }, { "maps", std::move(maps) } });
+        }
+        return areas;
+    }
+
+    // Straight-line distance (in worldmap units) between every pair of areas. Terrain-weighted travel
+    // cost would need worldmap.txt; this is the as-the-crow-flies "distance between places".
+    ordered_json distancesToJson(const CityTxt& city) {
+        auto distances = ordered_json::array();
+        const auto& areas = city.areas;
+        for (std::size_t i = 0; i < areas.size(); ++i) {
+            for (std::size_t j = i + 1; j < areas.size(); ++j) {
+                const double dx = static_cast<double>(areas[i].worldX - areas[j].worldX);
+                const double dy = static_cast<double>(areas[i].worldY - areas[j].worldY);
+                const double dist = std::round(std::sqrt(dx * dx + dy * dy) * 10.0) / 10.0;
+                distances.push_back({ { "from", areas[i].index }, { "to", areas[j].index },
+                    { "fromName", areas[i].name }, { "toName", areas[j].name }, { "distance", dist } });
+            }
+        }
+        return distances;
+    }
+
+} // namespace
+
+int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
+    const CityTxt city = loadCityTxt(resources);
+    if (city.areas.empty()) {
+        out << "{\"areas\":[],\"distances\":[],\"stats\":{\"areas\":0}}\n";
+        return 1;
+    }
+
+    int knownAtStart = 0;
+    for (const auto& area : city.areas) {
+        if (area.startOn) {
+            ++knownAtStart;
+        }
+    }
+
+    ordered_json root;
+    root["areas"] = areasToJson(city);
+    root["distances"] = distancesToJson(city);
+    root["stats"] = { { "areas", city.areas.size() }, { "knownAtStart", knownAtStart } };
+    out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -37,6 +37,25 @@ namespace {
         return areas;
     }
 
+    // Where a new game begins. The engine hard-codes the first map (fallout2-ce main.cc:
+    // `_mainMap = "artemple.map"`); resolve which worldmap area owns it + its map.msg name, so an
+    // agent has the entry point of the start->objectives->ending chain.
+    ordered_json startToJson(const CityTxt& city, const resource::MapNameResolver& names) {
+        constexpr const char* kStartMap = "artemple.map";
+        std::string area;
+        for (const CityArea& a : city.areas) {
+            for (const CityEntrance& entrance : a.entrances) {
+                if (names.fileNameOfLookup(entrance.map) == kStartMap) {
+                    area = a.name;
+                }
+            }
+        }
+        const std::string display = names.displayName(names.indexOf(kStartMap), 0);
+        return { { "map", kStartMap },
+            { "displayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
+            { "area", area.empty() ? ordered_json(nullptr) : ordered_json(area) } };
+    }
+
     // Straight-line distance (in worldmap units) between every pair of areas. Terrain-weighted travel
     // cost would need worldmap.txt; this is the as-the-crow-flies "distance between places".
     ordered_json distancesToJson(const CityTxt& city) {
@@ -73,6 +92,7 @@ int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
 
     const resource::MapNameResolver names(resources); // resolves entrance lookup_names -> .map files
     ordered_json root;
+    root["start"] = startToJson(city, names);
     root["areas"] = areasToJson(city, names);
     root["distances"] = distancesToJson(city);
     root["stats"] = { { "areas", city.areas.size() }, { "knownAtStart", knownAtStart } };

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -1,8 +1,10 @@
 #include "cli/WorldMap.h"
 
+#include "cli/ConfigLoad.h"
 #include "format/city/CityTxt.h"
 #include "reader/city/CityTxtReader.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 
 #include <nlohmann/json.hpp>
 
@@ -17,21 +19,16 @@ namespace {
 
     using ordered_json = nlohmann::ordered_json;
 
-    CityTxt loadCityTxt(resource::GameResources& resources) {
-        for (const char* path : { "data/city.txt", "city.txt" }) {
-            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
-                return parseCityTxt(std::string(bytes->begin(), bytes->end()));
-            }
-        }
-        return CityTxt{};
-    }
-
-    ordered_json areasToJson(const CityTxt& city) {
+    ordered_json areasToJson(const CityTxt& city, const resource::MapNameResolver& names) {
         auto areas = ordered_json::array();
         for (const auto& area : city.areas) {
             auto maps = ordered_json::array();
             for (const auto& entrance : area.entrances) {
-                maps.push_back({ { "map", entrance.map }, { "on", entrance.on } });
+                // mapFile resolves the entrance lookup_name to the .map filename, which is the join key
+                // to map_graph nodes (null when the lookup_name has no maps.txt entry).
+                const std::string mapFile = names.fileNameOfLookup(entrance.map);
+                maps.push_back({ { "map", entrance.map }, { "on", entrance.on },
+                    { "mapFile", mapFile.empty() ? ordered_json(nullptr) : ordered_json(mapFile) } });
             }
             areas.push_back({ { "index", area.index }, { "name", area.name },
                 { "worldPos", { { "x", area.worldX }, { "y", area.worldY } } },
@@ -60,7 +57,8 @@ namespace {
 } // namespace
 
 int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
-    const CityTxt city = loadCityTxt(resources);
+    const CityTxt city = loadConfig<CityTxt>(resources, { "data/city.txt", "city.txt" },
+        [](const std::string& text) { return parseCityTxt(text); });
     if (city.areas.empty()) {
         out << "{\"areas\":[],\"distances\":[],\"stats\":{\"areas\":0}}\n";
         return 1;
@@ -73,8 +71,9 @@ int buildWorldMap(resource::GameResources& resources, std::ostream& out) {
         }
     }
 
+    const resource::MapNameResolver names(resources); // resolves entrance lookup_names -> .map files
     ordered_json root;
-    root["areas"] = areasToJson(city);
+    root["areas"] = areasToJson(city, names);
     root["distances"] = distancesToJson(city);
     root["stats"] = { { "areas", city.areas.size() }, { "knownAtStart", knownAtStart } };
     out << root.dump(2, ' ', false, ordered_json::error_handler_t::replace) << "\n";

--- a/src/cli/WorldMap.h
+++ b/src/cli/WorldMap.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace geck::resource {
+class GameResources;
+}
+
+namespace geck::cli {
+
+/// The worldmap layer, from data/city.txt: every area (a city / town / encounter location) with its
+/// name, worldmap position, size, known-at-start flag and the maps it contains (its entrances), plus
+/// the straight-line distance between every pair of areas. This is the inter-city travel layer that
+/// the exit-grid graph (map_graph) does not cover — the player crosses the world map to get between
+/// these areas. Emits a JSON object to `out`; returns 0 on success, non-zero if city.txt isn't
+/// mounted.
+int buildWorldMap(resource::GameResources& resources, std::ostream& out);
+
+} // namespace geck::cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -344,6 +344,11 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 0;
     }
     if (out.findGvar) { // a single positional: the GVAR_* name to search for
+        if (arg.rfind("--", 0) == 0 || !out.findGvarName.empty()) {
+            std::cerr << "error: find-gvar takes exactly one GVAR name: " << arg << "\n";
+            printUsage(program);
+            return 0;
+        }
         out.findGvarName = arg;
         return 1;
     }
@@ -482,6 +487,10 @@ int main(int argc, char** argv) {
         return geck::cli::buildEndings(resources, std::cout);
     }
     if (cli.findGvar) {
+        if (cli.findGvarName.empty()) {
+            std::cerr << "error: find-gvar requires a GVAR name (e.g. find-gvar GVAR_ARROYO_RETURN_GECK)\n";
+            return 2;
+        }
         return geck::cli::findGvarRefs(resources, cli.findGvarName, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2,6 +2,7 @@
 #include "cli/MapAnalyzer.h"
 #include "cli/MapDescribe.h"
 #include "cli/MapGraph.h"
+#include "cli/WorldMap.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -26,6 +27,7 @@ struct CliArgs {
     bool reachability = false;
     bool describeMap = false;
     bool graph = false;
+    bool world = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -82,6 +84,9 @@ void printUsage(const char* program) {
               << "      The exit-grid connectivity graph: how maps link via exit grids WITHIN a location\n"
               << "      (+ worldmap hand-off edges), named via maps.txt/map.msg. Not inter-city travel\n"
               << "      (that's the world map / city.txt). No map arguments = every map.\n"
+              << "  " << program << " map world --data <dir-or-.dat> [--data <...>]\n"
+              << "      The worldmap layer from city.txt: every area (location) with its world position,\n"
+              << "      size, the maps it contains, and the straight-line distances between all areas.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -89,7 +94,7 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
-            || args[1] == "graph");
+            || args[1] == "graph" || args[1] == "world");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -301,6 +306,11 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         out.graphOpts.maps.push_back(arg);
         return 1;
     }
+    if (out.world) { // world takes no arguments beyond --data (handled above)
+        std::cerr << "error: unexpected argument: " << arg << "\n";
+        printUsage(program);
+        return 0;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -326,6 +336,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.reachability = args[1] == "reachability";
     out.describeMap = args[1] == "describe-map";
     out.graph = args[1] == "graph";
+    out.world = args[1] == "world";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -413,6 +424,9 @@ int main(int argc, char** argv) {
     }
     if (cli.graph) {
         return geck::cli::buildMapGraph(resources, cli.graphOpts, std::cout);
+    }
+    if (cli.world) {
+        return geck::cli::buildWorldMap(resources, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,6 +1,7 @@
 #include "cli/BundledResources.h"
 #include "cli/MapAnalyzer.h"
 #include "cli/MapDescribe.h"
+#include "cli/MapGraph.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -24,6 +25,7 @@ struct CliArgs {
     bool describeScript = false;
     bool reachability = false;
     bool describeMap = false;
+    bool graph = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -32,6 +34,7 @@ struct CliArgs {
     geck::cli::DescribeScriptOptions desc;
     geck::cli::ReachabilityOptions reach;
     geck::cli::DescribeMapOptions describeMapOpts;
+    geck::cli::MapGraphOptions graphOpts;
 };
 
 void printUsage(const char* program) {
@@ -75,13 +78,18 @@ void printUsage(const char* program) {
               << "  " << program << " map describe-map --map <path> --data <dir-or-.dat> [--data <...>]\n"
               << "      One digest composing analyze + reachability for a map (header, biome, structures,\n"
               << "      critter roster with AI + scripts, exits, reachability), as JSON.\n"
+              << "  " << program << " map graph [map ...] --data <dir-or-.dat> [--data <...>]\n"
+              << "      The exit-grid connectivity graph: how maps link via exit grids WITHIN a location\n"
+              << "      (+ worldmap hand-off edges), named via maps.txt/map.msg. Not inter-city travel\n"
+              << "      (that's the world map / city.txt). No map arguments = every map.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
 bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
-            || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map");
+            || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
+            || args[1] == "graph");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -289,6 +297,10 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.graph) { // trailing positional args are the maps to include (empty = all)
+        out.graphOpts.maps.push_back(arg);
+        return 1;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -313,6 +325,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.describeScript = args[1] == "describe-script";
     out.reachability = args[1] == "reachability";
     out.describeMap = args[1] == "describe-map";
+    out.graph = args[1] == "graph";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -397,6 +410,9 @@ int main(int argc, char** argv) {
     }
     if (cli.describeMap) {
         return geck::cli::describeMap(resources, cli.describeMapOpts, std::cout);
+    }
+    if (cli.graph) {
+        return geck::cli::buildMapGraph(resources, cli.graphOpts, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -3,6 +3,7 @@
 #include "cli/MapDescribe.h"
 #include "cli/MapGraph.h"
 #include "cli/WorldMap.h"
+#include "cli/WorldEncounters.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -28,6 +29,7 @@ struct CliArgs {
     bool describeMap = false;
     bool graph = false;
     bool world = false;
+    bool encounters = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -87,6 +89,8 @@ void printUsage(const char* program) {
               << "  " << program << " map world --data <dir-or-.dat> [--data <...>]\n"
               << "      The worldmap layer from city.txt: every area (location) with its world position,\n"
               << "      size, the maps it contains, and the straight-line distances between all areas.\n"
+              << "  " << program << " map encounters --data <dir-or-.dat> [--data <...>]\n"
+              << "      The worldmap terrain types and random-encounter group tables from worldmap.txt.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -94,7 +98,7 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
-            || args[1] == "graph" || args[1] == "world");
+            || args[1] == "graph" || args[1] == "world" || args[1] == "encounters");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -311,6 +315,11 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.encounters) { // encounters takes no arguments beyond --data (handled above)
+        std::cerr << "error: unexpected argument: " << arg << "\n";
+        printUsage(program);
+        return 0;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -337,6 +346,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.describeMap = args[1] == "describe-map";
     out.graph = args[1] == "graph";
     out.world = args[1] == "world";
+    out.encounters = args[1] == "encounters";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -427,6 +437,9 @@ int main(int argc, char** argv) {
     }
     if (cli.world) {
         return geck::cli::buildWorldMap(resources, std::cout);
+    }
+    if (cli.encounters) {
+        return geck::cli::buildWorldEncounters(resources, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -7,6 +7,7 @@
 #include "cli/GlobalVars.h"
 #include "cli/Quests.h"
 #include "cli/Endings.h"
+#include "cli/GvarRefs.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -36,6 +37,8 @@ struct CliArgs {
     bool gvars = false;
     bool quests = false;
     bool endings = false;
+    bool findGvar = false;
+    std::string findGvarName;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -103,6 +106,8 @@ void printUsage(const char* program) {
               << "      The quest registry (quests.txt): each quest's area, tracking gvar, thresholds, text.\n"
               << "  " << program << " map endings --data <dir-or-.dat> [--data <...>]\n"
               << "      The endgame win-condition table (endgame.txt): each slide's gvar==value, art, narrator.\n"
+              << "  " << program << " map find-gvar <GVAR_NAME> --data <dir-or-.dat> [--data <...>]\n"
+              << "      Scripts that read/write a global variable (needs an .ssl source tree mounted): set vs get.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -111,7 +116,7 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
             || args[1] == "graph" || args[1] == "world" || args[1] == "encounters"
-            || args[1] == "gvars" || args[1] == "quests" || args[1] == "endings");
+            || args[1] == "gvars" || args[1] == "quests" || args[1] == "endings" || args[1] == "find-gvar");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -338,6 +343,10 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.findGvar) { // a single positional: the GVAR_* name to search for
+        out.findGvarName = arg;
+        return 1;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -368,6 +377,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.gvars = args[1] == "gvars";
     out.quests = args[1] == "quests";
     out.endings = args[1] == "endings";
+    out.findGvar = args[1] == "find-gvar";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -470,6 +480,9 @@ int main(int argc, char** argv) {
     }
     if (cli.endings) {
         return geck::cli::buildEndings(resources, std::cout);
+    }
+    if (cli.findGvar) {
+        return geck::cli::findGvarRefs(resources, cli.findGvarName, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -6,6 +6,7 @@
 #include "cli/WorldEncounters.h"
 #include "cli/GlobalVars.h"
 #include "cli/Quests.h"
+#include "cli/Endings.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -34,6 +35,7 @@ struct CliArgs {
     bool encounters = false;
     bool gvars = false;
     bool quests = false;
+    bool endings = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -99,6 +101,8 @@ void printUsage(const char* program) {
               << "      The global-variable dictionary (vault13.gam): each GVAR index -> name + default.\n"
               << "  " << program << " map quests --data <dir-or-.dat> [--data <...>]\n"
               << "      The quest registry (quests.txt): each quest's area, tracking gvar, thresholds, text.\n"
+              << "  " << program << " map endings --data <dir-or-.dat> [--data <...>]\n"
+              << "      The endgame win-condition table (endgame.txt): each slide's gvar==value, art, narrator.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -107,7 +111,7 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
             || args[1] == "graph" || args[1] == "world" || args[1] == "encounters"
-            || args[1] == "gvars" || args[1] == "quests");
+            || args[1] == "gvars" || args[1] == "quests" || args[1] == "endings");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -329,7 +333,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
-    if (out.gvars || out.quests) { // gvars/quests take no arguments beyond --data (handled above)
+    if (out.gvars || out.quests || out.endings) { // these take no arguments beyond --data (handled above)
         std::cerr << "error: unexpected argument: " << arg << "\n";
         printUsage(program);
         return 0;
@@ -363,6 +367,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.encounters = args[1] == "encounters";
     out.gvars = args[1] == "gvars";
     out.quests = args[1] == "quests";
+    out.endings = args[1] == "endings";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -462,6 +467,9 @@ int main(int argc, char** argv) {
     }
     if (cli.quests) {
         return geck::cli::buildQuests(resources, std::cout);
+    }
+    if (cli.endings) {
+        return geck::cli::buildEndings(resources, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -4,6 +4,8 @@
 #include "cli/MapGraph.h"
 #include "cli/WorldMap.h"
 #include "cli/WorldEncounters.h"
+#include "cli/GlobalVars.h"
+#include "cli/Quests.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
@@ -30,6 +32,8 @@ struct CliArgs {
     bool graph = false;
     bool world = false;
     bool encounters = false;
+    bool gvars = false;
+    bool quests = false;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
     geck::cli::GenerateOptions gen;
@@ -91,6 +95,10 @@ void printUsage(const char* program) {
               << "      size, the maps it contains, and the straight-line distances between all areas.\n"
               << "  " << program << " map encounters --data <dir-or-.dat> [--data <...>]\n"
               << "      The worldmap terrain types and random-encounter group tables from worldmap.txt.\n"
+              << "  " << program << " map gvars --data <dir-or-.dat> [--data <...>]\n"
+              << "      The global-variable dictionary (vault13.gam): each GVAR index -> name + default.\n"
+              << "  " << program << " map quests --data <dir-or-.dat> [--data <...>]\n"
+              << "      The quest registry (quests.txt): each quest's area, tracking gvar, thresholds, text.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -98,7 +106,8 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
-            || args[1] == "graph" || args[1] == "world" || args[1] == "encounters");
+            || args[1] == "graph" || args[1] == "world" || args[1] == "encounters"
+            || args[1] == "gvars" || args[1] == "quests");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -320,6 +329,11 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.gvars || out.quests) { // gvars/quests take no arguments beyond --data (handled above)
+        std::cerr << "error: unexpected argument: " << arg << "\n";
+        printUsage(program);
+        return 0;
+    }
     if (arg == "--json") { // analyze only: machine-readable output for the MCP
         out.analyze.json = true;
         return 1;
@@ -347,6 +361,8 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.graph = args[1] == "graph";
     out.world = args[1] == "world";
     out.encounters = args[1] == "encounters";
+    out.gvars = args[1] == "gvars";
+    out.quests = args[1] == "quests";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -440,6 +456,12 @@ int main(int argc, char** argv) {
     }
     if (cli.encounters) {
         return geck::cli::buildWorldEncounters(resources, std::cout);
+    }
+    if (cli.gvars) {
+        return geck::cli::buildGlobalVars(resources, std::cout);
+    }
+    if (cli.quests) {
+        return geck::cli::buildQuests(resources, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/format/city/CityTxt.h
+++ b/src/format/city/CityTxt.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace geck {
+
+/// One entrance of a worldmap area (city.txt `entrance_N = state, x, y, map, elevation, tile,
+/// orientation`): which map the player drops into when entering this area, and where. `map` is the
+/// destination map's lookup_name (e.g. "Arroyo Bridge"), matched to maps.txt by the engine.
+struct CityEntrance {
+    bool on = false;     ///< entrance enabled (state On/Off)
+    int townX = -1;      ///< x on the town-map view
+    int townY = -1;      ///< y on the town-map view
+    std::string map;     ///< destination map lookup_name
+    int elevation = -1;  ///< destination elevation (-1 = engine default)
+    int tile = -1;       ///< destination tile (-1 = engine default)
+    int orientation = 0; ///< facing on arrival
+};
+
+/// One `[Area NN]` of Fallout 2's `data/city.txt`: a worldmap location (a city/town/encounter site).
+/// `worldX,worldY` is its position on the worldmap — the basis for straight-line distances between
+/// places. Its `entrances` link it to the maps it contains. Mirrors the fields the engine reads in
+/// `wmAreaInit` (fallout2-ce worldmap.cc). The display name may also live in worldmap.msg.
+struct CityArea {
+    int index = -1;
+    std::string name;     ///< area_name
+    int worldX = 0;       ///< world_pos x (worldmap position)
+    int worldY = 0;       ///< world_pos y
+    bool startOn = false; ///< start_state On = known/visible at game start
+    std::string size;     ///< small / medium / large
+    std::vector<CityEntrance> entrances;
+};
+
+/// Parsed `data/city.txt`: the worldmap areas, looked up by their `[Area NN]` index.
+struct CityTxt {
+    std::vector<CityArea> areas;
+
+    const CityArea* find(int index) const {
+        for (const auto& area : areas) {
+            if (area.index == index) {
+                return &area;
+            }
+        }
+        return nullptr;
+    }
+};
+
+} // namespace geck

--- a/src/format/city/CityTxt.h
+++ b/src/format/city/CityTxt.h
@@ -3,6 +3,27 @@
 #include <string>
 #include <vector>
 
+/// @file
+/// @brief Model for Fallout 2's `data/city.txt` — the worldmap area (location) registry.
+///
+/// `city.txt` is an INI-style file with one `[Area NN]` section per worldmap location; the
+/// zero-padded `NN` fixes the area's index (an exit grid's "town map" / the worldmap reference it).
+/// Inline `;` comments may appear on any line, **including section headers**, so a parser must strip
+/// them first. Recognized keys:
+///
+/// @verbatim
+/// [Area 00]                ; Arroyo
+/// area_name=Arroyo         ; internal name (the displayed name may also live in worldmap.msg)
+/// world_pos=184,133        ; x,y on the worldmap — the basis for distances between places
+/// start_state=On           ; On = known/visible at game start
+/// size=Medium              ; Small / Medium / Large
+/// entrance_0=On,350,275,Arroyo Bridge,-1,-1,3
+/// ;           state, x, y, map (a maps.txt lookup_name), elevation, tile, orientation
+/// @endverbatim
+///
+/// @see fallout2-ce `worldmap.cc` (`wmAreaInit`)
+/// @see https://fallout.wiki/wiki/CITY.TXT_File_Format
+
 namespace geck {
 
 /// One entrance of a worldmap area (city.txt `entrance_N = state, x, y, map, elevation, tile,

--- a/src/format/endgame/EndgameTxt.h
+++ b/src/format/endgame/EndgameTxt.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+/// @file
+/// @brief Model for Fallout 2's `data/endgame.txt` — the endgame slideshow's win-condition table.
+///
+/// One slide per line, comma-separated, `#` starting a comment (fallout2-ce endgame.cc
+/// `endgameEndingInit`): a slide is shown when its global variable equals its `value`. Several lines
+/// sharing a gvar with different values are the branching outcomes for one location.
+///
+/// @verbatim
+/// # gvar, value, art_number, narrator_file [, direction]
+/// 408, 1, 440, nar_ar1            ; if GVAR 408 == 1, show intrface.lst art 440 with voice-over nar_ar1
+/// 40,  1, 327, nar_10, 1          ; direction only applies to the panning-desert art (327)
+/// @endverbatim
+///
+/// - gvar/value: the slide shows when global var `gvar` equals `value`.
+/// - art: line in `art/intrface/intrface.lst` for the slide image.
+/// - narrator: base filename for the voice-over + subtitle (`text/<lang>/cuts/<narrator>.txt`).
+/// - direction: pan direction (-1/1) for the panning-desert image only.
+///
+/// @see fallout2-ce `endgame.cc` (EndgameEnding, endgameEndingInit)
+/// @see https://fallout.wiki/wiki/ENDGAME.TXT_File_Format
+
+namespace geck {
+
+struct Ending {
+    int gvar = -1;        ///< the global variable controlling this slide
+    int value = 0;        ///< the gvar value that triggers the slide
+    int art = -1;         ///< intrface.lst line of the slide image
+    std::string narrator; ///< base filename for the voice-over / subtitle
+    int direction = 0;    ///< pan direction for the panning-desert art (327); 0 if unused
+};
+
+/// Parsed `data/endgame.txt`: the ending slides, in file order.
+struct EndgameTxt {
+    std::vector<Ending> endings;
+};
+
+} // namespace geck

--- a/src/format/endgame/EndgameTxt.h
+++ b/src/format/endgame/EndgameTxt.h
@@ -31,7 +31,7 @@ struct Ending {
     int value = 0;        ///< the gvar value that triggers the slide
     int art = -1;         ///< intrface.lst line of the slide image
     std::string narrator; ///< base filename for the voice-over / subtitle
-    int direction = 0;    ///< pan direction for the panning-desert art (327); 0 if unused
+    int direction = 1;    ///< pan direction for the panning-desert art (327); engine default is 1
 };
 
 /// Parsed `data/endgame.txt`: the ending slides, in file order.

--- a/src/format/gam/Gam.h
+++ b/src/format/gam/Gam.h
@@ -14,10 +14,12 @@ public:
     const std::string& gvarKey(size_t index) const;
     int gvarValue(const std::string& key);
     int gvarValue(size_t index);
+    size_t gvarCount() const { return _gvars.size(); }
 
     const std::string& mvarKey(size_t index) const;
     int mvarValue(const std::string& key);
     int mvarValue(size_t index);
+    size_t mvarCount() const { return _mvars.size(); }
 
     void addMvar(const std::string& key, int value);
     void addGvar(const std::string& key, int value);

--- a/src/format/maps/MapsTxt.h
+++ b/src/format/maps/MapsTxt.h
@@ -4,6 +4,26 @@
 #include <utility>
 #include <vector>
 
+/// @file
+/// @brief Model for Fallout 2's `data/maps.txt` — the engine's index→map registry.
+///
+/// `maps.txt` is an INI-style file with one `[Map NNN]` section per map; the zero-padded `NNN` is the
+/// map's index — the number an exit grid's `destMap` references (so `destMap` 3 is `[Map 003]`).
+/// Recognized keys (the engine reads more; `map_name` is stored without an extension and lowercased):
+///
+/// @verbatim
+/// [Map 003]
+/// lookup_name=Arroyo Caves   ; internal area key (city.txt entrances match maps by this)
+/// map_name=arcaves           ; the .map filename (no extension in the file)
+/// music=02Desert
+/// ambient_sfx=brmnwind:35, coyote:10   ; sound:chance pairs
+/// saved=No
+/// pipboy_active=Yes
+/// @endverbatim
+///
+/// @see fallout2-ce `worldmap.cc` (`wmConfigInit`)
+/// @see https://fallout.wiki/wiki/MAPS.TXT_File_Format
+
 namespace geck {
 
 /// One `[Map NNN]` section of Fallout 2's `data/maps.txt` — the engine's index→map registry that an

--- a/src/format/maps/MapsTxt.h
+++ b/src/format/maps/MapsTxt.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 #include <utility>
 #include <vector>
@@ -61,6 +63,24 @@ struct MapsTxt {
     const MapInfo* findByName(const std::string& mapName) const {
         for (const auto& map : maps) {
             if (map.mapName == mapName) {
+                return &map;
+            }
+        }
+        return nullptr;
+    }
+
+    /// The section whose lookup_name matches `lookupName` (case-insensitively — the engine matches
+    /// city.txt entrance map names to maps.txt this way), or nullptr. This is the join between the
+    /// worldmap layer (city.txt entrances reference maps by lookup_name) and the .map files /
+    /// exit-grid graph (keyed by map_name).
+    const MapInfo* findByLookupName(const std::string& lookupName) const {
+        const auto ieq = [](const std::string& a, const std::string& b) {
+            return a.size() == b.size()
+                && std::equal(a.begin(), a.end(), b.begin(),
+                    [](unsigned char x, unsigned char y) { return std::tolower(x) == std::tolower(y); });
+        };
+        for (const auto& map : maps) {
+            if (ieq(map.lookupName, lookupName)) {
                 return &map;
             }
         }

--- a/src/format/quests/QuestsTxt.h
+++ b/src/format/quests/QuestsTxt.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+
+/// @file
+/// @brief Model for Fallout 2's `data/quests.txt` — the quest registry the Pip-Boy reads.
+///
+/// `quests.txt` is a plain table: one quest per line, five comma/space/tab-separated integers, with
+/// `#` starting a comment. The engine (fallout2-ce pipboy.cc `questInit`) reads exactly these fields:
+///
+/// @verbatim
+/// # location  description  gvar  displayThreshold  completedThreshold
+/// 1500, 130, 480, 0, 1
+/// @endverbatim
+///
+/// - location: index into **map.msg** for the area/location name (the 1500+ named-location range —
+///   NOT the per-(map,elevation) name formula).
+/// - description: index into **quests.msg** for the quest's text.
+/// - gvar: the global variable (vault13.gam GAME_GLOBAL_VARS ordinal) whose value tracks this quest.
+/// - displayThreshold / completedThreshold: the gvar value at which the quest appears in / is marked
+///   complete in the Pip-Boy. Staged quests share a gvar across rows with rising thresholds.
+///
+/// @see fallout2-ce `pipboy.cc` (QuestDescription, questInit)
+/// @see https://fallout.wiki/wiki/QUESTS.TXT_File_Format
+
+namespace geck {
+
+struct Quest {
+    int location = -1;          ///< map.msg index for the area/location name
+    int description = -1;       ///< quests.msg index for the quest text
+    int gvar = -1;              ///< the global variable that tracks this quest
+    int displayThreshold = 0;   ///< gvar value at which the quest becomes visible
+    int completedThreshold = 0; ///< gvar value at which the quest is complete
+};
+
+/// Parsed `data/quests.txt`: the quest table, in file order.
+struct QuestsTxt {
+    std::vector<Quest> quests;
+};
+
+} // namespace geck

--- a/src/format/worldmap/WorldmapTxt.h
+++ b/src/format/worldmap/WorldmapTxt.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+/// @file
+/// @brief Model for Fallout 2's `data/worldmap.txt` — worldmap terrain types and encounter tables.
+///
+/// `worldmap.txt` is a large INI-style file (inline `;` comments throughout). This model covers two
+/// of its section kinds; the bulky `[Tile NN]` sub-tile grid (per-position terrain and encounter
+/// placement) is intentionally not parsed yet.
+///
+/// @verbatim
+/// [Data]
+/// terrain_types=Desert:1, Mountain:2, City:1, Ocean:1   ; name:draw-weight pairs
+/// terrain_short_names=DES, MNT, CTY, OCN                ; aligned to terrain_types by position
+///
+/// [Encounter: Raiders]                                  ; region-prefixed names (ARRO_*, KLA_*, …)
+/// type_00=Ratio:35%, pid:16777252, Item:8{Wielded}, Item:40, Script:255
+/// type_01=Dead, pid:16777220, Item:40, Script:256       ; "Dead" = spawned as a corpse
+/// @endverbatim
+///
+/// @see fallout2-ce `worldmap.cc` (`wmConfigInit`)
+/// @see https://fallout.wiki/wiki/Worldmap.txt_File_Format
+
+namespace geck {
+
+/// A worldmap terrain type from worldmap.txt `[Data]` (`terrain_types` / `terrain_short_names`),
+/// e.g. {"Desert", "DES"}. The `weight` is the per-type number the engine uses when drawing the
+/// worldmap (Desert:1, Mountain:2, …).
+struct WorldmapTerrain {
+    std::string name;
+    std::string shortName;
+    int weight = 0;
+};
+
+/// One spawn entry of an `[Encounter: …]` group (a `type_NN = …` line): the proto pid to spawn, its
+/// selection ratio (percent), and the flags the table carries. Items are kept as raw pids.
+struct EncounterEntry {
+    int pid = -1;           ///< spawned critter/object proto pid
+    int ratioPercent = 0;   ///< Ratio:NN% (0 if unspecified)
+    bool dead = false;      ///< the "Dead" flag (spawned as a corpse)
+    int script = -1;        ///< Script:NN (-1 if none)
+    int distance = -1;      ///< Distance:NN (-1 if none)
+    std::vector<int> items; ///< Item:NN pids carried
+};
+
+/// One `[Encounter: NAME]` group. The shipped names are region-prefixed (ARRO_*, KLA_*, …), so they
+/// double as the worldmap's "location sections": which encounters belong to which area.
+struct Encounter {
+    std::string name;
+    std::vector<EncounterEntry> entries;
+};
+
+/// Parsed `data/worldmap.txt` — the worldmap's terrain types and random-encounter group tables.
+///
+/// NOTE: this intentionally omits the `[Tile NN]` sub-tile grid (per-position terrain and encounter
+/// placement) — a large, geometry-heavy layer left for a follow-up; without it there is no
+/// terrain-at-position lookup or terrain-weighted travel cost yet.
+struct WorldmapTxt {
+    std::vector<WorldmapTerrain> terrains;
+    std::vector<Encounter> encounters;
+
+    const Encounter* findEncounter(const std::string& name) const {
+        for (const auto& encounter : encounters) {
+            if (encounter.name == name) {
+                return &encounter;
+            }
+        }
+        return nullptr;
+    }
+};
+
+} // namespace geck

--- a/src/format/worldmap/WorldmapTxt.h
+++ b/src/format/worldmap/WorldmapTxt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -26,12 +27,12 @@
 namespace geck {
 
 /// A worldmap terrain type from worldmap.txt `[Data]` (`terrain_types` / `terrain_short_names`),
-/// e.g. {"Desert", "DES"}. The `weight` is the per-type number the engine uses when drawing the
-/// worldmap (Desert:1, Mountain:2, …).
+/// e.g. {"Desert", "DES"}. `difficulty` is the engine's terrain difficulty — the `:N` in
+/// `terrain_types` (Desert:1, Mountain:2, …) — i.e. the per-step cost it adds to worldmap travel.
 struct WorldmapTerrain {
     std::string name;
     std::string shortName;
-    int weight = 0;
+    int difficulty = 0;
 };
 
 /// One spawn entry of an `[Encounter: …]` group (a `type_NN = …` line): the proto pid to spawn, its
@@ -52,14 +53,28 @@ struct Encounter {
     std::vector<EncounterEntry> entries;
 };
 
-/// Parsed `data/worldmap.txt` — the worldmap's terrain types and random-encounter group tables.
-///
-/// NOTE: this intentionally omits the `[Tile NN]` sub-tile grid (per-position terrain and encounter
-/// placement) — a large, geometry-heavy layer left for a follow-up; without it there is no
-/// terrain-at-position lookup or terrain-weighted travel cost yet.
+// The worldmap is a grid of tiles (WM_TILE_WIDTH x WM_TILE_HEIGHT pixels), each split into a
+// SUBTILE_GRID_WIDTH x SUBTILE_GRID_HEIGHT lattice of WM_SUBTILE_SIZE-pixel subtiles; every subtile
+// has a terrain. Constants mirror fallout2-ce worldmap.cc.
+inline constexpr int WM_TILE_WIDTH = 350;
+inline constexpr int WM_TILE_HEIGHT = 300;
+inline constexpr int WM_SUBTILE_SIZE = 50;
+inline constexpr int SUBTILE_GRID_WIDTH = 7;  // subtile columns per tile (the "row" key index, 0-6)
+inline constexpr int SUBTILE_GRID_HEIGHT = 6; // subtile rows per tile (the "column" key index, 0-5)
+
+/// One worldmap tile's subtile terrain grid, indexed [row][column] to match the engine's
+/// "row_column" keys (row 0-6 across, column 0-5 down).
+struct WorldmapTile {
+    std::array<std::array<std::string, SUBTILE_GRID_HEIGHT>, SUBTILE_GRID_WIDTH> terrain;
+};
+
+/// Parsed `data/worldmap.txt` — the worldmap's terrain types, random-encounter group tables, and the
+/// per-subtile terrain grid (`[Tile NN]`).
 struct WorldmapTxt {
     std::vector<WorldmapTerrain> terrains;
     std::vector<Encounter> encounters;
+    std::vector<WorldmapTile> tiles; ///< the worldmap tile grid, indexed by [Tile NN]
+    int numHorizontalTiles = 0;      ///< [Tile Data] num_horizontal_tiles (worldmap width, in tiles)
 
     const Encounter* findEncounter(const std::string& name) const {
         for (const auto& encounter : encounters) {
@@ -68,6 +83,35 @@ struct WorldmapTxt {
             }
         }
         return nullptr;
+    }
+
+    /// The terrain at worldmap pixel (x, y), or "" if out of range / the grid isn't parsed. Mirrors
+    /// fallout2-ce wmFindCurSubTileFromPos.
+    std::string terrainAt(int x, int y) const {
+        if (x < 0 || y < 0 || numHorizontalTiles <= 0) {
+            return {};
+        }
+        const int tileColumn = x / WM_TILE_WIDTH;
+        if (tileColumn >= numHorizontalTiles) {
+            return {};
+        }
+        const int tile = (y / WM_TILE_HEIGHT) * numHorizontalTiles + tileColumn;
+        if (tile < 0 || tile >= static_cast<int>(tiles.size())) {
+            return {};
+        }
+        const int row = (x % WM_TILE_WIDTH) / WM_SUBTILE_SIZE;  // 0-6
+        const int col = (y % WM_TILE_HEIGHT) / WM_SUBTILE_SIZE; // 0-5
+        return tiles[tile].terrain[row][col];
+    }
+
+    /// The difficulty of a terrain type by name (exact match), or 0 if unknown.
+    int difficultyOf(const std::string& terrainName) const {
+        for (const auto& terrain : terrains) {
+            if (terrain.name == terrainName) {
+                return terrain.difficulty;
+            }
+        }
+        return 0;
     }
 };
 

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -7,6 +7,7 @@
 #include "cli/WorldEncounters.h"
 #include "cli/GlobalVars.h"
 #include "cli/Quests.h"
+#include "cli/Endings.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -274,6 +275,17 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolEndings(resource::GameResources& resources, const json& /*args*/) {
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildEndings(resources, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("endings failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
@@ -477,6 +489,15 @@ namespace {
             "a gvar index (from quests, or a script) to a human-readable name. No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolGlobalVars(r, a); } });
+        t.push_back({ "endings",
+            "The endgame slideshow's win-condition table from endgame.txt: each ending slide with the "
+            "global variable + value that triggers it ('gvar' + 'gvarName' via vault13.gam + a readable "
+            "'condition'), the slide 'art', and the 'narrator' subtitle base name. Slides sharing a gvar "
+            "at different values are a location's branching outcomes — so this answers 'what world state "
+            "produces each ending'. With quests + gvars it closes the start->objectives->ending loop. "
+            "No arguments.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json& a) { return toolEndings(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -468,23 +468,25 @@ namespace {
             [](resource::GameResources& r, const json& a) { return toolMapGraph(r, a); } });
         t.push_back({ "world_map",
             "The WORLDMAP layer from city.txt — the inter-city travel layer that map_graph does not "
-            "cover. 'areas': every location (city/town/encounter site) with its 'name', 'worldPos' "
-            "{x,y} on the world map, 'size', 'knownAtStart', and 'maps' (the maps it contains — each "
-            "{map (the lookup_name), on, mapFile}). 'mapFile' is the .map filename, the JOIN KEY to "
-            "map_graph: world_map.areas[].maps[].mapFile == map_graph.nodes[].file (null when the "
-            "lookup_name has no maps.txt entry, e.g. a disabled entrance). 'distances': the "
-            "straight-line distance between every pair of areas (worldmap units) — how far apart places "
-            "are. Use this for 'how does the player get from city A to city B' (they cross the world "
-            "map); use map_graph for travel by exit grids within one location. No arguments.",
+            "cover. 'start': where a new game begins ({map, displayName, area} = artemple.map / Arroyo). "
+            "'areas': every location (city/town/encounter site) with its 'name', 'worldPos' {x,y} on the "
+            "world map, 'size', 'knownAtStart', 'terrain' (from worldmap.txt's tile grid, null if absent), "
+            "and 'maps' (the maps it contains — each {map (the lookup_name), on, mapFile}). 'mapFile' is "
+            "the .map filename, the JOIN KEY to map_graph: world_map.areas[].maps[].mapFile == "
+            "map_graph.nodes[].file (null when the lookup_name has no maps.txt entry, e.g. a disabled "
+            "entrance). 'distances': between every pair of areas, the straight-line 'distance' (worldmap "
+            "units) and a terrain-weighted 'travelCost' (null without the terrain grid). Use this for "
+            "'how does the player get from city A to city B' (they cross the world map); use map_graph "
+            "for travel by exit grids within one location. No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolWorldMap(r, a); } });
         t.push_back({ "world_encounters",
             "The worldmap's terrain types and random-encounter group tables, from worldmap.txt. "
-            "'terrains' (name, shortName, draw weight) and 'encounters' — each [Encounter: NAME] group "
-            "with its spawn 'entries' ({pid, ratioPercent, dead, script, items}). The shipped encounter "
-            "names are region-prefixed (ARRO_*, KLA_*, …), so they map to areas. Critter pids are raw — "
-            "resolve them with proto_info. (The geographic per-tile placement of encounters is not yet "
-            "parsed.) No arguments.",
+            "'terrains' (name, shortName, 'difficulty' — the terrain's per-step travel cost) and "
+            "'encounters' — each [Encounter: NAME] group with its spawn 'entries' ({pid, ratioPercent, "
+            "dead, script, items}). The shipped encounter names are region-prefixed (ARRO_*, KLA_*, …), "
+            "so they map to areas. Critter pids are raw — resolve them with proto_info. (Per-position "
+            "encounter placement is not parsed; terrain-at-position is in world_map.) No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolWorldEncounters(r, a); } });
         t.push_back({ "quests",

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -3,6 +3,7 @@
 #include "cli/MapAnalyzer.h"
 #include "cli/MapDescribe.h"
 #include "cli/MapGraph.h"
+#include "cli/WorldMap.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -226,6 +227,17 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolWorldMap(resource::GameResources& resources, const json& /*args*/) {
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildWorldMap(resources, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("world_map failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
@@ -391,6 +403,16 @@ namespace {
             "every map, or pass it to scope (e.g. one town's maps).",
             json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
             [](resource::GameResources& r, const json& a) { return toolMapGraph(r, a); } });
+        t.push_back({ "world_map",
+            "The WORLDMAP layer from city.txt — the inter-city travel layer that map_graph does not "
+            "cover. 'areas': every location (city/town/encounter site) with its 'name', 'worldPos' "
+            "{x,y} on the world map, 'size', 'knownAtStart', and 'maps' (the maps it contains, by "
+            "lookup_name, each with an 'on' flag). 'distances': the straight-line distance between "
+            "every pair of areas (worldmap units) — how far apart places are. Use this for 'how does "
+            "the player get from city A to city B' (they cross the world map); use map_graph for travel "
+            "by exit grids within one location. No arguments.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json& a) { return toolWorldMap(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -2,6 +2,7 @@
 
 #include "cli/MapAnalyzer.h"
 #include "cli/MapDescribe.h"
+#include "cli/MapGraph.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -136,19 +137,27 @@ namespace {
         return toolText(json(paths).dump()); // json(vector<string>) -> a JSON array, "[]" when empty
     }
 
+    // Optional "maps" string array -> the maps list (empty = every map). Shared by analyze, palette
+    // and map_graph; non-string entries are ignored.
+    std::vector<std::string> optMaps(const json& args) {
+        std::vector<std::string> maps;
+        if (args.contains("maps") && args.at("maps").is_array()) {
+            for (const auto& m : args.at("maps")) {
+                if (m.is_string()) {
+                    maps.push_back(m.get<std::string>());
+                }
+            }
+        }
+        return maps;
+    }
+
     // analyze (full JSON report) and palette (just the weighted generation palette) share the maps
     // parsing and the same headless analyzeMaps entry.
     json runAnalyze(resource::GameResources& resources, const json& args, bool paletteOnly) {
         cli::AnalyzeOptions opts;
         opts.json = !paletteOnly;
         opts.palette = paletteOnly;
-        if (args.contains("maps") && args["maps"].is_array()) {
-            for (const auto& m : args["maps"]) {
-                if (m.is_string()) {
-                    opts.maps.push_back(m.get<std::string>());
-                }
-            }
-        }
+        opts.maps = optMaps(args);
         std::ostringstream oss;
         int rc = 0;
         try {
@@ -200,6 +209,19 @@ namespace {
             rc = cli::describeMap(resources, opts, oss);
         } catch (const std::exception& e) {
             return toolText(std::string("describe_map failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolMapGraph(resource::GameResources& resources, const json& args) {
+        cli::MapGraphOptions opts;
+        opts.maps = optMaps(args);
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildMapGraph(resources, opts, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("map_graph failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
         }
         return toolText(oss.str(), rc != 0);
     }
@@ -355,6 +377,20 @@ namespace {
             "Args: map.",
             json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
             [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
+        t.push_back({ "map_graph",
+            "The EXIT-GRID connectivity graph — how maps link via exit grids: within a location "
+            "(intramap self-edges for elevation changes, and intermap edges between a town's maps, e.g. "
+            "Arroyo village<->bridge) and where a map hands off to the world map (edges with "
+            "kind=worldmap). NOT inter-city travel: cities are reached across the world map, not by exit "
+            "grids, so this graph is connected only within a location — for the world layer (areas, "
+            "positions, distances) use city.txt. 'nodes' (maps, each with the map.msg displayName and "
+            "'analysed' = loaded vs only seen as an exit target); 'edges' ({from,to,kind,destMap,"
+            "toName,exits}) where 'exits' counts the exit-grid hexes and 'kind' is "
+            "map/worldmap/townmap/unknown; 'stats' flags 'deadEnds' (no outgoing map edge) and "
+            "'noIncoming' (no map exits to it — a location's entry points or orphans). Omit 'maps' for "
+            "every map, or pass it to scope (e.g. one town's maps).",
+            json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
+            [](resource::GameResources& r, const json& a) { return toolMapGraph(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -5,6 +5,8 @@
 #include "cli/MapGraph.h"
 #include "cli/WorldMap.h"
 #include "cli/WorldEncounters.h"
+#include "cli/GlobalVars.h"
+#include "cli/Quests.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -250,6 +252,28 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolGlobalVars(resource::GameResources& resources, const json& /*args*/) {
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildGlobalVars(resources, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("gvars failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolQuests(resource::GameResources& resources, const json& /*args*/) {
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildQuests(resources, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("quests failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
@@ -407,8 +431,10 @@ namespace {
             "Arroyo village<->bridge) and where a map hands off to the world map (edges with "
             "kind=worldmap). NOT inter-city travel: cities are reached across the world map, not by exit "
             "grids, so this graph is connected only within a location — for the world layer (areas, "
-            "positions, distances) use city.txt. 'nodes' (maps, each with the map.msg displayName and "
-            "'analysed' = loaded vs only seen as an exit target); 'edges' ({from,to,kind,destMap,"
+            "positions, distances) use city.txt / world_map. 'nodes' (maps, each with: 'file' = the "
+            ".map filename — the JOIN KEY to world_map's area.maps[].mapFile; the map.msg 'displayName'; "
+            "the owning world_map 'area' and its city.txt 'lookupName' (so you can go map->area, the "
+            "reverse of world_map's area->map); and 'analysed'); 'edges' ({from,to,kind,destMap,"
             "toName,exits}) where 'exits' counts the exit-grid hexes and 'kind' is "
             "map/worldmap/townmap/unknown; 'stats' flags 'deadEnds' (no outgoing map edge) and "
             "'noIncoming' (no map exits to it — a location's entry points or orphans). Omit 'maps' for "
@@ -418,11 +444,13 @@ namespace {
         t.push_back({ "world_map",
             "The WORLDMAP layer from city.txt — the inter-city travel layer that map_graph does not "
             "cover. 'areas': every location (city/town/encounter site) with its 'name', 'worldPos' "
-            "{x,y} on the world map, 'size', 'knownAtStart', and 'maps' (the maps it contains, by "
-            "lookup_name, each with an 'on' flag). 'distances': the straight-line distance between "
-            "every pair of areas (worldmap units) — how far apart places are. Use this for 'how does "
-            "the player get from city A to city B' (they cross the world map); use map_graph for travel "
-            "by exit grids within one location. No arguments.",
+            "{x,y} on the world map, 'size', 'knownAtStart', and 'maps' (the maps it contains — each "
+            "{map (the lookup_name), on, mapFile}). 'mapFile' is the .map filename, the JOIN KEY to "
+            "map_graph: world_map.areas[].maps[].mapFile == map_graph.nodes[].file (null when the "
+            "lookup_name has no maps.txt entry, e.g. a disabled entrance). 'distances': the "
+            "straight-line distance between every pair of areas (worldmap units) — how far apart places "
+            "are. Use this for 'how does the player get from city A to city B' (they cross the world "
+            "map); use map_graph for travel by exit grids within one location. No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolWorldMap(r, a); } });
         t.push_back({ "world_encounters",
@@ -434,6 +462,21 @@ namespace {
             "parsed.) No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolWorldEncounters(r, a); } });
+        t.push_back({ "quests",
+            "The quest registry from quests.txt — what the player has to DO. Each quest: 'area' (the "
+            "location name, joins to world_map area names), 'gvar' + 'gvarName' (GVAR_*) + 'gvarStart' "
+            "(the global variable that tracks it, via vault13.gam — scripts set/check this same gvar), "
+            "'displayThreshold'/'completedThreshold' (the gvar values that reveal/complete it), and "
+            "'description' (the objective text). The spine for reasoning about progression: read what "
+            "must be done, where, and which world-state flag proves it. No arguments.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json& a) { return toolQuests(r, a); } });
+        t.push_back({ "gvars",
+            "The global-variable dictionary from vault13.gam: every GVAR by 'index' -> 'name' (GVAR_*) "
+            "+ 'default'. Global variables are the engine's progression state machine, so this decodes "
+            "a gvar index (from quests, or a script) to a human-readable name. No arguments.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json& a) { return toolGlobalVars(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -514,11 +514,13 @@ namespace {
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolEndings(r, a); } });
         t.push_back({ "find_gvar",
-            "Find where a global variable is used in the mounted .ssl script sources: every script that "
-            "reads or writes 'gvar', with line, source text, and kind 'set' (set_global_var — the action "
-            "that advances/gates a quest) or 'get' (a check). The causal link: a quest's gvar (from "
-            "quests) -> the scripts that change it -> describe_script for the logic. Needs a script-source "
-            "tree (e.g. FRP scripts_src) mounted. Args: gvar (the GVAR_* name).",
+            "Find where a global variable is used in the mounted .ssl / .h script sources: every script "
+            "that reads or writes 'gvar', with line, source text, and kind 'set' (set_global_var — the "
+            "action that advances/gates a quest) or 'get' (a check). Headers are scanned too, since many "
+            "gvars are only touched via macro aliases there (e.g. caravan.h). The causal link: a quest's "
+            "gvar (from quests) -> the scripts that change it -> describe_script for the logic. An empty "
+            "result means the gvar is genuinely unused (not an error). Needs a script-source tree (e.g. "
+            "FRP scripts_src) mounted. Args: gvar (the GVAR_* name).",
             json({ { "type", "object" }, { "properties", { { "gvar", { { "type", "string" } } } } }, { "required", json::array({ "gvar" }) } }),
             [](resource::GameResources& r, const json& a) { return toolFindGvar(r, a); } });
         t.push_back({ "script_api",

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -8,6 +8,7 @@
 #include "cli/GlobalVars.h"
 #include "cli/Quests.h"
 #include "cli/Endings.h"
+#include "cli/GvarRefs.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -286,6 +287,18 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolFindGvar(resource::GameResources& resources, const json& args) {
+        const std::string gvarName = requireString(args, "gvar");
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::findGvarRefs(resources, gvarName, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("find_gvar failed: ") + e.what(), true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
@@ -498,6 +511,14 @@ namespace {
             "No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolEndings(r, a); } });
+        t.push_back({ "find_gvar",
+            "Find where a global variable is used in the mounted .ssl script sources: every script that "
+            "reads or writes 'gvar', with line, source text, and kind 'set' (set_global_var — the action "
+            "that advances/gates a quest) or 'get' (a check). The causal link: a quest's gvar (from "
+            "quests) -> the scripts that change it -> describe_script for the logic. Needs a script-source "
+            "tree (e.g. FRP scripts_src) mounted. Args: gvar (the GVAR_* name).",
+            json({ { "type", "object" }, { "properties", { { "gvar", { { "type", "string" } } } } }, { "required", json::array({ "gvar" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolFindGvar(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -4,6 +4,7 @@
 #include "cli/MapDescribe.h"
 #include "cli/MapGraph.h"
 #include "cli/WorldMap.h"
+#include "cli/WorldEncounters.h"
 #include "cli/MapGenerator.h"
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
@@ -238,6 +239,17 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolWorldEncounters(resource::GameResources& resources, const json& /*args*/) {
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::buildWorldEncounters(resources, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("world_encounters failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolProtoInfo(resource::GameResources& resources, const json& args) {
         const auto pid = static_cast<uint32_t>(requireInt(args, "pid", 0, UINT32_MAX));
         try {
@@ -413,6 +425,15 @@ namespace {
             "by exit grids within one location. No arguments.",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json& a) { return toolWorldMap(r, a); } });
+        t.push_back({ "world_encounters",
+            "The worldmap's terrain types and random-encounter group tables, from worldmap.txt. "
+            "'terrains' (name, shortName, draw weight) and 'encounters' — each [Encounter: NAME] group "
+            "with its spawn 'entries' ({pid, ratioPercent, dead, script, items}). The shipped encounter "
+            "names are region-prefixed (ARRO_*, KLA_*, …), so they map to areas. Critter pids are raw — "
+            "resolve them with proto_info. (The geographic per-tile placement of encounters is not yet "
+            "parsed.) No arguments.",
+            json({ { "type", "object" }, { "properties", json::object() } }),
+            [](resource::GameResources& r, const json& a) { return toolWorldEncounters(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/reader/IniParser.h
+++ b/src/reader/IniParser.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <istream>
+#include <string>
+
+#include "reader/TextParsing.h"
+
+namespace geck::ini {
+
+/// Drive the line loop shared by Fallout's `[Section]` / `key=value` .txt configs (maps.txt,
+/// city.txt, worldmap.txt, ai.txt): strip inline `;` comments, skip blanks, and for each line call
+/// either @p onSection (with the trimmed text inside `[...]`, case preserved) or @p onField (with the
+/// **lowercased** key and the trimmed value). Keys before the first section are ignored. The caller
+/// supplies the section/field semantics (flush-and-start, which keys it cares about) in the callbacks,
+/// so each reader keeps only its own logic and not a copy of the loop.
+inline void parse(std::istream& in,
+    const std::function<void(const std::string& section)>& onSection,
+    const std::function<void(const std::string& key, const std::string& value)>& onField) {
+    bool inSection = false;
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string content = text::trim(text::stripComment(line));
+        if (content.empty()) {
+            continue;
+        }
+        if (content.front() == '[' && content.back() == ']') {
+            onSection(text::trim(content.substr(1, content.size() - 2)));
+            inSection = true;
+            continue;
+        }
+        if (!inSection) {
+            continue; // a stray key before the first section
+        }
+        const auto eq = content.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        onField(text::toLower(text::trim(content.substr(0, eq))), text::trim(content.substr(eq + 1)));
+    }
+}
+
+} // namespace geck::ini

--- a/src/reader/TextParsing.h
+++ b/src/reader/TextParsing.h
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 #include <string>
+#include <vector>
 
 namespace geck::text {
 
@@ -20,6 +22,33 @@ inline std::string trim(const std::string& s) {
 inline std::string toLower(std::string s) {
     std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return s;
+}
+
+/// Drop an inline `;` comment (and everything after it) — Fallout's .txt configs comment any line,
+/// including section headers, so strip before parsing.
+inline std::string stripComment(const std::string& line) {
+    return line.substr(0, line.find(';'));
+}
+
+/// Split on commas, trimming each field. Used for the comma-separated value lists (world_pos,
+/// entrance rows, terrain lists, encounter entries) in the .txt configs.
+inline std::vector<std::string> splitCsv(const std::string& s) {
+    std::vector<std::string> out;
+    std::istringstream stream(s);
+    std::string item;
+    while (std::getline(stream, item, ',')) {
+        out.push_back(trim(item));
+    }
+    return out;
+}
+
+/// std::stoi with a fallback; stops at the first non-digit, so "35%" -> 35 and "8{Wielded}" -> 8.
+inline int intOr(const std::string& s, int fallback) {
+    try {
+        return std::stoi(s);
+    } catch (const std::exception&) {
+        return fallback;
+    }
 }
 
 } // namespace geck::text

--- a/src/reader/city/CityTxtReader.cpp
+++ b/src/reader/city/CityTxtReader.cpp
@@ -4,38 +4,16 @@
 
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace geck {
 
 namespace {
 
+    using geck::text::intOr;
+    using geck::text::splitCsv;
+    using geck::text::stripComment;
     using geck::text::toLower;
     using geck::text::trim;
-
-    // city.txt uses inline ';' comments on almost every line (even section headers), so drop the
-    // comment before any other parsing.
-    std::string stripComment(const std::string& line) {
-        return line.substr(0, line.find(';'));
-    }
-
-    std::vector<std::string> splitCsv(const std::string& s) {
-        std::vector<std::string> out;
-        std::istringstream stream(s);
-        std::string item;
-        while (std::getline(stream, item, ',')) {
-            out.push_back(trim(item));
-        }
-        return out;
-    }
-
-    int intOr(const std::string& s, int fallback) {
-        try {
-            return std::stoi(s);
-        } catch (const std::exception&) {
-            return fallback;
-        }
-    }
 
     // "[Area NN]" section name -> NN, or -1 if it isn't an area section.
     int parseAreaIndex(const std::string& section) {

--- a/src/reader/city/CityTxtReader.cpp
+++ b/src/reader/city/CityTxtReader.cpp
@@ -1,0 +1,139 @@
+#include "reader/city/CityTxtReader.h"
+
+#include "reader/TextParsing.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace geck {
+
+namespace {
+
+    using geck::text::toLower;
+    using geck::text::trim;
+
+    // city.txt uses inline ';' comments on almost every line (even section headers), so drop the
+    // comment before any other parsing.
+    std::string stripComment(const std::string& line) {
+        return line.substr(0, line.find(';'));
+    }
+
+    std::vector<std::string> splitCsv(const std::string& s) {
+        std::vector<std::string> out;
+        std::istringstream stream(s);
+        std::string item;
+        while (std::getline(stream, item, ',')) {
+            out.push_back(trim(item));
+        }
+        return out;
+    }
+
+    int intOr(const std::string& s, int fallback) {
+        try {
+            return std::stoi(s);
+        } catch (const std::exception&) {
+            return fallback;
+        }
+    }
+
+    // "[Area NN]" section name -> NN, or -1 if it isn't an area section.
+    int parseAreaIndex(const std::string& section) {
+        if (toLower(section).rfind("area", 0) != 0) {
+            return -1;
+        }
+        return intOr(section.substr(4), -1); // after "Area", stoi skips the space and stops at the end
+    }
+
+    // entrance_N = state, townX, townY, map, elevation, tile, orientation
+    CityEntrance parseEntrance(const std::string& value) {
+        CityEntrance entrance;
+        const auto f = splitCsv(value);
+        if (f.size() > 0) {
+            entrance.on = toLower(f[0]) == "on";
+        }
+        if (f.size() > 1) {
+            entrance.townX = intOr(f[1], -1);
+        }
+        if (f.size() > 2) {
+            entrance.townY = intOr(f[2], -1);
+        }
+        if (f.size() > 3) {
+            entrance.map = f[3];
+        }
+        if (f.size() > 4) {
+            entrance.elevation = intOr(f[4], -1);
+        }
+        if (f.size() > 5) {
+            entrance.tile = intOr(f[5], -1);
+        }
+        if (f.size() > 6) {
+            entrance.orientation = intOr(f[6], 0);
+        }
+        return entrance;
+    }
+
+    void applyField(CityArea& area, const std::string& key, const std::string& value) {
+        if (key == "area_name") {
+            area.name = value;
+        } else if (key == "world_pos") {
+            const auto xy = splitCsv(value);
+            if (xy.size() > 0) {
+                area.worldX = intOr(xy[0], 0);
+            }
+            if (xy.size() > 1) {
+                area.worldY = intOr(xy[1], 0);
+            }
+        } else if (key == "start_state") {
+            area.startOn = toLower(value) == "on";
+        } else if (key == "size") {
+            area.size = toLower(value);
+        } else if (key.rfind("entrance_", 0) == 0) {
+            area.entrances.push_back(parseEntrance(value));
+        }
+    }
+
+} // namespace
+
+CityTxt parseCityTxt(std::istream& in) {
+    CityTxt out;
+    CityArea current;
+    bool inSection = false;
+    const auto flush = [&] {
+        if (inSection && current.index >= 0) {
+            out.areas.push_back(current);
+        }
+    };
+
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string content = trim(stripComment(line));
+        if (content.empty()) {
+            continue;
+        }
+        if (content.front() == '[' && content.back() == ']') {
+            flush();
+            current = CityArea{};
+            current.index = parseAreaIndex(trim(content.substr(1, content.size() - 2)));
+            inSection = true;
+            continue;
+        }
+        if (!inSection) {
+            continue;
+        }
+        const auto eq = content.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        applyField(current, toLower(trim(content.substr(0, eq))), trim(content.substr(eq + 1)));
+    }
+    flush();
+    return out;
+}
+
+CityTxt parseCityTxt(const std::string& text) {
+    std::istringstream in(text);
+    return parseCityTxt(in);
+}
+
+} // namespace geck

--- a/src/reader/city/CityTxtReader.cpp
+++ b/src/reader/city/CityTxtReader.cpp
@@ -1,5 +1,6 @@
 #include "reader/city/CityTxtReader.h"
 
+#include "reader/IniParser.h"
 #include "reader/TextParsing.h"
 
 #include <sstream>
@@ -11,9 +12,7 @@ namespace {
 
     using geck::text::intOr;
     using geck::text::splitCsv;
-    using geck::text::stripComment;
     using geck::text::toLower;
-    using geck::text::trim;
 
     // "[Area NN]" section name -> NN, or -1 if it isn't an area section.
     int parseAreaIndex(const std::string& section) {
@@ -83,28 +82,15 @@ CityTxt parseCityTxt(std::istream& in) {
         }
     };
 
-    std::string line;
-    while (std::getline(in, line)) {
-        const std::string content = trim(stripComment(line));
-        if (content.empty()) {
-            continue;
-        }
-        if (content.front() == '[' && content.back() == ']') {
+    ini::parse(
+        in,
+        [&](const std::string& section) {
             flush();
             current = CityArea{};
-            current.index = parseAreaIndex(trim(content.substr(1, content.size() - 2)));
+            current.index = parseAreaIndex(section);
             inSection = true;
-            continue;
-        }
-        if (!inSection) {
-            continue;
-        }
-        const auto eq = content.find('=');
-        if (eq == std::string::npos) {
-            continue;
-        }
-        applyField(current, toLower(trim(content.substr(0, eq))), trim(content.substr(eq + 1)));
-    }
+        },
+        [&](const std::string& key, const std::string& value) { applyField(current, key, value); });
     flush();
     return out;
 }

--- a/src/reader/city/CityTxtReader.h
+++ b/src/reader/city/CityTxtReader.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include "format/city/CityTxt.h"
+
+namespace geck {
+
+/// Parse Fallout 2's `data/city.txt` — an INI file with one `[Area NN]` section per worldmap
+/// location: `area_name`, `world_pos = x,y`, `start_state`, `size`, and `entrance_N = state, x, y,
+/// map, elevation, tile, orientation` lines. Reads the fields the engine reads in `wmAreaInit`
+/// (fallout2-ce worldmap.cc). Never throws — returns whatever parsed (an empty CityTxt for
+/// empty/garbage input), so a missing file just means no world layer is available.
+CityTxt parseCityTxt(std::istream& in);
+CityTxt parseCityTxt(const std::string& text);
+
+} // namespace geck

--- a/src/reader/endgame/EndgameTxtReader.cpp
+++ b/src/reader/endgame/EndgameTxtReader.cpp
@@ -1,0 +1,46 @@
+#include "reader/endgame/EndgameTxtReader.h"
+
+#include "reader/TextParsing.h"
+
+#include <sstream>
+#include <string>
+
+namespace geck {
+
+namespace {
+    using geck::text::intOr;
+    using geck::text::splitCsv;
+    using geck::text::trim;
+} // namespace
+
+EndgameTxt parseEndgameTxt(std::istream& in) {
+    EndgameTxt out;
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string content = trim(line.substr(0, line.find('#'))); // '#' starts a comment
+        if (content.empty()) {
+            continue;
+        }
+        const auto fields = splitCsv(content); // gvar, value, art, narrator [, direction]
+        if (fields.size() < 4) {
+            continue; // not a slide row
+        }
+        Ending ending;
+        ending.gvar = intOr(fields[0], -1);
+        ending.value = intOr(fields[1], 0);
+        ending.art = intOr(fields[2], -1);
+        ending.narrator = fields[3];
+        if (fields.size() > 4) {
+            ending.direction = intOr(fields[4], 0);
+        }
+        out.endings.push_back(ending);
+    }
+    return out;
+}
+
+EndgameTxt parseEndgameTxt(const std::string& text) {
+    std::istringstream in(text);
+    return parseEndgameTxt(in);
+}
+
+} // namespace geck

--- a/src/reader/endgame/EndgameTxtReader.cpp
+++ b/src/reader/endgame/EndgameTxtReader.cpp
@@ -31,7 +31,7 @@ EndgameTxt parseEndgameTxt(std::istream& in) {
         ending.art = intOr(fields[2], -1);
         ending.narrator = fields[3];
         if (fields.size() > 4) {
-            ending.direction = intOr(fields[4], 0);
+            ending.direction = intOr(fields[4], 1); // engine default is 1 (endgame.cc)
         }
         out.endings.push_back(ending);
     }

--- a/src/reader/endgame/EndgameTxtReader.h
+++ b/src/reader/endgame/EndgameTxtReader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include "format/endgame/EndgameTxt.h"
+
+namespace geck {
+
+/// Parse Fallout 2's `data/endgame.txt` — one ending slide per line: `gvar, value, art, narrator
+/// [, direction]`, comma-separated, with `#` starting a comment. Lines with fewer than four fields
+/// are skipped. Never throws — returns whatever parsed.
+EndgameTxt parseEndgameTxt(std::istream& in);
+EndgameTxt parseEndgameTxt(const std::string& text);
+
+} // namespace geck

--- a/src/reader/gam/GamReader.cpp
+++ b/src/reader/gam/GamReader.cpp
@@ -1,6 +1,5 @@
 #include "GamReader.h"
 
-#include <iostream>
 #include <regex>
 #include <spdlog/spdlog.h>
 
@@ -25,7 +24,10 @@ std::unique_ptr<Gam> GamReader::read() {
 
         auto gam = std::make_unique<Gam>(_path);
 
-        const std::regex regex_key_value(R"~(^\s*(\w+)\s*:=\s*(\d+)\s*;)~");
+        // Value may be negative (e.g. GVAR_*_PRICE := -1), so accept a leading '-'. With (\d+) those
+        // gvars were silently dropped, shifting every later gvar's ordinal — and gvar ordinals are how
+        // quests.txt / scripts reference them, so the shift mis-resolved gvar names.
+        const std::regex regex_key_value(R"~(^\s*(\w+)\s*:=\s*(-?\d+)\s*;)~");
         const std::regex regex_gvars_start(R"~(^\s*GAME_GLOBAL_VARS:)~");
         const std::regex regex_mvars_start(R"~(^\s*MAP_GLOBAL_VARS:)~");
         const std::regex regex_comment(R"~(^\s*//.*$)~");

--- a/src/reader/quests/QuestsTxtReader.cpp
+++ b/src/reader/quests/QuestsTxtReader.cpp
@@ -1,0 +1,66 @@
+#include "reader/quests/QuestsTxtReader.h"
+
+#include "reader/TextParsing.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace geck {
+
+namespace {
+
+    using geck::text::intOr;
+    using geck::text::trim;
+
+    // Split on any of space/tab/comma (the engine's questInit delimiters), dropping empty tokens.
+    std::vector<std::string> tokenize(const std::string& s) {
+        std::vector<std::string> out;
+        std::string current;
+        for (const char c : s) {
+            if (c == ' ' || c == '\t' || c == ',') {
+                if (!current.empty()) {
+                    out.push_back(current);
+                    current.clear();
+                }
+            } else {
+                current += c;
+            }
+        }
+        if (!current.empty()) {
+            out.push_back(current);
+        }
+        return out;
+    }
+
+} // namespace
+
+QuestsTxt parseQuestsTxt(std::istream& in) {
+    QuestsTxt out;
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string content = trim(line.substr(0, line.find('#'))); // '#' starts a comment
+        if (content.empty()) {
+            continue;
+        }
+        const auto tokens = tokenize(content);
+        if (tokens.size() < 5) {
+            continue; // not a quest row
+        }
+        Quest quest;
+        quest.location = intOr(tokens[0], -1);
+        quest.description = intOr(tokens[1], -1);
+        quest.gvar = intOr(tokens[2], -1);
+        quest.displayThreshold = intOr(tokens[3], 0);
+        quest.completedThreshold = intOr(tokens[4], 0);
+        out.quests.push_back(quest);
+    }
+    return out;
+}
+
+QuestsTxt parseQuestsTxt(const std::string& text) {
+    std::istringstream in(text);
+    return parseQuestsTxt(in);
+}
+
+} // namespace geck

--- a/src/reader/quests/QuestsTxtReader.h
+++ b/src/reader/quests/QuestsTxtReader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include "format/quests/QuestsTxt.h"
+
+namespace geck {
+
+/// Parse Fallout 2's `data/quests.txt` — one quest per line, five integers separated by any of
+/// space/tab/comma, `#` starting a comment (matching the engine's `questInit` tokenizer). Lines with
+/// fewer than five integers are skipped. Never throws — returns whatever parsed.
+QuestsTxt parseQuestsTxt(std::istream& in);
+QuestsTxt parseQuestsTxt(const std::string& text);
+
+} // namespace geck

--- a/src/reader/worldmap/WorldmapTxtReader.cpp
+++ b/src/reader/worldmap/WorldmapTxtReader.cpp
@@ -1,0 +1,149 @@
+#include "reader/worldmap/WorldmapTxtReader.h"
+
+#include "reader/TextParsing.h"
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace geck {
+
+namespace {
+
+    using geck::text::toLower;
+    using geck::text::trim;
+
+    // worldmap.txt uses inline ';' comments throughout (even on section headers), so drop the comment
+    // before any other parsing.
+    std::string stripComment(const std::string& line) {
+        return line.substr(0, line.find(';'));
+    }
+
+    std::vector<std::string> splitCsv(const std::string& s) {
+        std::vector<std::string> out;
+        std::istringstream stream(s);
+        std::string item;
+        while (std::getline(stream, item, ',')) {
+            out.push_back(trim(item));
+        }
+        return out;
+    }
+
+    // stoi that stops at the first non-digit, so "35%" -> 35 and "8{Wielded}" -> 8; fallback on junk.
+    int intOr(const std::string& s, int fallback) {
+        try {
+            return std::stoi(s);
+        } catch (const std::exception&) {
+            return fallback;
+        }
+    }
+
+    // [Data]: terrain_types = "Desert:1, Mountain:2, …"; terrain_short_names = "DES, MNT, …" (aligned
+    // to terrain_types by position).
+    void applyDataField(WorldmapTxt& out, const std::string& key, const std::string& value) {
+        if (key == "terrain_types") {
+            for (const auto& pair : splitCsv(value)) {
+                const auto colon = pair.find(':');
+                WorldmapTerrain terrain;
+                terrain.name = colon == std::string::npos ? pair : trim(pair.substr(0, colon));
+                terrain.weight = colon == std::string::npos ? 0 : intOr(trim(pair.substr(colon + 1)), 0);
+                out.terrains.push_back(terrain);
+            }
+        } else if (key == "terrain_short_names") {
+            const auto shorts = splitCsv(value);
+            for (std::size_t i = 0; i < shorts.size() && i < out.terrains.size(); ++i) {
+                out.terrains[i].shortName = shorts[i];
+            }
+        }
+    }
+
+    // type_NN = "Ratio:35%, pid:16777252, Item:8{Wielded}, Item:40, Script:255" (or a bare "Dead").
+    EncounterEntry parseEncounterEntry(const std::string& value) {
+        EncounterEntry entry;
+        for (const auto& field : splitCsv(value)) {
+            const auto colon = field.find(':');
+            if (colon == std::string::npos) {
+                if (toLower(field) == "dead") {
+                    entry.dead = true;
+                }
+                continue;
+            }
+            const std::string key = toLower(trim(field.substr(0, colon)));
+            const std::string val = trim(field.substr(colon + 1));
+            if (key == "pid") {
+                entry.pid = intOr(val, -1);
+            } else if (key == "ratio") {
+                entry.ratioPercent = intOr(val, 0);
+            } else if (key == "script") {
+                entry.script = intOr(val, -1);
+            } else if (key == "distance") {
+                entry.distance = intOr(val, -1);
+            } else if (key == "item") {
+                entry.items.push_back(intOr(val, -1));
+            }
+        }
+        return entry;
+    }
+
+    enum class Mode {
+        Other,
+        Data,
+        Encounter
+    };
+
+} // namespace
+
+WorldmapTxt parseWorldmapTxt(std::istream& in) {
+    WorldmapTxt out;
+    Mode mode = Mode::Other;
+    Encounter current;
+    const auto flushEncounter = [&] {
+        if (mode == Mode::Encounter && !current.name.empty()) {
+            out.encounters.push_back(current);
+        }
+    };
+
+    std::string line;
+    while (std::getline(in, line)) {
+        const std::string content = trim(stripComment(line));
+        if (content.empty()) {
+            continue;
+        }
+        if (content.front() == '[' && content.back() == ']') {
+            flushEncounter();
+            const std::string section = trim(content.substr(1, content.size() - 2));
+            const std::string lower = toLower(section);
+            if (lower == "data") {
+                mode = Mode::Data;
+            } else if (lower.rfind("encounter:", 0) == 0) {
+                mode = Mode::Encounter;
+                current = Encounter{};
+                current.name = trim(section.substr(std::string("encounter:").size()));
+            } else {
+                mode = Mode::Other; // [Random Maps: …], [Tile Data], [Tile NN], … are not parsed
+            }
+            continue;
+        }
+        const auto eq = content.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        const std::string key = toLower(trim(content.substr(0, eq)));
+        const std::string value = trim(content.substr(eq + 1));
+        if (mode == Mode::Data) {
+            applyDataField(out, key, value);
+        } else if (mode == Mode::Encounter && key.rfind("type_", 0) == 0) {
+            current.entries.push_back(parseEncounterEntry(value));
+        }
+    }
+    flushEncounter();
+    return out;
+}
+
+WorldmapTxt parseWorldmapTxt(const std::string& text) {
+    std::istringstream in(text);
+    return parseWorldmapTxt(in);
+}
+
+} // namespace geck

--- a/src/reader/worldmap/WorldmapTxtReader.cpp
+++ b/src/reader/worldmap/WorldmapTxtReader.cpp
@@ -5,39 +5,16 @@
 #include <cstddef>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace geck {
 
 namespace {
 
+    using geck::text::intOr;
+    using geck::text::splitCsv;
+    using geck::text::stripComment;
     using geck::text::toLower;
     using geck::text::trim;
-
-    // worldmap.txt uses inline ';' comments throughout (even on section headers), so drop the comment
-    // before any other parsing.
-    std::string stripComment(const std::string& line) {
-        return line.substr(0, line.find(';'));
-    }
-
-    std::vector<std::string> splitCsv(const std::string& s) {
-        std::vector<std::string> out;
-        std::istringstream stream(s);
-        std::string item;
-        while (std::getline(stream, item, ',')) {
-            out.push_back(trim(item));
-        }
-        return out;
-    }
-
-    // stoi that stops at the first non-digit, so "35%" -> 35 and "8{Wielded}" -> 8; fallback on junk.
-    int intOr(const std::string& s, int fallback) {
-        try {
-            return std::stoi(s);
-        } catch (const std::exception&) {
-            return fallback;
-        }
-    }
 
     // [Data]: terrain_types = "Desert:1, Mountain:2, …"; terrain_short_names = "DES, MNT, …" (aligned
     // to terrain_types by position).

--- a/src/reader/worldmap/WorldmapTxtReader.cpp
+++ b/src/reader/worldmap/WorldmapTxtReader.cpp
@@ -1,5 +1,6 @@
 #include "reader/worldmap/WorldmapTxtReader.h"
 
+#include "reader/IniParser.h"
 #include "reader/TextParsing.h"
 
 #include <cstddef>
@@ -12,7 +13,6 @@ namespace {
 
     using geck::text::intOr;
     using geck::text::splitCsv;
-    using geck::text::stripComment;
     using geck::text::toLower;
     using geck::text::trim;
 
@@ -81,15 +81,10 @@ WorldmapTxt parseWorldmapTxt(std::istream& in) {
         }
     };
 
-    std::string line;
-    while (std::getline(in, line)) {
-        const std::string content = trim(stripComment(line));
-        if (content.empty()) {
-            continue;
-        }
-        if (content.front() == '[' && content.back() == ']') {
+    ini::parse(
+        in,
+        [&](const std::string& section) {
             flushEncounter();
-            const std::string section = trim(content.substr(1, content.size() - 2));
             const std::string lower = toLower(section);
             if (lower == "data") {
                 mode = Mode::Data;
@@ -100,20 +95,14 @@ WorldmapTxt parseWorldmapTxt(std::istream& in) {
             } else {
                 mode = Mode::Other; // [Random Maps: …], [Tile Data], [Tile NN], … are not parsed
             }
-            continue;
-        }
-        const auto eq = content.find('=');
-        if (eq == std::string::npos) {
-            continue;
-        }
-        const std::string key = toLower(trim(content.substr(0, eq)));
-        const std::string value = trim(content.substr(eq + 1));
-        if (mode == Mode::Data) {
-            applyDataField(out, key, value);
-        } else if (mode == Mode::Encounter && key.rfind("type_", 0) == 0) {
-            current.entries.push_back(parseEncounterEntry(value));
-        }
-    }
+        },
+        [&](const std::string& key, const std::string& value) {
+            if (mode == Mode::Data) {
+                applyDataField(out, key, value);
+            } else if (mode == Mode::Encounter && key.rfind("type_", 0) == 0) {
+                current.entries.push_back(parseEncounterEntry(value));
+            }
+        });
     flushEncounter();
     return out;
 }

--- a/src/reader/worldmap/WorldmapTxtReader.cpp
+++ b/src/reader/worldmap/WorldmapTxtReader.cpp
@@ -24,7 +24,7 @@ namespace {
                 const auto colon = pair.find(':');
                 WorldmapTerrain terrain;
                 terrain.name = colon == std::string::npos ? pair : trim(pair.substr(0, colon));
-                terrain.weight = colon == std::string::npos ? 0 : intOr(trim(pair.substr(colon + 1)), 0);
+                terrain.difficulty = colon == std::string::npos ? 0 : intOr(trim(pair.substr(colon + 1)), 0);
                 out.terrains.push_back(terrain);
             }
         } else if (key == "terrain_short_names") {
@@ -32,6 +32,24 @@ namespace {
             for (std::size_t i = 0; i < shorts.size() && i < out.terrains.size(); ++i) {
                 out.terrains[i].shortName = shorts[i];
             }
+        }
+    }
+
+    // A [Tile NN] subtile line: key "row_column" (row 0-6, column 0-5) -> "terrain, fill, chances, …".
+    // We keep the terrain (the first field).
+    void applyTileField(WorldmapTile& tile, const std::string& key, const std::string& value) {
+        const auto underscore = key.find('_');
+        if (underscore == std::string::npos) {
+            return;
+        }
+        const int row = intOr(key.substr(0, underscore), -1);
+        const int col = intOr(key.substr(underscore + 1), -1);
+        if (row < 0 || row >= SUBTILE_GRID_WIDTH || col < 0 || col >= SUBTILE_GRID_HEIGHT) {
+            return;
+        }
+        const auto fields = splitCsv(value);
+        if (!fields.empty()) {
+            tile.terrain[row][col] = fields[0];
         }
     }
 
@@ -66,44 +84,82 @@ namespace {
     enum class Mode {
         Other,
         Data,
-        Encounter
+        Encounter,
+        TileData,
+        Tile
     };
+
+    struct ParseState {
+        Mode mode = Mode::Other;
+        Encounter current;
+        int currentTile = -1;
+    };
+
+    void flushEncounter(WorldmapTxt& out, ParseState& st) {
+        if (st.mode == Mode::Encounter && !st.current.name.empty()) {
+            out.encounters.push_back(st.current);
+        }
+    }
+
+    // Start a new [Section]: flush any pending encounter, then switch parse mode.
+    void selectSection(const std::string& section, WorldmapTxt& out, ParseState& st) {
+        flushEncounter(out, st);
+        const std::string lower = toLower(section);
+        if (lower == "data") {
+            st.mode = Mode::Data;
+        } else if (lower == "tile data") {
+            st.mode = Mode::TileData;
+        } else if (lower.rfind("tile ", 0) == 0) {
+            st.mode = Mode::Tile;
+            st.currentTile = intOr(section.substr(std::string("tile ").size()), -1);
+            if (st.currentTile >= 0 && st.currentTile >= static_cast<int>(out.tiles.size())) {
+                out.tiles.resize(st.currentTile + 1);
+            }
+        } else if (lower.rfind("encounter:", 0) == 0) {
+            st.mode = Mode::Encounter;
+            st.current = Encounter{};
+            st.current.name = trim(section.substr(std::string("encounter:").size()));
+        } else {
+            st.mode = Mode::Other; // [Random Maps: …] etc. are not parsed
+        }
+    }
+
+    // Apply a key=value line according to the current parse mode.
+    void applyField(const std::string& key, const std::string& value, WorldmapTxt& out, ParseState& st) {
+        switch (st.mode) {
+            case Mode::Data:
+                applyDataField(out, key, value);
+                break;
+            case Mode::TileData:
+                if (key == "num_horizontal_tiles") {
+                    out.numHorizontalTiles = intOr(value, 0);
+                }
+                break;
+            case Mode::Tile:
+                if (st.currentTile >= 0 && st.currentTile < static_cast<int>(out.tiles.size())) {
+                    applyTileField(out.tiles[st.currentTile], key, value);
+                }
+                break;
+            case Mode::Encounter:
+                if (key.rfind("type_", 0) == 0) {
+                    st.current.entries.push_back(parseEncounterEntry(value));
+                }
+                break;
+            default:
+                break;
+        }
+    }
 
 } // namespace
 
 WorldmapTxt parseWorldmapTxt(std::istream& in) {
     WorldmapTxt out;
-    Mode mode = Mode::Other;
-    Encounter current;
-    const auto flushEncounter = [&] {
-        if (mode == Mode::Encounter && !current.name.empty()) {
-            out.encounters.push_back(current);
-        }
-    };
-
+    ParseState st;
     ini::parse(
         in,
-        [&](const std::string& section) {
-            flushEncounter();
-            const std::string lower = toLower(section);
-            if (lower == "data") {
-                mode = Mode::Data;
-            } else if (lower.rfind("encounter:", 0) == 0) {
-                mode = Mode::Encounter;
-                current = Encounter{};
-                current.name = trim(section.substr(std::string("encounter:").size()));
-            } else {
-                mode = Mode::Other; // [Random Maps: …], [Tile Data], [Tile NN], … are not parsed
-            }
-        },
-        [&](const std::string& key, const std::string& value) {
-            if (mode == Mode::Data) {
-                applyDataField(out, key, value);
-            } else if (mode == Mode::Encounter && key.rfind("type_", 0) == 0) {
-                current.entries.push_back(parseEncounterEntry(value));
-            }
-        });
-    flushEncounter();
+        [&](const std::string& section) { selectSection(section, out, st); },
+        [&](const std::string& key, const std::string& value) { applyField(key, value, out, st); });
+    flushEncounter(out, st);
     return out;
 }
 

--- a/src/reader/worldmap/WorldmapTxtReader.h
+++ b/src/reader/worldmap/WorldmapTxtReader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+#include "format/worldmap/WorldmapTxt.h"
+
+namespace geck {
+
+/// Parse Fallout 2's `data/worldmap.txt` — the `[Data]` terrain types and the `[Encounter: NAME]`
+/// random-encounter group tables (`type_NN = Ratio:…, pid:…, …`). The large `[Tile NN]` sub-tile
+/// grid is intentionally skipped (see WorldmapTxt). Never throws — returns whatever parsed (an empty
+/// WorldmapTxt for empty/garbage input).
+WorldmapTxt parseWorldmapTxt(std::istream& in);
+WorldmapTxt parseWorldmapTxt(const std::string& text);
+
+} // namespace geck

--- a/src/resource/MapNameResolver.cpp
+++ b/src/resource/MapNameResolver.cpp
@@ -58,4 +58,14 @@ int MapNameResolver::indexOf(const std::string& mapFileName) const {
     return info != nullptr ? info->index : -1;
 }
 
+std::string MapNameResolver::fileNameOfLookup(const std::string& lookupName) const {
+    const MapInfo* info = _mapsTxt.findByLookupName(lookupName);
+    return info != nullptr ? info->mapName : std::string{};
+}
+
+std::string MapNameResolver::lookupNameOf(const std::string& mapFileName) const {
+    const MapInfo* info = _mapsTxt.findByName(toLower(mapFileName));
+    return info != nullptr ? info->lookupName : std::string{};
+}
+
 } // namespace geck::resource

--- a/src/resource/MapNameResolver.h
+++ b/src/resource/MapNameResolver.h
@@ -32,6 +32,15 @@ public:
     /// The maps.txt index for a .map filename (basename, any case), or -1 if absent.
     int indexOf(const std::string& mapFileName) const;
 
+    /// The .map filename for a maps.txt lookup_name (city.txt's entrance map key, e.g. "Arroyo
+    /// Bridge"), case-insensitive, or "" if no map has that lookup_name. The join from the worldmap
+    /// layer (city.txt areas) to the .map files / exit-grid graph.
+    std::string fileNameOfLookup(const std::string& lookupName) const;
+
+    /// The lookup_name for a .map filename (basename, any case), or "" if absent. The reverse join,
+    /// from a .map file to the worldmap key city.txt uses.
+    std::string lookupNameOf(const std::string& mapFileName) const;
+
 private:
     GameResources& _resources;
     MapsTxt _mapsTxt;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(general_tests
     general/test_city_txt.cpp
     general/test_worldmap_txt.cpp
     general/test_quests_txt.cpp
+    general/test_endgame_txt.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(general_tests
     general/test_reading_gam.cpp
     general/test_ai_txt.cpp
     general/test_maps_txt.cpp
+    general/test_city_txt.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(general_tests
     general/test_maps_txt.cpp
     general/test_city_txt.cpp
     general/test_worldmap_txt.cpp
+    general/test_quests_txt.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(general_tests
     general/test_worldmap_txt.cpp
     general/test_quests_txt.cpp
     general/test_endgame_txt.cpp
+    general/test_gvar_refs.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(general_tests
     general/test_ai_txt.cpp
     general/test_maps_txt.cpp
     general/test_city_txt.cpp
+    general/test_worldmap_txt.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/general/test_city_txt.cpp
+++ b/tests/general/test_city_txt.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/city/CityTxt.h"
+#include "reader/city/CityTxtReader.h"
+
+using namespace geck;
+
+namespace {
+// A trimmed-down city.txt in the real format: inline ';' comments on section headers and values
+// (which the reader must strip), world_pos, the yes/no start_state, and entrance lines whose map
+// field is a lookup_name with a space (so it survives the comma split).
+constexpr const char* kCityTxt = R"(; City datafile for worldmap
+[Area 00]                ; Arroyo
+area_name=Arroyo
+world_pos=184,133        ; Absolute position ; SAVED
+start_state=On           ; Starting state
+size=Medium              ; Size of circle
+townmap_art_idx=156
+entrance_0=On,350,275,Arroyo Bridge,-1,-1,3  ; Etc.
+entrance_1=On,280,175,Arroyo Village,-1,-1,0
+entrance_2=Off,-1,-1,Arroyo Caves,-1,-1,0
+
+[Area 01]                ; The Den
+area_name=The Den
+world_pos=308,213
+start_state=Off
+size=Large
+entrance_0=On,300,300,Den,-1,-1,2
+)";
+} // namespace
+
+TEST_CASE("parseCityTxt reads worldmap areas, positions and entrances", "[city]") {
+    const CityTxt city = parseCityTxt(std::string{ kCityTxt });
+
+    CHECK(city.areas.size() == 2);
+
+    const CityArea* arroyo = city.find(0);
+    REQUIRE(arroyo != nullptr);
+    CHECK(arroyo->name == "Arroyo");
+    CHECK(arroyo->worldX == 184); // world_pos x, inline comment stripped
+    CHECK(arroyo->worldY == 133);
+    CHECK(arroyo->startOn == true);
+    CHECK(arroyo->size == "medium");
+    REQUIRE(arroyo->entrances.size() == 3);
+    CHECK(arroyo->entrances[0].on == true);
+    CHECK(arroyo->entrances[0].map == "Arroyo Bridge"); // lookup_name with a space survives the split
+    CHECK(arroyo->entrances[0].orientation == 3);
+    CHECK(arroyo->entrances[2].on == false);
+    CHECK(arroyo->entrances[2].map == "Arroyo Caves");
+
+    const CityArea* den = city.find(1);
+    REQUIRE(den != nullptr);
+    CHECK(den->name == "The Den");
+    CHECK(den->worldX == 308);
+    CHECK(den->size == "large");
+    REQUIRE(den->entrances.size() == 1);
+    CHECK(den->entrances[0].map == "Den");
+
+    CHECK(city.find(99) == nullptr);
+}
+
+TEST_CASE("parseCityTxt tolerates empty input", "[city]") {
+    CHECK(parseCityTxt(std::string{}).areas.empty());
+}

--- a/tests/general/test_endgame_txt.cpp
+++ b/tests/general/test_endgame_txt.cpp
@@ -25,7 +25,7 @@ TEST_CASE("parseEndgameTxt reads ending slides, skipping comments and short line
     CHECK(endgame.endings[0].value == 1);
     CHECK(endgame.endings[0].art == 440);
     CHECK(endgame.endings[0].narrator == "nar_ar1");
-    CHECK(endgame.endings[0].direction == 0);
+    CHECK(endgame.endings[0].direction == 1); // no 5th field -> engine default 1 (not 0)
 
     CHECK(endgame.endings[1].narrator == "nar_eldr"); // inline '#' comment stripped
     CHECK(endgame.endings[2].direction == 1);         // optional 5th field (panning-desert art)

--- a/tests/general/test_endgame_txt.cpp
+++ b/tests/general/test_endgame_txt.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/endgame/EndgameTxt.h"
+#include "reader/endgame/EndgameTxtReader.h"
+
+using namespace geck;
+
+namespace {
+// endgame.txt rows: comma-separated, an inline '#' comment, the optional 5th 'direction' field, and a
+// too-short line that must be skipped.
+constexpr const char* kEndgameTxt = R"(# gvar, value, art, narrator [, direction]
+408, 1, 440, nar_ar1
+700, 1, 471, nar_eldr #471 - killap
+40, 1, 327, nar_10, 1
+bad, line
+)";
+} // namespace
+
+TEST_CASE("parseEndgameTxt reads ending slides, skipping comments and short lines", "[endgame]") {
+    const EndgameTxt endgame = parseEndgameTxt(std::string{ kEndgameTxt });
+
+    REQUIRE(endgame.endings.size() == 3);
+
+    CHECK(endgame.endings[0].gvar == 408);
+    CHECK(endgame.endings[0].value == 1);
+    CHECK(endgame.endings[0].art == 440);
+    CHECK(endgame.endings[0].narrator == "nar_ar1");
+    CHECK(endgame.endings[0].direction == 0);
+
+    CHECK(endgame.endings[1].narrator == "nar_eldr"); // inline '#' comment stripped
+    CHECK(endgame.endings[2].direction == 1);         // optional 5th field (panning-desert art)
+}
+
+TEST_CASE("parseEndgameTxt tolerates empty input", "[endgame]") {
+    CHECK(parseEndgameTxt(std::string{}).endings.empty());
+}

--- a/tests/general/test_gvar_refs.cpp
+++ b/tests/general/test_gvar_refs.cpp
@@ -1,0 +1,81 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "cli/GvarRefs.h"
+#include "resource/GameResources.h"
+
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+using namespace geck;
+namespace fs = std::filesystem;
+
+namespace {
+
+void writeFile(const fs::path& path, const std::string& contents) {
+    fs::create_directories(path.parent_path());
+    std::ofstream(path) << contents;
+}
+
+nlohmann::json runFindGvar(const fs::path& root, const std::string& gvar, int& rc) {
+    resource::GameResources resources;
+    resources.files().addDataPath(root.string());
+    std::ostringstream oss;
+    rc = cli::findGvarRefs(resources, gvar, oss);
+    return nlohmann::json::parse(oss.str());
+}
+
+} // namespace
+
+TEST_CASE("findGvarRefs classifies set/get, honors word boundaries, scans headers, ignores comments", "[gvar_refs]") {
+    const fs::path root = fs::path{ GECK_TEST_TMP_DIR } / "gvar_refs_src";
+    fs::remove_all(root);
+    writeFile(root / "a.ssl",
+        "if (global_var(GVAR_FOO) == 1) then begin\n" // get
+        "   set_global_var(GVAR_FOO, 2);\n"           // set
+        "end\n"
+        "// set_global_var(GVAR_FOO, 9);  commented out\n" // line comment -> ignored
+        "x := global_var(GVAR_FOOBAR);\n");                // must NOT match GVAR_FOO
+    writeFile(root / "headers" / "caravan.h",
+        "#define get_foo   global_var(GVAR_FOO)\n"); // gvar reached only via a header macro -> a get
+
+    int rc = -1;
+    const auto j = runFindGvar(root, "GVAR_FOO", rc);
+
+    CHECK(rc == 0);
+    CHECK(j["stats"]["refs"] == 3);    // a.ssl get + set (comment excluded) + caravan.h macro
+    CHECK(j["stats"]["setters"] == 1); // only the set_global_var line
+    CHECK(j["stats"]["scripts"] == 2); // a.ssl + caravan.h
+    bool sawFoobar = false;
+    for (const auto& ref : j["refs"]) {
+        if (ref["text"].get<std::string>().find("GVAR_FOOBAR") != std::string::npos) {
+            sawFoobar = true;
+        }
+    }
+    CHECK_FALSE(sawFoobar); // whole-word match: GVAR_FOO must not match GVAR_FOOBAR
+    fs::remove_all(root);
+}
+
+TEST_CASE("findGvarRefs: unused-with-sources is success, no-sources is an error", "[gvar_refs]") {
+    const fs::path root = fs::path{ GECK_TEST_TMP_DIR } / "gvar_refs_empty";
+    fs::remove_all(root);
+    writeFile(root / "a.ssl", "set_global_var(GVAR_OTHER, 1);\n");
+
+    int rc = -1;
+    const auto j = runFindGvar(root, "GVAR_NEVER_USED", rc);
+    CHECK(rc == 0); // scanned a source, found nothing -> a valid "unused" answer, not an error
+    CHECK(j["stats"]["refs"] == 0);
+    fs::remove_all(root);
+
+    // Nothing mounted at all -> error, so the MCP flags isError (vs. a genuine "unused").
+    resource::GameResources empty;
+    std::ostringstream oss;
+    CHECK(cli::findGvarRefs(empty, "GVAR_FOO", oss) != 0);
+}

--- a/tests/general/test_maps_txt.cpp
+++ b/tests/general/test_maps_txt.cpp
@@ -69,6 +69,13 @@ TEST_CASE("parseMapsTxt reads map sections keyed by their [Map NNN] index", "[ma
     CHECK(maps.findByName("artemple.map")->index == 3);
     CHECK(maps.findByName("desert1.map") == maps.find(0));
     CHECK(maps.findByName("nosuch.map") == nullptr);
+
+    // Lookup by lookup_name, case-insensitive (the join from city.txt entrances to .map files).
+    REQUIRE(maps.findByLookupName("Temple") != nullptr);
+    CHECK(maps.findByLookupName("Temple")->mapName == "artemple.map");
+    CHECK(maps.findByLookupName("temple") == maps.find(3)); // case-insensitive
+    CHECK(maps.findByLookupName("Desert Encounter") == maps.find(0));
+    CHECK(maps.findByLookupName("nope") == nullptr);
 }
 
 TEST_CASE("parseMapsTxt tolerates empty / section-less input", "[maps]") {

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -103,6 +103,12 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
     SECTION("describe_map without a map is a tool error") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 12 }, { "method", "tools/call" },
             { "params", { { "name", "describe_map" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("map_graph with no data mounted reports a tool error (no maps found)") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 13 }, { "method", "tools/call" },
+            { "params", { { "name", "map_graph" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
 

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -109,6 +109,12 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
     SECTION("map_graph with no data mounted reports a tool error (no maps found)") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 13 }, { "method", "tools/call" },
             { "params", { { "name", "map_graph" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("world_map with no data mounted reports a tool error (no city.txt)") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 14 }, { "method", "tools/call" },
+            { "params", { { "name", "world_map" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
 

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -122,6 +122,18 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 15 }, { "method", "tools/call" },
             { "params", { { "name", "world_encounters" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("quests / gvars with no data mounted report tool errors (no quests.txt / vault13.gam)") {
+        const json q = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 16 }, { "method", "tools/call" },
+            { "params", { { "name", "quests" }, { "arguments", json::object() } } } });
+        CHECK(q["result"]["isError"] == true);
+        const json g = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 17 }, { "method", "tools/call" },
+            { "params", { { "name", "gvars" }, { "arguments", json::object() } } } });
+        CHECK(g["result"]["isError"] == true);
+        const json e = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 18 }, { "method", "tools/call" },
+            { "params", { { "name", "endings" }, { "arguments", json::object() } } } });
+        CHECK(e["result"]["isError"] == true);
     }
 
     SECTION("bad argument types and out-of-range numbers are tool errors, not silent casts") {

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -115,6 +115,12 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
     SECTION("world_map with no data mounted reports a tool error (no city.txt)") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 14 }, { "method", "tools/call" },
             { "params", { { "name", "world_map" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("world_encounters with no data mounted reports a tool error (no worldmap.txt)") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 15 }, { "method", "tools/call" },
+            { "params", { { "name", "world_encounters" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
 

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "generate", "render_map", "extract_pattern", "script_api" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -150,6 +150,8 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
         CHECK(call("render_map", { { "map", 123 }, { "out", "o.png" } }, 23)["result"]["isError"] == true);
         // A negative entry in a pid array would have wrapped too.
         CHECK(call("extract_pattern", { { "map", "m" }, { "out", "o" }, { "name", "n" }, { "pids", json::array({ -1 }) } }, 24)["result"]["isError"] == true);
+        // find_gvar requires a non-empty gvar name (empty would match every line).
+        CHECK(call("find_gvar", json::object(), 25)["result"]["isError"] == true);
     }
 
     SECTION("ping is answered promptly with an empty result") {

--- a/tests/general/test_quests_txt.cpp
+++ b/tests/general/test_quests_txt.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/quests/QuestsTxt.h"
+#include "reader/quests/QuestsTxtReader.h"
+
+using namespace geck;
+
+namespace {
+// quests.txt rows: comma-separated, an inline '#' comment, a full-line comment, a space-separated row
+// (the engine tokenizes on space/tab/comma), and a too-short line that must be skipped.
+constexpr const char* kQuestsTxt = R"(# location  description  gvar  display  completed
+1500, 100, 9, 2, 6
+1500, 130, 480, 0, 1   # Retrieve the GECK for Arroyo
+# a full-line comment
+1501 200 100 1 2
+badline
+)";
+} // namespace
+
+TEST_CASE("parseQuestsTxt reads quest rows, skipping comments and short lines", "[quests]") {
+    const QuestsTxt quests = parseQuestsTxt(std::string{ kQuestsTxt });
+
+    REQUIRE(quests.quests.size() == 3);
+
+    CHECK(quests.quests[0].location == 1500);
+    CHECK(quests.quests[0].description == 100);
+    CHECK(quests.quests[0].gvar == 9);
+    CHECK(quests.quests[0].displayThreshold == 2);
+    CHECK(quests.quests[0].completedThreshold == 6);
+
+    CHECK(quests.quests[1].gvar == 480); // inline '#' comment stripped
+    CHECK(quests.quests[1].completedThreshold == 1);
+
+    CHECK(quests.quests[2].location == 1501); // space-separated row also parses
+    CHECK(quests.quests[2].gvar == 100);
+}
+
+TEST_CASE("parseQuestsTxt tolerates empty input", "[quests]") {
+    CHECK(parseQuestsTxt(std::string{}).quests.empty());
+}

--- a/tests/general/test_reading_gam.cpp
+++ b/tests/general/test_reading_gam.cpp
@@ -32,17 +32,22 @@ TEST_CASE("GamReader parses gvars and mvars, skipping comments and blanks", "[ga
                                                       "// a comment\n"
                                                       "GVAR_FOO := 5 ;\n"
                                                       "\n"
+                                                      "GVAR_NEG := -1 ;\n" // negative default must be read, not skipped
                                                       "GVAR_BAR := 10 ;\n"
                                                       "MAP_GLOBAL_VARS:\n"
                                                       "MVAR_BAZ := 7 ;\n"));
 
     REQUIRE(gam != nullptr);
     CHECK(gam->gvarValue("GVAR_FOO") == 5);
+    CHECK(gam->gvarValue("GVAR_NEG") == -1);
     CHECK(gam->gvarValue("GVAR_BAR") == 10);
     CHECK(gam->mvarValue("MVAR_BAZ") == 7);
-    // Variables keep their file order.
+    // Variables keep their file order — a negative-default gvar must not be dropped, or every later
+    // gvar's ordinal shifts (gvar ordinals are how quests.txt / scripts reference them).
+    CHECK(gam->gvarCount() == 3);
     CHECK(gam->gvarKey(0) == "GVAR_FOO");
-    CHECK(gam->gvarValue(1) == 10);
+    CHECK(gam->gvarKey(1) == "GVAR_NEG");
+    CHECK(gam->gvarValue(2) == 10); // GVAR_BAR keeps ordinal 2, not shifted to 1
     CHECK(gam->mvarValue(0) == 7);
 }
 

--- a/tests/general/test_worldmap_txt.cpp
+++ b/tests/general/test_worldmap_txt.cpp
@@ -21,11 +21,11 @@ terrain_short_names=DES, MNT, CTY, OCN ; WIP
 map_00=desert1
 
 [Encounter: Raiders]  ; WIP!
-type_00=Ratio:35%, pid:16777252, Item:8{Wielded}, Item:40, Script:255
+type_00=Ratio:35%, pid:16777252, Item:8{Wielded}, Item:40, Script:255, Distance:7
 type_01=Dead, pid:16777220, Item:40, Script:256
 
 [Encounter: ARRO_Rats]
-type_00=Ratio:100%, pid:16777276
+type_00=ratio:100%, pid:16777276, Distance:3
 )";
 } // namespace
 
@@ -48,15 +48,18 @@ TEST_CASE("parseWorldmapTxt reads terrain types and encounter groups", "[worldma
     CHECK(raiders->entries[0].ratioPercent == 35); // "35%" parsed
     CHECK(raiders->entries[0].dead == false);
     CHECK(raiders->entries[0].script == 255);
+    CHECK(raiders->entries[0].distance == 7);                      // Distance:NN branch
     CHECK(raiders->entries[0].items == std::vector<int>{ 8, 40 }); // "8{Wielded}" -> 8
     CHECK(raiders->entries[1].dead == true);                       // bare "Dead" flag
     CHECK(raiders->entries[1].pid == 16777220);
+    CHECK(raiders->entries[1].distance == -1); // absent -> default
 
     const Encounter* rats = world.findEncounter("ARRO_Rats");
     REQUIRE(rats != nullptr);
     REQUIRE(rats->entries.size() == 1);
     CHECK(rats->entries[0].pid == 16777276);
-    CHECK(rats->entries[0].ratioPercent == 100);
+    CHECK(rats->entries[0].ratioPercent == 100); // lowercase "ratio:" key still parsed
+    CHECK(rats->entries[0].distance == 3);
 
     CHECK(world.findEncounter("Nope") == nullptr);
 }

--- a/tests/general/test_worldmap_txt.cpp
+++ b/tests/general/test_worldmap_txt.cpp
@@ -35,9 +35,9 @@ TEST_CASE("parseWorldmapTxt reads terrain types and encounter groups", "[worldma
     REQUIRE(world.terrains.size() == 4);
     CHECK(world.terrains[0].name == "Desert");
     CHECK(world.terrains[0].shortName == "DES");
-    CHECK(world.terrains[0].weight == 1);
+    CHECK(world.terrains[0].difficulty == 1);
     CHECK(world.terrains[1].name == "Mountain");
-    CHECK(world.terrains[1].weight == 2);
+    CHECK(world.terrains[1].difficulty == 2);
     CHECK(world.terrains[3].shortName == "OCN");
 
     REQUIRE(world.encounters.size() == 2);
@@ -61,7 +61,36 @@ TEST_CASE("parseWorldmapTxt reads terrain types and encounter groups", "[worldma
     CHECK(world.findEncounter("Nope") == nullptr);
 }
 
+TEST_CASE("parseWorldmapTxt reads the [Tile NN] grid and terrainAt maps pixels to terrain", "[worldmap]") {
+    constexpr const char* kTiles = R"(
+[Data]
+terrain_types=Desert:1, Mountain:4, Ocean:2
+[Tile Data]
+num_horizontal_tiles=2
+[Tile 0]
+0_0=Desert, No_Fill, None, None, None, Desert1
+1_0=Mountain, No_Fill, None, None, None, Mtn
+0_1=Ocean, Fill_W, None, None, None, Fish
+[Tile 1]
+0_0=Mountain, No_Fill, None, None, None, Mtn
+)";
+    const WorldmapTxt world = parseWorldmapTxt(std::string{ kTiles });
+
+    CHECK(world.numHorizontalTiles == 2);
+    REQUIRE(world.tiles.size() == 2);
+    // terrainAt: row = (x%350)/50, col = (y%300)/50, tile = (y/300)*numHoriz + x/350.
+    CHECK(world.terrainAt(0, 0) == "Desert");     // tile 0, row 0, col 0
+    CHECK(world.terrainAt(60, 0) == "Mountain");  // row 1 (60/50)
+    CHECK(world.terrainAt(0, 60) == "Ocean");     // col 1 (60/50)
+    CHECK(world.terrainAt(350, 0) == "Mountain"); // tile 1
+    CHECK(world.terrainAt(99999, 0).empty());     // out of range
+
+    CHECK(world.difficultyOf("Mountain") == 4);
+    CHECK(world.difficultyOf("Nope") == 0);
+}
+
 TEST_CASE("parseWorldmapTxt tolerates empty input", "[worldmap]") {
     CHECK(parseWorldmapTxt(std::string{}).encounters.empty());
     CHECK(parseWorldmapTxt(std::string{}).terrains.empty());
+    CHECK(parseWorldmapTxt(std::string{}).terrainAt(0, 0).empty());
 }

--- a/tests/general/test_worldmap_txt.cpp
+++ b/tests/general/test_worldmap_txt.cpp
@@ -1,0 +1,67 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+#include "format/worldmap/WorldmapTxt.h"
+#include "reader/worldmap/WorldmapTxtReader.h"
+
+using namespace geck;
+
+namespace {
+// A trimmed-down worldmap.txt: the [Data] terrain lists, an ignored [Random Maps] section, and two
+// [Encounter: NAME] groups whose type_NN lines carry the real syntax (Ratio:NN%, pid, Item:N{suffix},
+// the bare "Dead" flag, Script:NN) plus inline ';' comments the reader must strip.
+constexpr const char* kWorldmapTxt = R"(; worldmap data
+[Data]
+Frequent=43%       ; ignored frequency
+terrain_types=Desert:1, Mountain:2, City:1, Ocean:1
+terrain_short_names=DES, MNT, CTY, OCN ; WIP
+
+[Random Maps: Desert]   ; not parsed
+map_00=desert1
+
+[Encounter: Raiders]  ; WIP!
+type_00=Ratio:35%, pid:16777252, Item:8{Wielded}, Item:40, Script:255
+type_01=Dead, pid:16777220, Item:40, Script:256
+
+[Encounter: ARRO_Rats]
+type_00=Ratio:100%, pid:16777276
+)";
+} // namespace
+
+TEST_CASE("parseWorldmapTxt reads terrain types and encounter groups", "[worldmap]") {
+    const WorldmapTxt world = parseWorldmapTxt(std::string{ kWorldmapTxt });
+
+    REQUIRE(world.terrains.size() == 4);
+    CHECK(world.terrains[0].name == "Desert");
+    CHECK(world.terrains[0].shortName == "DES");
+    CHECK(world.terrains[0].weight == 1);
+    CHECK(world.terrains[1].name == "Mountain");
+    CHECK(world.terrains[1].weight == 2);
+    CHECK(world.terrains[3].shortName == "OCN");
+
+    REQUIRE(world.encounters.size() == 2);
+    const Encounter* raiders = world.findEncounter("Raiders");
+    REQUIRE(raiders != nullptr);
+    REQUIRE(raiders->entries.size() == 2);
+    CHECK(raiders->entries[0].pid == 16777252);
+    CHECK(raiders->entries[0].ratioPercent == 35); // "35%" parsed
+    CHECK(raiders->entries[0].dead == false);
+    CHECK(raiders->entries[0].script == 255);
+    CHECK(raiders->entries[0].items == std::vector<int>{ 8, 40 }); // "8{Wielded}" -> 8
+    CHECK(raiders->entries[1].dead == true);                       // bare "Dead" flag
+    CHECK(raiders->entries[1].pid == 16777220);
+
+    const Encounter* rats = world.findEncounter("ARRO_Rats");
+    REQUIRE(rats != nullptr);
+    REQUIRE(rats->entries.size() == 1);
+    CHECK(rats->entries[0].pid == 16777276);
+    CHECK(rats->entries[0].ratioPercent == 100);
+
+    CHECK(world.findEncounter("Nope") == nullptr);
+}
+
+TEST_CASE("parseWorldmapTxt tolerates empty input", "[worldmap]") {
+    CHECK(parseWorldmapTxt(std::string{}).encounters.empty());
+    CHECK(parseWorldmapTxt(std::string{}).terrains.empty());
+}


### PR DESCRIPTION
## Summary
Two complementary layers for understanding how Fallout 2's world fits together — and a correction to
how they relate.

- **`map_graph` (exit-grid layer).** Folds every map's exit grids into a directed map→map graph
  (nodes + aggregated edges with hex counts, names via maps.txt/map.msg), with stats for dead-ends
  and orphan/entry maps. This is travel **within a location** (intramap elevation changes + intermap
  edges within a town) plus the hand-off to the world map. It is **not** inter-city travel.
- **`world_map` (worldmap layer, from city.txt).** A vault `CityTxt` reader + a tool that emits every
  worldmap **area** (name, `world_pos`, size, known-at-start, the maps it contains) and the
  **straight-line distance between every pair of areas**. This is the inter-city layer — the player
  crosses the world map to get between these.

Together they answer both "how do I move within Arroyo" (exit grids) and "how far is the Den from
Arroyo" (world map). Shared helpers (`collectMapExits`, `listMapPaths`, `optMaps`) were extracted to
avoid duplication.

## Verification
- 242 tests pass (new `test_city_txt`, extended MCP tests); both tools driven over the real
  `gecko-mcp` stdio binary (map_graph on Arroyo; world_map = 49 areas, 1176 distances).
- CLI: `map graph`, `map world`.

## PLAN
Corrected world model documented (exit layer vs world layer); `worldmap.txt` (terrain + encounter
tables → terrain-weighted travel cost) and `worldmap.msg` (localized names) queued as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)