### PR TITLE
Map Info panel: show resolved map name + lookup name

### DIFF
--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -11,11 +11,11 @@
 #include <filesystem>
 
 #include "format/map/Map.h"
-#include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
 #include "format/gam/Gam.h"
 #include "format/lst/Lst.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 #include "reader/ReaderFactory.h"
 #include "resource/ResourcePaths.h"
 #include "util/Coordinates.h"
@@ -32,6 +32,8 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     , _contentLayout(nullptr)
     , _mapHeaderGroup(nullptr)
     , _filenameEdit(nullptr)
+    , _displayNameLabel(nullptr)
+    , _lookupNameLabel(nullptr)
     , _elevation1Check(nullptr)
     , _elevation2Check(nullptr)
     , _elevation3Check(nullptr)
@@ -66,6 +68,8 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     setupUI();
 }
 
+MapInfoPanel::~MapInfoPanel() = default;
+
 QSize MapInfoPanel::sizeHint() const {
     return QSize(ui::constants::sizes::PANEL_PREFERRED_WIDTH, ui::constants::sizes::PANEL_PREFERRED_HEIGHT);
 }
@@ -96,6 +100,19 @@ void MapInfoPanel::setupUI() {
 
     _filenameEdit = new QLineEdit();
     headerLayout->addRow("Filename:", _filenameEdit);
+
+    // Friendly names resolved from maps.txt / map.msg (read-only; blank when game data is unmounted).
+    _displayNameLabel = new QLabel();
+    _displayNameLabel->setObjectName("mapDisplayName");
+    _displayNameLabel->setWordWrap(true);
+    _displayNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    headerLayout->addRow("Map name:", _displayNameLabel);
+
+    _lookupNameLabel = new QLabel();
+    _lookupNameLabel->setObjectName("mapLookupName");
+    _lookupNameLabel->setWordWrap(true);
+    _lookupNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    headerLayout->addRow("Lookup name:", _lookupNameLabel);
 
     QWidget* elevationsWidget = new QWidget();
     QVBoxLayout* elevationsLayout = new QVBoxLayout(elevationsWidget);
@@ -314,6 +331,8 @@ void MapInfoPanel::updateMapInfo() {
         loadScriptVars();
         _mapScriptEdit->setText(QString::fromStdString(_mapScriptName));
 
+        updateMapNameDisplay();
+
         _globalVarsTree->clear();
 
         if (_mvars.empty() && mapInfo.header.num_global_vars > 0) {
@@ -359,6 +378,38 @@ void MapInfoPanel::updateMapInfo() {
     } catch (const std::exception& e) {
         spdlog::error("Error updating map info: {}", e.what());
         clearMapInfo();
+    }
+}
+
+void MapInfoPanel::updateMapNameDisplay() {
+    if (!_displayNameLabel || !_lookupNameLabel) {
+        return;
+    }
+    if (!_map) {
+        _displayNameLabel->clear();
+        _lookupNameLabel->clear();
+        return;
+    }
+
+    // Built lazily: maps.txt / map.msg are read once, and by the time a map is open the game data is
+    // mounted. Resolution degrades to blank when the data is missing (resolver returns "").
+    if (!_mapNames) {
+        _mapNames = std::make_unique<resource::MapNameResolver>(_resources);
+    }
+
+    const auto& header = _map->getMapFile().header;
+    const std::string file = header.filename;
+    const int index = _mapNames->indexOf(file); // by filename, not header.map_id
+    const int elevation = static_cast<int>(header.player_default_elevation);
+
+    const std::string display = (index >= 0) ? _mapNames->displayName(index, elevation) : std::string();
+    const std::string lookup = _mapNames->lookupNameOf(file);
+
+    _displayNameLabel->setText(display.empty() ? QStringLiteral("—") : QString::fromStdString(display));
+    if (!lookup.empty()) {
+        _lookupNameLabel->setText(QString::fromStdString(lookup));
+    } else {
+        _lookupNameLabel->setText(index < 0 ? QStringLiteral("(not in maps.txt)") : QStringLiteral("—"));
     }
 }
 
@@ -439,6 +490,13 @@ void MapInfoPanel::clearMapInfo() {
     _mapScriptEdit->clear();
     _mapScriptEdit->setPlaceholderText("No script");
 
+    if (_displayNameLabel) {
+        _displayNameLabel->clear();
+    }
+    if (_lookupNameLabel) {
+        _lookupNameLabel->clear();
+    }
+
     _globalVarsTree->clear();
 
     _mvars.clear();
@@ -471,6 +529,7 @@ void MapInfoPanel::onFieldChanged() {
     if (sender == _playerPositionSpin) {
         Q_EMIT playerPositionChanged(_playerPositionSpin->value());
     } else if (sender == _playerElevationSpin) {
+        updateMapNameDisplay(); // the map.msg display name is per-elevation
         Q_EMIT playerElevationChanged(_playerElevationSpin->value());
     } else if (sender == _mapScriptIdSpin) {
         Q_EMIT mapScriptIdChanged(_mapScriptIdSpin->value());

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -13,6 +13,7 @@
 #include <QTreeWidgetItem>
 #include <QComboBox>
 #include <QPushButton>
+#include <memory>
 #include <unordered_map>
 
 namespace geck {
@@ -20,6 +21,7 @@ namespace geck {
 class Map;
 namespace resource {
     class GameResources;
+    class MapNameResolver;
 }
 
 /// @brief Qt6 widget for displaying properties from the current MAP file.
@@ -28,6 +30,7 @@ class MapInfoPanel : public QWidget {
 
 public:
     explicit MapInfoPanel(resource::GameResources& resources, QWidget* parent = nullptr);
+    ~MapInfoPanel() override; // out-of-line for the unique_ptr<MapNameResolver> member
 
     void setMap(Map* map);
     void setPlayerPosition(int hexPosition, int elevation);
@@ -68,6 +71,7 @@ private:
     void loadScriptVars();
     void clearMapInfo();
     void updateMapScriptsDisplay();
+    void updateMapNameDisplay();
     void updateElevationCheckboxStates();
     void setElevationCheckboxesBlocked(bool blocked);
 
@@ -79,6 +83,8 @@ private:
     // Map header group
     QGroupBox* _mapHeaderGroup;
     QLineEdit* _filenameEdit;
+    QLabel* _displayNameLabel; // resolved map.msg display name (per current elevation)
+    QLabel* _lookupNameLabel;  // maps.txt lookup_name
     QCheckBox* _elevation1Check;
     QCheckBox* _elevation2Check;
     QCheckBox* _elevation3Check;
@@ -111,6 +117,7 @@ private:
     QComboBox* _copyToCombo;
 
     resource::GameResources& _resources;
+    std::unique_ptr<resource::MapNameResolver> _mapNames; // built lazily; reads maps.txt/map.msg once
     Map* _map;
     std::string _mapScriptName;
     std::unordered_map<std::string, uint32_t> _mvars;

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -40,6 +40,8 @@
 #include "resource/GameResources.h"
 #include "util/FalloutEngineEnums.h"
 #include "ui/Settings.h"
+#include "ui/panels/MapInfoPanel.h"
+#include "format/map/Map.h"
 
 namespace {
 
@@ -689,3 +691,37 @@ TEST_CASE("Script console setSource loads the editor and feeds Run", "[qt][scrip
     CHECK(runSource == src);
 }
 #endif
+
+// Phase A of the map-info editor work: the Map Info panel resolves the current map's friendly names
+// (maps.txt lookup_name + the per-elevation map.msg display name) read-only, reusing MapNameResolver.
+TEST_CASE("MapInfoPanel shows resolved map.msg display name and maps.txt lookup name", "[qt][mapinfo]") {
+    ResourceDataScope data;
+    data.writeGameMessageFile("maps.txt", "[Map 0]\nlookup_name=Test Town\nmap_name=testmap\n");
+    // displayName(index 0, elevation 0) reads map.msg[0*3 + 0 + 200] = 200.
+    data.writeGameMessageFile("text/english/game/map.msg", messageLine(200, QStringLiteral("Test Display")));
+    data.mount();
+
+    geck::Map map("testmap.map");
+    auto mapFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
+    mapFile->header.filename = "testmap.map";
+    mapFile->header.player_default_elevation = 0;
+    map.setMapFile(std::move(mapFile));
+
+    geck::MapInfoPanel panel(data.resources());
+    panel.setMap(&map);
+
+    auto* displayLabel = panel.findChild<QLabel*>("mapDisplayName");
+    auto* lookupLabel = panel.findChild<QLabel*>("mapLookupName");
+    REQUIRE(displayLabel != nullptr);
+    REQUIRE(lookupLabel != nullptr);
+    CHECK(displayLabel->text() == QStringLiteral("Test Display"));
+    CHECK(lookupLabel->text() == QStringLiteral("Test Town"));
+
+    // A map not listed in maps.txt resolves to placeholders, not a crash.
+    geck::Map unknown("nosuch.map");
+    auto unknownFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
+    unknownFile->header.filename = "nosuch.map";
+    unknown.setMapFile(std::move(unknownFile));
+    panel.setMap(&unknown);
+    CHECK(lookupLabel->text() == QStringLiteral("(not in maps.txt)"));
+}


### PR DESCRIPTION
## What

The Map Info panel only showed the raw `.map` filename. This surfaces the friendly names the vault readers already resolve, as two read-only rows under **Map Header**:

- **Map name** — the per-elevation display name from `map.msg` (`map.msg[index*3 + elevation + 200]`)
- **Lookup name** — the `maps.txt` `lookup_name`

Reuses `MapNameResolver` (the same resolver the exit-grid dialog already uses), built lazily per panel. It degrades gracefully: blank / `(not in maps.txt)` when game data is unmounted or the map isn't registered. The display name re-resolves when the default elevation changes (map.msg names are per-elevation).

## Scope

This is **Phase A (read-only display)** of the map-info editor work. Making `maps.txt`/`map.msg` **user-editable** (the DAT→writable-root copy mechanism + `MsgWriter`/`MapsTxtWriter`, which don't exist yet) is a deliberately deferred follow-up with its own UX decisions (external editor vs in-app).

## Test

Adds a `qt_tests` case that mounts a synthetic `maps.txt` + `map.msg`, loads a map, and asserts the panel populates both names — plus the `(not in maps.txt)` placeholder path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)