### PR TITLE
Vault: in-place patchers for maps.txt / map.msg map names

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -316,6 +316,9 @@ add_library(vault STATIC
     writer/pro/ProWriter.h
     writer/pro/ProWriter.cpp
 
+    writer/maps/MapRegistryWriter.h
+    writer/maps/MapRegistryWriter.cpp
+
     #
     # FILE LOADERS
     #

--- a/src/writer/maps/MapRegistryWriter.cpp
+++ b/src/writer/maps/MapRegistryWriter.cpp
@@ -1,0 +1,185 @@
+#include "writer/maps/MapRegistryWriter.h"
+
+#include "reader/TextParsing.h"
+
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace geck::writer {
+
+namespace {
+
+    using geck::text::toLower;
+    using geck::text::trim;
+
+    std::string readBytes(const std::filesystem::path& path) {
+        std::ifstream in(path, std::ios::binary);
+        if (!in) {
+            throw std::runtime_error("MapRegistryWriter: cannot open " + path.string());
+        }
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    void writeBytes(const std::filesystem::path& path, const std::string& bytes) {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            throw std::runtime_error("MapRegistryWriter: cannot write " + path.string());
+        }
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    }
+
+    // Split into lines, each segment KEEPING its trailing "\r\n"/"\n"; a final newline-less segment is
+    // kept as-is. Rejoining the vector reproduces the input byte-for-byte.
+    std::vector<std::string> splitKeepEol(const std::string& content) {
+        std::vector<std::string> lines;
+        std::size_t start = 0;
+        while (start < content.size()) {
+            const std::size_t nl = content.find('\n', start);
+            if (nl == std::string::npos) {
+                lines.push_back(content.substr(start));
+                break;
+            }
+            lines.push_back(content.substr(start, nl - start + 1));
+            start = nl + 1;
+        }
+        return lines;
+    }
+
+    std::string eolOf(const std::string& line) {
+        if (line.size() >= 2 && line[line.size() - 2] == '\r' && line.back() == '\n') {
+            return "\r\n";
+        }
+        if (!line.empty() && line.back() == '\n') {
+            return "\n";
+        }
+        return "";
+    }
+
+    std::string bodyOf(const std::string& line) {
+        return line.substr(0, line.size() - eolOf(line).size());
+    }
+
+    std::string detectEol(const std::vector<std::string>& lines) {
+        for (const auto& line : lines) {
+            const std::string eol = eolOf(line);
+            if (!eol.empty()) {
+                return eol;
+            }
+        }
+        return "\n";
+    }
+
+    std::string join(const std::vector<std::string>& lines) {
+        std::string out;
+        for (const auto& line : lines) {
+            out += line;
+        }
+        return out;
+    }
+
+    // "[Map NNN]" inner text -> NNN, or -1; mirrors MapsTxtReader::parseSectionIndex.
+    int sectionIndex(const std::string& sectionInner) {
+        if (toLower(sectionInner).rfind("map", 0) != 0) {
+            return -1;
+        }
+        try {
+            return std::stoi(sectionInner.substr(3));
+        } catch (const std::exception&) {
+            return -1;
+        }
+    }
+
+    // If `line` is the `{targetId}{audio}{text}` message, return it rebuilt with `newText` (audio kept,
+    // line ending preserved); otherwise nullopt. Brace-matched so a text containing '}{' round-trips.
+    std::optional<std::string> rebuildMessageLine(const std::string& line, int targetId, const std::string& newText) {
+        const std::string body = bodyOf(line);
+        const std::size_t open0 = body.find('{');
+        if (open0 == std::string::npos) {
+            return std::nullopt; // comment / blank line
+        }
+        const std::size_t close0 = body.find('}', open0);
+        if (close0 == std::string::npos) {
+            return std::nullopt;
+        }
+        int lineId = -1;
+        try {
+            lineId = std::stoi(body.substr(open0 + 1, close0 - open0 - 1));
+        } catch (const std::exception&) {
+            return std::nullopt;
+        }
+        if (lineId != targetId) {
+            return std::nullopt;
+        }
+        const std::size_t open1 = body.find('{', close0);
+        const std::size_t close1 = open1 == std::string::npos ? std::string::npos : body.find('}', open1);
+        if (close1 == std::string::npos) {
+            return std::nullopt;
+        }
+        const std::string audio = body.substr(open1 + 1, close1 - open1 - 1);
+        return body.substr(0, open0) + "{" + std::to_string(targetId) + "}{" + audio + "}{" + newText + "}" + eolOf(line);
+    }
+
+} // namespace
+
+bool updateLookupName(const std::filesystem::path& mapsTxtPath, int mapIndex, const std::string& newName) {
+    if (mapIndex < 0) {
+        return false;
+    }
+    std::vector<std::string> lines = splitKeepEol(readBytes(mapsTxtPath));
+
+    int section = -1;
+    for (std::string& line : lines) {
+        const std::string body = bodyOf(line);
+        const std::string trimmed = trim(body);
+        if (!trimmed.empty() && trimmed.front() == '[' && trimmed.back() == ']') {
+            section = sectionIndex(trim(trimmed.substr(1, trimmed.size() - 2)));
+            continue;
+        }
+        if (section != mapIndex) {
+            continue;
+        }
+        const std::size_t eq = body.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        if (toLower(trim(body.substr(0, eq))) == "lookup_name") {
+            line = body.substr(0, eq + 1) + newName + eolOf(line); // key + '=' kept, value replaced
+            writeBytes(mapsTxtPath, join(lines));
+            return true;
+        }
+    }
+    return false; // no matching [Map mapIndex] section, or it has no lookup_name
+}
+
+bool updateDisplayName(const std::filesystem::path& mapMsgPath, int mapIndex, int elevation, const std::string& newText) {
+    if (mapIndex < 0 || elevation < 0 || elevation > 2) {
+        return false;
+    }
+    const int id = mapIndex * 3 + elevation + 200;
+    std::vector<std::string> lines = splitKeepEol(readBytes(mapMsgPath));
+
+    for (std::string& line : lines) {
+        if (const auto rebuilt = rebuildMessageLine(line, id, newText)) {
+            line = *rebuilt;
+            writeBytes(mapMsgPath, join(lines));
+            return true;
+        }
+    }
+
+    // Id not present: append a fresh message, keeping the file's line-ending style.
+    const std::string eol = detectEol(lines);
+    std::string content = join(lines);
+    if (!content.empty() && content.back() != '\n') {
+        content += eol;
+    }
+    content += "{" + std::to_string(id) + "}{}{" + newText + "}" + eol;
+    writeBytes(mapMsgPath, content);
+    return true;
+}
+
+} // namespace geck::writer

--- a/src/writer/maps/MapRegistryWriter.h
+++ b/src/writer/maps/MapRegistryWriter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace geck::writer {
+
+/// In-place patch of a loose `data/maps.txt`: replace the `lookup_name` value of the `[Map <mapIndex>]`
+/// section, preserving every other byte — CRLF line endings, `;` comments, blank lines, and the keys
+/// the reader doesn't model (music, ambient_sfx, can_rest_here, random_start_point_N, …). This is a
+/// targeted edit of one field, NOT a re-serialization of the parsed model (which would drop all of the
+/// above). Section matching mirrors MapsTxtReader (`[Map NNN]`, zero-padded or not).
+///
+/// @return true if the section's `lookup_name` line was found and rewritten; false if the map section
+///         (or its lookup_name) is absent — the caller should report "map not in maps.txt".
+bool updateLookupName(const std::filesystem::path& mapsTxtPath, int mapIndex, const std::string& newName);
+
+/// In-place patch of a loose `map.msg`: set a map's per-elevation display name. The message id is
+/// `mapIndex*3 + elevation + 200` (the engine / MapNameResolver formula). Keeps the message's audio
+/// field and every other line (CRLF, `#` comments) verbatim; if the id isn't present, appends a new
+/// `{id}{}{text}` line. Parses the `{id}{audio}{text}` triple by brace matching (not the reader's
+/// greedy regex) so a text value containing `}{` round-trips.
+///
+/// @return true on patch or append; false for an invalid mapIndex (<0) or elevation (not 0..2).
+bool updateDisplayName(const std::filesystem::path& mapMsgPath, int mapIndex, int elevation, const std::string& newText);
+
+} // namespace geck::writer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(general_tests
     general/test_quests_txt.cpp
     general/test_endgame_txt.cpp
     general/test_gvar_refs.cpp
+    general/test_map_registry_writer.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/general/test_map_registry_writer.cpp
+++ b/tests/general/test_map_registry_writer.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/maps/MapsTxt.h"
+#include "reader/maps/MapsTxtReader.h"
+#include "writer/maps/MapRegistryWriter.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+using namespace geck;
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path writeTemp(const std::string& name, const std::string& content) {
+    const fs::path path = fs::path{ GECK_TEST_TMP_DIR } / name;
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    return path;
+}
+
+std::string readAll(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+// Real maps.txt shape: CRLF, a `;` header comment, zero-padded [Map NNN], an inline-comment line, and
+// keys the reader doesn't model (can_rest_here) — all of which the patch must leave byte-identical.
+constexpr const char* kMapsTxt = "; a header comment\r\n"
+                                 "\r\n"
+                                 "[Map 000]\r\n"
+                                 "lookup_name=Desert Encounter 1\r\n"
+                                 "map_name=desert1\r\n"
+                                 "can_rest_here=No,No,No  ; all 3 elevations\r\n"
+                                 "\r\n"
+                                 "[Map 003]\r\n"
+                                 "lookup_name=Klamath\r\n"
+                                 "map_name=klamath\r\n";
+
+// Real map.msg shape: CRLF, `#` comments, {id}{audio}{text} with an empty and a non-empty audio field.
+constexpr const char* kMapMsg = "#\r\n"
+                                "# Map Names\r\n"
+                                "{200}{}{Desert}\r\n"
+                                "{201}{}{}\r\n"
+                                "{209}{snd}{Klamath}\r\n";
+
+} // namespace
+
+TEST_CASE("updateLookupName patches one maps.txt field, preserving CRLF/comments/unmodeled keys", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_maps.txt", kMapsTxt);
+
+    REQUIRE(writer::updateLookupName(path, 0, "New Arroyo"));
+
+    const std::string out = readAll(path);
+    CHECK(out.find("lookup_name=New Arroyo\r\n") != std::string::npos);
+    CHECK(out.find("lookup_name=Desert Encounter 1") == std::string::npos); // old value gone
+    // Everything else byte-identical: header comment, inline-comment line, unmodeled keys, other section.
+    CHECK(out.find("; a header comment\r\n") != std::string::npos);
+    CHECK(out.find("can_rest_here=No,No,No  ; all 3 elevations\r\n") != std::string::npos);
+    CHECK(out.find("map_name=desert1\r\n") != std::string::npos);
+    CHECK(out.find("lookup_name=Klamath\r\n") != std::string::npos); // [Map 003] untouched
+
+    const MapsTxt parsed = parseMapsTxt(out);
+    const MapInfo* map0 = parsed.find(0);
+    REQUIRE(map0 != nullptr);
+    CHECK(map0->lookupName == "New Arroyo");
+}
+
+TEST_CASE("updateLookupName matches zero-padded sections and refuses missing ones", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_maps2.txt", kMapsTxt);
+    REQUIRE(writer::updateLookupName(path, 3, "Klamath Region")); // [Map 003] via stoi tolerance
+    CHECK(readAll(path).find("lookup_name=Klamath Region\r\n") != std::string::npos);
+
+    const fs::path missing = writeTemp("mrw_maps3.txt", kMapsTxt);
+    CHECK_FALSE(writer::updateLookupName(missing, 99, "Nope")); // no [Map 099]
+    CHECK(readAll(missing) == std::string{ kMapsTxt });         // left untouched (byte-for-byte)
+}
+
+TEST_CASE("updateDisplayName patches map.msg, preserves audio, appends when missing", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_map.msg", kMapMsg);
+
+    REQUIRE(writer::updateDisplayName(path, 0, 0, "Wasteland"));   // id 200
+    REQUIRE(writer::updateDisplayName(path, 3, 0, "New Klamath")); // id 209 (3*3+0+200), audio kept
+    REQUIRE(writer::updateDisplayName(path, 50, 0, "Brand New"));  // id 350, not present -> append
+
+    const std::string out = readAll(path);
+    CHECK(out.find("{200}{}{Wasteland}\r\n") != std::string::npos);
+    CHECK(out.find("{209}{snd}{New Klamath}\r\n") != std::string::npos); // audio field preserved
+    CHECK(out.find("{350}{}{Brand New}\r\n") != std::string::npos);      // appended at EOF
+    CHECK(out.find("# Map Names\r\n") != std::string::npos);             // comments preserved
+    CHECK(out.find("{200}{}{Desert}") == std::string::npos);             // old text gone
+
+    CHECK_FALSE(writer::updateDisplayName(path, 0, 5, "x"));  // elevation out of range
+    CHECK_FALSE(writer::updateDisplayName(path, -1, 0, "x")); // map not in the registry
+}


### PR DESCRIPTION
## What

The headless persistence core for the upcoming in-app *edit map names* feature. Two targeted, byte-preserving patchers in `geck::writer` (`src/writer/maps/MapRegistryWriter`):

- `updateLookupName(maps.txt, mapIndex, name)` — rewrite the one `lookup_name` line of `[Map NNN]`.
- `updateDisplayName(map.msg, mapIndex, elevation, text)` — rewrite the `{id}{audio}{text}` message at `id = mapIndex*3 + elevation + 200` (keeping the audio field); append `{id}{}{text}` if the id is absent.

## Why patch, not a writer

These files carry data the parsers drop — `maps.txt` has unmodeled keys (`ambient_sfx`, `can_rest_here`, `random_start_point_N`) plus `;` comments; `map.msg` has `#` comments — and both are CRLF. A re-serializer from the parsed model would destroy all of it. So each function edits **one field in place** and preserves every other byte. The `{id}{audio}{text}` triple is brace-matched (not the reader's greedy regex) so a text value containing `}{` round-trips.

This decision came out of a design workflow that examined the real Fallout 2 file bytes + reader fidelity.

## Scope

This is the **first slice** of the in-app editable-names work (you chose in-app editing). The copy-on-edit (DAT→writable-root) + writable-root Setting + mount-last wiring, and the Map Info panel editable fields, follow in subsequent PRs. Shipping the patchers first lands the riskiest byte-level logic with full coverage, reviewable on its own.

## Test

`test_map_registry_writer` — 23 assertions: byte-fidelity (comments/CRLF/unmodeled keys untouched), zero-padded `[Map 003]` section matching, refuse-on-missing-section, audio-field preservation, append-when-missing, and invalid-index/elevation guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)