### PR TITLE
Map name editing: editable names in the Map Info panel (Phase B)

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -193,7 +193,7 @@ void Application::loadDataPaths() {
     // creation all need access to FRM/tile/object assets from the DAT files.
     auto loadingWidget = std::make_unique<LoadingWidget>(_mainWindow.get());
     loadingWidget->setWindowTitle("Loading Game Data");
-    loadingWidget->addLoader(std::make_unique<DataPathLoader>(_resources, dataPaths));
+    loadingWidget->addLoader(std::make_unique<DataPathLoader>(_resources, dataPaths, settings.getWritableDataRoot()));
 
     loadingWidget->exec();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -316,6 +316,9 @@ add_library(vault STATIC
     writer/pro/ProWriter.h
     writer/pro/ProWriter.cpp
 
+    writer/maps/MapRegistryWriter.h
+    writer/maps/MapRegistryWriter.cpp
+
     #
     # FILE LOADERS
     #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,6 +427,9 @@ add_library(gecko_resource STATIC
 
     resource/MapNameResolver.h
     resource/MapNameResolver.cpp
+
+    resource/WritableDataRoot.h
+    resource/WritableDataRoot.cpp
 )
 add_library(gecko::resource ALIAS gecko_resource)
 

--- a/src/resource/WritableDataRoot.cpp
+++ b/src/resource/WritableDataRoot.cpp
@@ -1,0 +1,31 @@
+#include "resource/WritableDataRoot.h"
+
+#include "resource/DataFileSystem.h"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace geck::resource {
+
+std::filesystem::path ensureWritableCopy(const DataFileSystem& files,
+    const std::filesystem::path& writableRoot, const std::string& vfsRelPath) {
+    const std::filesystem::path dest = writableRoot / vfsRelPath;
+    if (std::filesystem::exists(dest)) {
+        return dest; // already a writable copy (possibly already edited) — do not clobber it
+    }
+
+    const auto bytes = files.readRawBytes(vfsRelPath);
+    if (!bytes.has_value()) {
+        throw std::runtime_error("ensureWritableCopy: cannot read '" + vfsRelPath + "' from the mounted data");
+    }
+
+    std::filesystem::create_directories(dest.parent_path());
+    std::ofstream out(dest, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        throw std::runtime_error("ensureWritableCopy: cannot write " + dest.string());
+    }
+    out.write(reinterpret_cast<const char*>(bytes->data()), static_cast<std::streamsize>(bytes->size()));
+    return dest;
+}
+
+} // namespace geck::resource

--- a/src/resource/WritableDataRoot.h
+++ b/src/resource/WritableDataRoot.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace geck::resource {
+
+class DataFileSystem;
+
+/// Ensure a loose, writable copy of a VFS file exists under `writableRoot`, and return its native path.
+///
+/// Editing game data that lives inside a read-only DAT requires copying it out first. If a copy is
+/// already present at `writableRoot / vfsRelPath` (from a prior edit), it is returned untouched — the
+/// edited copy is the source of truth and must not be clobbered. Otherwise the file's current bytes
+/// (resolved through the VFS — from a DAT or any mounted directory) are written there verbatim (binary,
+/// so CRLF survives), creating the nested directory structure.
+///
+/// The writable root is expected to be mounted LAST in the VFS so this copy shadows the original on the
+/// next read. Throws std::runtime_error if the source file can't be read or the copy can't be written.
+std::filesystem::path ensureWritableCopy(const DataFileSystem& files,
+    const std::filesystem::path& writableRoot, const std::string& vfsRelPath);
+
+} // namespace geck::resource

--- a/src/state/loader/DataPathLoader.cpp
+++ b/src/state/loader/DataPathLoader.cpp
@@ -1,14 +1,17 @@
 #include "DataPathLoader.h"
 #include "resource/GameResources.h"
 #include "resource/ResourceInitializer.h"
+#include <system_error>
 #include <thread>
 #include <spdlog/spdlog.h>
 
 namespace geck {
 
-DataPathLoader::DataPathLoader(std::shared_ptr<resource::GameResources> resources, const std::vector<std::filesystem::path>& dataPaths)
+DataPathLoader::DataPathLoader(std::shared_ptr<resource::GameResources> resources,
+    const std::vector<std::filesystem::path>& dataPaths, std::filesystem::path writableRoot)
     : _resources(std::move(resources))
-    , _dataPaths(dataPaths) {
+    , _dataPaths(dataPaths)
+    , _writableRoot(std::move(writableRoot)) {
 }
 
 DataPathLoader::~DataPathLoader() {
@@ -48,6 +51,18 @@ void DataPathLoader::load() {
             _errorMessage = "Failed to load data path: " + path.string() + "\nError: " + e.what();
             _hasError = true;
             // Continue loading the remaining paths despite this failure.
+        }
+    }
+
+    // Mount the writable overlay LAST so loose, edited copies shadow the archived (DAT) originals.
+    if (!_writableRoot.empty()) {
+        try {
+            std::error_code ec;
+            std::filesystem::create_directories(_writableRoot, ec); // a native mount needs the dir to exist
+            _resources->files().addDataPath(_writableRoot);
+            spdlog::info("DataPathLoader: mounted writable data root: {}", _writableRoot.string());
+        } catch (const std::exception& e) {
+            spdlog::warn("DataPathLoader: could not mount writable data root {}: {}", _writableRoot.string(), e.what());
         }
     }
 

--- a/src/state/loader/DataPathLoader.h
+++ b/src/state/loader/DataPathLoader.h
@@ -19,7 +19,10 @@ namespace resource {
  */
 class DataPathLoader : public Loader {
 public:
-    explicit DataPathLoader(std::shared_ptr<resource::GameResources> resources, const std::vector<std::filesystem::path>& dataPaths);
+    /// @param writableRoot a per-user overlay dir mounted LAST (after all data paths) so loose, edited
+    ///        copies shadow the archived originals; created if missing, ignored when empty.
+    explicit DataPathLoader(std::shared_ptr<resource::GameResources> resources,
+        const std::vector<std::filesystem::path>& dataPaths, std::filesystem::path writableRoot = {});
     ~DataPathLoader() override;
 
     void init() override;
@@ -32,6 +35,7 @@ public:
 private:
     std::shared_ptr<resource::GameResources> _resources;
     std::vector<std::filesystem::path> _dataPaths;
+    std::filesystem::path _writableRoot;
     std::atomic<bool> _done{ false };
     bool _hasError{ false };
     std::string _errorMessage;

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -147,6 +147,10 @@ QJsonObject Settings::toJson() const {
 
     json["gameLocation"] = gameLocation;
 
+    // Unconditional (empty when unset) to keep this hot serializer branch-free; getWritableDataRoot()
+    // supplies the default when the stored value is empty.
+    json["writableDataRoot"] = QString::fromStdString(_writableDataRoot.string());
+
     QJsonObject selectionColors;
     for (auto it = _selectionColors.constBegin(); it != _selectionColors.constEnd(); ++it) {
         selectionColors[it.key()] = it.value().name(); // "#rrggbb"
@@ -226,6 +230,10 @@ void Settings::fromJson(const QJsonObject& json) {
             }
         }
     }
+
+    // Branch-free: a missing/empty key yields an empty path, and getWritableDataRoot() falls back to
+    // the default location.
+    _writableDataRoot = std::filesystem::path(json.value("writableDataRoot").toString().toStdString());
 
     _selectionColors.clear();
     if (json.contains("selectionColors") && json["selectionColors"].isObject()) {
@@ -557,6 +565,19 @@ std::filesystem::path Settings::getGameDataDirectory() const {
 void Settings::setGameDataDirectory(const std::filesystem::path& location) {
     _gameDataDirectory = location;
     spdlog::info("Game data directory set to: {}", location.string());
+}
+
+std::filesystem::path Settings::getWritableDataRoot() const {
+    if (!_writableDataRoot.empty()) {
+        return _writableDataRoot;
+    }
+    const QString base = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    return std::filesystem::path(base.toStdString()) / "writable-data";
+}
+
+void Settings::setWritableDataRoot(const std::filesystem::path& location) {
+    _writableDataRoot = location;
+    spdlog::info("Writable data root set to: {}", location.string());
 }
 
 bool Settings::isGameLocationValid() const {

--- a/src/ui/Settings.h
+++ b/src/ui/Settings.h
@@ -97,6 +97,12 @@ public:
     std::filesystem::path getGameDataDirectory() const;
     void setGameDataDirectory(const std::filesystem::path& location);
 
+    /// Writable overlay root for editing game data that ships inside read-only DATs: files are copied
+    /// here and mounted LAST so the loose copy shadows the archived original. Defaults to a per-user
+    /// app-data location when unset.
+    std::filesystem::path getWritableDataRoot() const;
+    void setWritableDataRoot(const std::filesystem::path& location);
+
     // Auto-detection helpers
     static std::vector<std::filesystem::path> detectFallout2Installations();
 
@@ -137,6 +143,7 @@ private:
     // Game location configuration
     std::filesystem::path _executableGameLocation;
     std::filesystem::path _gameDataDirectory;
+    std::filesystem::path _writableDataRoot;
 
     // Constants
     static constexpr const char* SETTINGS_VERSION = "1.0";

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -826,7 +826,7 @@ void MainWindow::setupDockWidgets() {
         return dock;
     };
 
-    _mapInfoPanel = new MapInfoPanel(*_resourcesShared);
+    _mapInfoPanel = new MapInfoPanel(*_resourcesShared, _settings);
     _mapInfoDock = createDock("Map Information", "MapInfoDock", _mapInfoPanel, Qt::RightDockWidgetArea, QSizePolicy::Preferred, ui::constants::dock::MIN_HEIGHT_SMALL);
 
     _selectionPanel = new SelectionPanel(*_resourcesShared);
@@ -962,7 +962,7 @@ void MainWindow::replaceDockPanelWidget(QDockWidget* dock, QWidget* panel, QSize
 }
 
 void MainWindow::rebuildResourcePanels() {
-    _mapInfoPanel = new MapInfoPanel(*_resourcesShared);
+    _mapInfoPanel = new MapInfoPanel(*_resourcesShared, _settings);
     replaceDockPanelWidget(_mapInfoDock, _mapInfoPanel, QSizePolicy::Preferred);
 
     _selectionPanel = new SelectionPanel(*_resourcesShared);
@@ -1003,7 +1003,7 @@ void MainWindow::rebuildGameResourcesFromSettings() {
     auto loadingWidget = std::make_unique<LoadingWidget>(this);
     loadingWidget->setWindowTitle("Reloading Game Data");
 
-    auto loader = std::make_unique<DataPathLoader>(newResources, dataPaths);
+    auto loader = std::make_unique<DataPathLoader>(newResources, dataPaths, _settings->getWritableDataRoot());
     DataPathLoader* loaderPtr = loader.get();
     loadingWidget->addLoader(std::move(loader));
     loadingWidget->exec();

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -16,6 +16,9 @@
 #include "format/lst/Lst.h"
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
+#include "resource/WritableDataRoot.h"
+#include "writer/maps/MapRegistryWriter.h"
+#include "ui/Settings.h"
 #include "reader/ReaderFactory.h"
 #include "resource/ResourcePaths.h"
 #include "util/Coordinates.h"
@@ -24,7 +27,7 @@
 
 namespace geck {
 
-MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
+MapInfoPanel::MapInfoPanel(resource::GameResources& resources, std::shared_ptr<Settings> settings, QWidget* parent)
     : QWidget(parent)
     , _mainLayout(nullptr)
     , _scrollArea(nullptr)
@@ -32,8 +35,9 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     , _contentLayout(nullptr)
     , _mapHeaderGroup(nullptr)
     , _filenameEdit(nullptr)
-    , _displayNameLabel(nullptr)
-    , _lookupNameLabel(nullptr)
+    , _displayNameEdit(nullptr)
+    , _lookupNameEdit(nullptr)
+    , _saveNamesButton(nullptr)
     , _elevation1Check(nullptr)
     , _elevation2Check(nullptr)
     , _elevation3Check(nullptr)
@@ -59,6 +63,7 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     , _copyFromCombo(nullptr)
     , _copyToCombo(nullptr)
     , _resources(resources)
+    , _settings(std::move(settings))
     , _map(nullptr)
     , _mapScriptName("no script") {
 
@@ -101,18 +106,22 @@ void MapInfoPanel::setupUI() {
     _filenameEdit = new QLineEdit();
     headerLayout->addRow("Filename:", _filenameEdit);
 
-    // Friendly names resolved from maps.txt / map.msg (read-only; blank when game data is unmounted).
-    _displayNameLabel = new QLabel();
-    _displayNameLabel->setObjectName("mapDisplayName");
-    _displayNameLabel->setWordWrap(true);
-    _displayNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    headerLayout->addRow("Map name:", _displayNameLabel);
+    // Editable friendly names from maps.txt / map.msg (blank + disabled when game data is unmounted or
+    // the map isn't registered). Edits are saved to a writable copy via "Save names" below.
+    _displayNameEdit = new QLineEdit();
+    _displayNameEdit->setObjectName("mapDisplayName");
+    headerLayout->addRow("Map name:", _displayNameEdit);
 
-    _lookupNameLabel = new QLabel();
-    _lookupNameLabel->setObjectName("mapLookupName");
-    _lookupNameLabel->setWordWrap(true);
-    _lookupNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    headerLayout->addRow("Lookup name:", _lookupNameLabel);
+    _lookupNameEdit = new QLineEdit();
+    _lookupNameEdit->setObjectName("mapLookupName");
+    headerLayout->addRow("Lookup name:", _lookupNameEdit);
+
+    _saveNamesButton = new QPushButton("Save names");
+    _saveNamesButton->setObjectName("saveNamesButton");
+    _saveNamesButton->setToolTip("Write the edited map name / lookup name to maps.txt and map.msg "
+                                 "(copied out of the DAT to a writable location first).");
+    headerLayout->addRow("", _saveNamesButton);
+    connect(_saveNamesButton, &QPushButton::clicked, this, &MapInfoPanel::onSaveNamesClicked);
 
     QWidget* elevationsWidget = new QWidget();
     QVBoxLayout* elevationsLayout = new QVBoxLayout(elevationsWidget);
@@ -382,12 +391,15 @@ void MapInfoPanel::updateMapInfo() {
 }
 
 void MapInfoPanel::updateMapNameDisplay() {
-    if (!_displayNameLabel || !_lookupNameLabel) {
+    if (!_displayNameEdit || !_lookupNameEdit) {
         return;
     }
     if (!_map) {
-        _displayNameLabel->clear();
-        _lookupNameLabel->clear();
+        _displayNameEdit->clear();
+        _lookupNameEdit->clear();
+        if (_saveNamesButton) {
+            _saveNamesButton->setEnabled(false);
+        }
         return;
     }
 
@@ -401,15 +413,18 @@ void MapInfoPanel::updateMapNameDisplay() {
     const std::string file = header.filename;
     const int index = _mapNames->indexOf(file); // by filename, not header.map_id
     const int elevation = static_cast<int>(header.player_default_elevation);
+    const bool registered = index >= 0; // present in maps.txt -> names are editable + persistable
 
-    const std::string display = (index >= 0) ? _mapNames->displayName(index, elevation) : std::string();
+    const std::string display = registered ? _mapNames->displayName(index, elevation) : std::string();
     const std::string lookup = _mapNames->lookupNameOf(file);
 
-    _displayNameLabel->setText(display.empty() ? QStringLiteral("—") : QString::fromStdString(display));
-    if (!lookup.empty()) {
-        _lookupNameLabel->setText(QString::fromStdString(lookup));
-    } else {
-        _lookupNameLabel->setText(index < 0 ? QStringLiteral("(not in maps.txt)") : QStringLiteral("—"));
+    // setText resets QLineEdit::isModified() to false, so populating is not treated as a user edit.
+    _displayNameEdit->setText(QString::fromStdString(display));
+    _lookupNameEdit->setText(registered ? QString::fromStdString(lookup) : QStringLiteral("(not in maps.txt)"));
+    _displayNameEdit->setReadOnly(!registered);
+    _lookupNameEdit->setReadOnly(!registered);
+    if (_saveNamesButton) {
+        _saveNamesButton->setEnabled(registered);
     }
 }
 
@@ -490,11 +505,14 @@ void MapInfoPanel::clearMapInfo() {
     _mapScriptEdit->clear();
     _mapScriptEdit->setPlaceholderText("No script");
 
-    if (_displayNameLabel) {
-        _displayNameLabel->clear();
+    if (_displayNameEdit) {
+        _displayNameEdit->clear();
     }
-    if (_lookupNameLabel) {
-        _lookupNameLabel->clear();
+    if (_lookupNameEdit) {
+        _lookupNameEdit->clear();
+    }
+    if (_saveNamesButton) {
+        _saveNamesButton->setEnabled(false);
     }
 
     _globalVarsTree->clear();
@@ -938,6 +956,57 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
     Q_EMIT addSpatialScriptRequested(dialog.programIndex(), dialog.tile(),
         dialog.elevation(), dialog.radius());
     updateMapScriptsDisplay();
+}
+
+void MapInfoPanel::onSaveNamesClicked() {
+    if (!_map || !_mapNames || !_settings) {
+        return;
+    }
+
+    const auto& header = _map->getMapFile().header;
+    const std::string file = header.filename;
+    const int index = _mapNames->indexOf(file);
+    if (index < 0) {
+        QMessageBox::warning(this, "Save Names",
+            "This map has no entry in maps.txt, so its names can't be edited here.");
+        return;
+    }
+    const int elevation = static_cast<int>(header.player_default_elevation);
+    const std::filesystem::path writableRoot = _settings->getWritableDataRoot();
+
+    try {
+        bool wrote = false;
+        // Only persist the field the user actually edited (QLineEdit tracks isModified since setText).
+        if (_lookupNameEdit->isModified()) {
+            const auto maps = resource::ensureWritableCopy(_resources.files(), writableRoot, "data/maps.txt");
+            if (!writer::updateLookupName(maps, index, _lookupNameEdit->text().toStdString())) {
+                QMessageBox::warning(this, "Save Names", "Could not find this map's lookup_name in maps.txt.");
+                return;
+            }
+            wrote = true;
+        }
+        if (_displayNameEdit->isModified()) {
+            const auto msg = resource::ensureWritableCopy(_resources.files(), writableRoot, "text/english/game/map.msg");
+            writer::updateDisplayName(msg, index, elevation, _displayNameEdit->text().toStdString());
+            wrote = true;
+        }
+        if (!wrote) {
+            return; // nothing changed
+        }
+
+        // Reflect the edit this session: re-mount the writable root so the VFS's file listing includes
+        // the freshly-copied file (vfspp caches the listing at mount time, so a just-created overlay
+        // file is otherwise invisible). The re-mount is last, so the patched copy shadows the original.
+        // Saving names is a rare manual action and the overlay holds only maps.txt/map.msg, so the
+        // extra mount is negligible. Then drop the cached map.msg and rebuild the resolver.
+        _resources.files().addDataPath(writableRoot);
+        _resources.repository().clear();
+        _mapNames = std::make_unique<resource::MapNameResolver>(_resources);
+        updateMapNameDisplay();
+        spdlog::info("MapInfoPanel: saved map names for '{}' to {}", file, writableRoot.string());
+    } catch (const std::exception& e) {
+        QMessageBox::warning(this, "Save Names", QString("Failed to save map names:\n%1").arg(e.what()));
+    }
 }
 
 } // namespace geck

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -11,11 +11,11 @@
 #include <filesystem>
 
 #include "format/map/Map.h"
-#include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
 #include "format/gam/Gam.h"
 #include "format/lst/Lst.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 #include "reader/ReaderFactory.h"
 #include "resource/ResourcePaths.h"
 #include "util/Coordinates.h"
@@ -32,6 +32,8 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     , _contentLayout(nullptr)
     , _mapHeaderGroup(nullptr)
     , _filenameEdit(nullptr)
+    , _displayNameLabel(nullptr)
+    , _lookupNameLabel(nullptr)
     , _elevation1Check(nullptr)
     , _elevation2Check(nullptr)
     , _elevation3Check(nullptr)
@@ -66,6 +68,8 @@ MapInfoPanel::MapInfoPanel(resource::GameResources& resources, QWidget* parent)
     setupUI();
 }
 
+MapInfoPanel::~MapInfoPanel() = default;
+
 QSize MapInfoPanel::sizeHint() const {
     return QSize(ui::constants::sizes::PANEL_PREFERRED_WIDTH, ui::constants::sizes::PANEL_PREFERRED_HEIGHT);
 }
@@ -96,6 +100,19 @@ void MapInfoPanel::setupUI() {
 
     _filenameEdit = new QLineEdit();
     headerLayout->addRow("Filename:", _filenameEdit);
+
+    // Friendly names resolved from maps.txt / map.msg (read-only; blank when game data is unmounted).
+    _displayNameLabel = new QLabel();
+    _displayNameLabel->setObjectName("mapDisplayName");
+    _displayNameLabel->setWordWrap(true);
+    _displayNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    headerLayout->addRow("Map name:", _displayNameLabel);
+
+    _lookupNameLabel = new QLabel();
+    _lookupNameLabel->setObjectName("mapLookupName");
+    _lookupNameLabel->setWordWrap(true);
+    _lookupNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    headerLayout->addRow("Lookup name:", _lookupNameLabel);
 
     QWidget* elevationsWidget = new QWidget();
     QVBoxLayout* elevationsLayout = new QVBoxLayout(elevationsWidget);
@@ -314,6 +331,8 @@ void MapInfoPanel::updateMapInfo() {
         loadScriptVars();
         _mapScriptEdit->setText(QString::fromStdString(_mapScriptName));
 
+        updateMapNameDisplay();
+
         _globalVarsTree->clear();
 
         if (_mvars.empty() && mapInfo.header.num_global_vars > 0) {
@@ -359,6 +378,38 @@ void MapInfoPanel::updateMapInfo() {
     } catch (const std::exception& e) {
         spdlog::error("Error updating map info: {}", e.what());
         clearMapInfo();
+    }
+}
+
+void MapInfoPanel::updateMapNameDisplay() {
+    if (!_displayNameLabel || !_lookupNameLabel) {
+        return;
+    }
+    if (!_map) {
+        _displayNameLabel->clear();
+        _lookupNameLabel->clear();
+        return;
+    }
+
+    // Built lazily: maps.txt / map.msg are read once, and by the time a map is open the game data is
+    // mounted. Resolution degrades to blank when the data is missing (resolver returns "").
+    if (!_mapNames) {
+        _mapNames = std::make_unique<resource::MapNameResolver>(_resources);
+    }
+
+    const auto& header = _map->getMapFile().header;
+    const std::string file = header.filename;
+    const int index = _mapNames->indexOf(file); // by filename, not header.map_id
+    const int elevation = static_cast<int>(header.player_default_elevation);
+
+    const std::string display = (index >= 0) ? _mapNames->displayName(index, elevation) : std::string();
+    const std::string lookup = _mapNames->lookupNameOf(file);
+
+    _displayNameLabel->setText(display.empty() ? QStringLiteral("—") : QString::fromStdString(display));
+    if (!lookup.empty()) {
+        _lookupNameLabel->setText(QString::fromStdString(lookup));
+    } else {
+        _lookupNameLabel->setText(index < 0 ? QStringLiteral("(not in maps.txt)") : QStringLiteral("—"));
     }
 }
 
@@ -439,6 +490,13 @@ void MapInfoPanel::clearMapInfo() {
     _mapScriptEdit->clear();
     _mapScriptEdit->setPlaceholderText("No script");
 
+    if (_displayNameLabel) {
+        _displayNameLabel->clear();
+    }
+    if (_lookupNameLabel) {
+        _lookupNameLabel->clear();
+    }
+
     _globalVarsTree->clear();
 
     _mvars.clear();
@@ -471,6 +529,7 @@ void MapInfoPanel::onFieldChanged() {
     if (sender == _playerPositionSpin) {
         Q_EMIT playerPositionChanged(_playerPositionSpin->value());
     } else if (sender == _playerElevationSpin) {
+        updateMapNameDisplay(); // the map.msg display name is per-elevation
         Q_EMIT playerElevationChanged(_playerElevationSpin->value());
     } else if (sender == _mapScriptIdSpin) {
         Q_EMIT mapScriptIdChanged(_mapScriptIdSpin->value());

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -13,6 +13,7 @@
 #include <QTreeWidgetItem>
 #include <QComboBox>
 #include <QPushButton>
+#include <memory>
 #include <unordered_map>
 
 namespace geck {
@@ -20,6 +21,7 @@ namespace geck {
 class Map;
 namespace resource {
     class GameResources;
+    class MapNameResolver;
 }
 
 /// @brief Qt6 widget for displaying properties from the current MAP file.
@@ -28,6 +30,7 @@ class MapInfoPanel : public QWidget {
 
 public:
     explicit MapInfoPanel(resource::GameResources& resources, QWidget* parent = nullptr);
+    ~MapInfoPanel() override; // out-of-line for the unique_ptr<MapNameResolver> member
 
     void setMap(Map* map);
     void setPlayerPosition(int hexPosition, int elevation);
@@ -68,6 +71,7 @@ private:
     void loadScriptVars();
     void clearMapInfo();
     void updateMapScriptsDisplay();
+    void updateMapNameDisplay();
     void updateElevationCheckboxStates();
     void setElevationCheckboxesBlocked(bool blocked);
 
@@ -79,6 +83,8 @@ private:
     // Map header group
     QGroupBox* _mapHeaderGroup;
     QLineEdit* _filenameEdit;
+    QLabel* _displayNameLabel; // resolved map.msg display name (per current elevation)
+    QLabel* _lookupNameLabel;  // maps.txt lookup_name
     QCheckBox* _elevation1Check;
     QCheckBox* _elevation2Check;
     QCheckBox* _elevation3Check;
@@ -111,6 +117,7 @@ private:
     QComboBox* _copyToCombo;
 
     resource::GameResources& _resources;
+    std::unique_ptr<resource::MapNameResolver> _mapNames; // built lazily; reads maps.txt/map.msg once
     Map* _map;
     std::string _mapScriptName;
     std::unordered_map<std::string, uint32_t> _mvars;

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -19,6 +19,7 @@
 namespace geck {
 
 class Map;
+class Settings;
 namespace resource {
     class GameResources;
     class MapNameResolver;
@@ -29,7 +30,7 @@ class MapInfoPanel : public QWidget {
     Q_OBJECT
 
 public:
-    explicit MapInfoPanel(resource::GameResources& resources, QWidget* parent = nullptr);
+    explicit MapInfoPanel(resource::GameResources& resources, std::shared_ptr<Settings> settings, QWidget* parent = nullptr);
     ~MapInfoPanel() override; // out-of-line for the unique_ptr<MapNameResolver> member
 
     void setMap(Map* map);
@@ -64,6 +65,7 @@ private slots:
     void onClearElevationClicked();
     void onCopyElevationClicked();
     void onAddSpatialScriptClicked();
+    void onSaveNamesClicked();
 
 private:
     void setupUI();
@@ -83,8 +85,9 @@ private:
     // Map header group
     QGroupBox* _mapHeaderGroup;
     QLineEdit* _filenameEdit;
-    QLabel* _displayNameLabel; // resolved map.msg display name (per current elevation)
-    QLabel* _lookupNameLabel;  // maps.txt lookup_name
+    QLineEdit* _displayNameEdit; // editable map.msg display name (per current elevation)
+    QLineEdit* _lookupNameEdit;  // editable maps.txt lookup_name
+    QPushButton* _saveNamesButton;
     QCheckBox* _elevation1Check;
     QCheckBox* _elevation2Check;
     QCheckBox* _elevation3Check;
@@ -117,6 +120,7 @@ private:
     QComboBox* _copyToCombo;
 
     resource::GameResources& _resources;
+    std::shared_ptr<Settings> _settings;                  // for the writable data root used when editing names
     std::unique_ptr<resource::MapNameResolver> _mapNames; // built lazily; reads maps.txt/map.msg once
     Map* _map;
     std::string _mapScriptName;

--- a/src/writer/maps/MapRegistryWriter.cpp
+++ b/src/writer/maps/MapRegistryWriter.cpp
@@ -1,0 +1,185 @@
+#include "writer/maps/MapRegistryWriter.h"
+
+#include "reader/TextParsing.h"
+
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace geck::writer {
+
+namespace {
+
+    using geck::text::toLower;
+    using geck::text::trim;
+
+    std::string readBytes(const std::filesystem::path& path) {
+        std::ifstream in(path, std::ios::binary);
+        if (!in) {
+            throw std::runtime_error("MapRegistryWriter: cannot open " + path.string());
+        }
+        return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+
+    void writeBytes(const std::filesystem::path& path, const std::string& bytes) {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            throw std::runtime_error("MapRegistryWriter: cannot write " + path.string());
+        }
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    }
+
+    // Split into lines, each segment KEEPING its trailing "\r\n"/"\n"; a final newline-less segment is
+    // kept as-is. Rejoining the vector reproduces the input byte-for-byte.
+    std::vector<std::string> splitKeepEol(const std::string& content) {
+        std::vector<std::string> lines;
+        std::size_t start = 0;
+        while (start < content.size()) {
+            const std::size_t nl = content.find('\n', start);
+            if (nl == std::string::npos) {
+                lines.push_back(content.substr(start));
+                break;
+            }
+            lines.push_back(content.substr(start, nl - start + 1));
+            start = nl + 1;
+        }
+        return lines;
+    }
+
+    std::string eolOf(const std::string& line) {
+        if (line.size() >= 2 && line[line.size() - 2] == '\r' && line.back() == '\n') {
+            return "\r\n";
+        }
+        if (!line.empty() && line.back() == '\n') {
+            return "\n";
+        }
+        return "";
+    }
+
+    std::string bodyOf(const std::string& line) {
+        return line.substr(0, line.size() - eolOf(line).size());
+    }
+
+    std::string detectEol(const std::vector<std::string>& lines) {
+        for (const auto& line : lines) {
+            const std::string eol = eolOf(line);
+            if (!eol.empty()) {
+                return eol;
+            }
+        }
+        return "\n";
+    }
+
+    std::string join(const std::vector<std::string>& lines) {
+        std::string out;
+        for (const auto& line : lines) {
+            out += line;
+        }
+        return out;
+    }
+
+    // "[Map NNN]" inner text -> NNN, or -1; mirrors MapsTxtReader::parseSectionIndex.
+    int sectionIndex(const std::string& sectionInner) {
+        if (toLower(sectionInner).rfind("map", 0) != 0) {
+            return -1;
+        }
+        try {
+            return std::stoi(sectionInner.substr(3));
+        } catch (const std::exception&) {
+            return -1;
+        }
+    }
+
+    // If `line` is the `{targetId}{audio}{text}` message, return it rebuilt with `newText` (audio kept,
+    // line ending preserved); otherwise nullopt. Brace-matched so a text containing '}{' round-trips.
+    std::optional<std::string> rebuildMessageLine(const std::string& line, int targetId, const std::string& newText) {
+        const std::string body = bodyOf(line);
+        const std::size_t open0 = body.find('{');
+        if (open0 == std::string::npos) {
+            return std::nullopt; // comment / blank line
+        }
+        const std::size_t close0 = body.find('}', open0);
+        if (close0 == std::string::npos) {
+            return std::nullopt;
+        }
+        int lineId = -1;
+        try {
+            lineId = std::stoi(body.substr(open0 + 1, close0 - open0 - 1));
+        } catch (const std::exception&) {
+            return std::nullopt;
+        }
+        if (lineId != targetId) {
+            return std::nullopt;
+        }
+        const std::size_t open1 = body.find('{', close0);
+        const std::size_t close1 = open1 == std::string::npos ? std::string::npos : body.find('}', open1);
+        if (close1 == std::string::npos) {
+            return std::nullopt;
+        }
+        const std::string audio = body.substr(open1 + 1, close1 - open1 - 1);
+        return body.substr(0, open0) + "{" + std::to_string(targetId) + "}{" + audio + "}{" + newText + "}" + eolOf(line);
+    }
+
+} // namespace
+
+bool updateLookupName(const std::filesystem::path& mapsTxtPath, int mapIndex, const std::string& newName) {
+    if (mapIndex < 0) {
+        return false;
+    }
+    std::vector<std::string> lines = splitKeepEol(readBytes(mapsTxtPath));
+
+    int section = -1;
+    for (std::string& line : lines) {
+        const std::string body = bodyOf(line);
+        const std::string trimmed = trim(body);
+        if (!trimmed.empty() && trimmed.front() == '[' && trimmed.back() == ']') {
+            section = sectionIndex(trim(trimmed.substr(1, trimmed.size() - 2)));
+            continue;
+        }
+        if (section != mapIndex) {
+            continue;
+        }
+        const std::size_t eq = body.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+        if (toLower(trim(body.substr(0, eq))) == "lookup_name") {
+            line = body.substr(0, eq + 1) + newName + eolOf(line); // key + '=' kept, value replaced
+            writeBytes(mapsTxtPath, join(lines));
+            return true;
+        }
+    }
+    return false; // no matching [Map mapIndex] section, or it has no lookup_name
+}
+
+bool updateDisplayName(const std::filesystem::path& mapMsgPath, int mapIndex, int elevation, const std::string& newText) {
+    if (mapIndex < 0 || elevation < 0 || elevation > 2) {
+        return false;
+    }
+    const int id = mapIndex * 3 + elevation + 200;
+    std::vector<std::string> lines = splitKeepEol(readBytes(mapMsgPath));
+
+    for (std::string& line : lines) {
+        if (const auto rebuilt = rebuildMessageLine(line, id, newText)) {
+            line = *rebuilt;
+            writeBytes(mapMsgPath, join(lines));
+            return true;
+        }
+    }
+
+    // Id not present: append a fresh message, keeping the file's line-ending style.
+    const std::string eol = detectEol(lines);
+    std::string content = join(lines);
+    if (!content.empty() && content.back() != '\n') {
+        content += eol;
+    }
+    content += "{" + std::to_string(id) + "}{}{" + newText + "}" + eol;
+    writeBytes(mapMsgPath, content);
+    return true;
+}
+
+} // namespace geck::writer

--- a/src/writer/maps/MapRegistryWriter.h
+++ b/src/writer/maps/MapRegistryWriter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace geck::writer {
+
+/// In-place patch of a loose `data/maps.txt`: replace the `lookup_name` value of the `[Map <mapIndex>]`
+/// section, preserving every other byte — CRLF line endings, `;` comments, blank lines, and the keys
+/// the reader doesn't model (music, ambient_sfx, can_rest_here, random_start_point_N, …). This is a
+/// targeted edit of one field, NOT a re-serialization of the parsed model (which would drop all of the
+/// above). Section matching mirrors MapsTxtReader (`[Map NNN]`, zero-padded or not).
+///
+/// @return true if the section's `lookup_name` line was found and rewritten; false if the map section
+///         (or its lookup_name) is absent — the caller should report "map not in maps.txt".
+bool updateLookupName(const std::filesystem::path& mapsTxtPath, int mapIndex, const std::string& newName);
+
+/// In-place patch of a loose `map.msg`: set a map's per-elevation display name. The message id is
+/// `mapIndex*3 + elevation + 200` (the engine / MapNameResolver formula). Keeps the message's audio
+/// field and every other line (CRLF, `#` comments) verbatim; if the id isn't present, appends a new
+/// `{id}{}{text}` line. Parses the `{id}{audio}{text}` triple by brace matching (not the reader's
+/// greedy regex) so a text value containing `}{` round-trips.
+///
+/// @return true on patch or append; false for an invalid mapIndex (<0) or elevation (not 0..2).
+bool updateDisplayName(const std::filesystem::path& mapMsgPath, int mapIndex, int elevation, const std::string& newText);
+
+} // namespace geck::writer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(general_tests
     general/test_endgame_txt.cpp
     general/test_gvar_refs.cpp
     general/test_map_registry_writer.cpp
+    general/test_writable_data_root.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(general_tests
     general/test_quests_txt.cpp
     general/test_endgame_txt.cpp
     general/test_gvar_refs.cpp
+    general/test_map_registry_writer.cpp
     general/test_reading_msg.cpp
     general/test_reading_pro_drug.cpp
     general/test_pro_roundtrip.cpp

--- a/tests/general/test_map_registry_writer.cpp
+++ b/tests/general/test_map_registry_writer.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "format/maps/MapsTxt.h"
+#include "reader/maps/MapsTxtReader.h"
+#include "writer/maps/MapRegistryWriter.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+using namespace geck;
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path writeTemp(const std::string& name, const std::string& content) {
+    const fs::path path = fs::path{ GECK_TEST_TMP_DIR } / name;
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    return path;
+}
+
+std::string readAll(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+// Real maps.txt shape: CRLF, a `;` header comment, zero-padded [Map NNN], an inline-comment line, and
+// keys the reader doesn't model (can_rest_here) — all of which the patch must leave byte-identical.
+constexpr const char* kMapsTxt = "; a header comment\r\n"
+                                 "\r\n"
+                                 "[Map 000]\r\n"
+                                 "lookup_name=Desert Encounter 1\r\n"
+                                 "map_name=desert1\r\n"
+                                 "can_rest_here=No,No,No  ; all 3 elevations\r\n"
+                                 "\r\n"
+                                 "[Map 003]\r\n"
+                                 "lookup_name=Klamath\r\n"
+                                 "map_name=klamath\r\n";
+
+// Real map.msg shape: CRLF, `#` comments, {id}{audio}{text} with an empty and a non-empty audio field.
+constexpr const char* kMapMsg = "#\r\n"
+                                "# Map Names\r\n"
+                                "{200}{}{Desert}\r\n"
+                                "{201}{}{}\r\n"
+                                "{209}{snd}{Klamath}\r\n";
+
+} // namespace
+
+TEST_CASE("updateLookupName patches one maps.txt field, preserving CRLF/comments/unmodeled keys", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_maps.txt", kMapsTxt);
+
+    REQUIRE(writer::updateLookupName(path, 0, "New Arroyo"));
+
+    const std::string out = readAll(path);
+    CHECK(out.find("lookup_name=New Arroyo\r\n") != std::string::npos);
+    CHECK(out.find("lookup_name=Desert Encounter 1") == std::string::npos); // old value gone
+    // Everything else byte-identical: header comment, inline-comment line, unmodeled keys, other section.
+    CHECK(out.find("; a header comment\r\n") != std::string::npos);
+    CHECK(out.find("can_rest_here=No,No,No  ; all 3 elevations\r\n") != std::string::npos);
+    CHECK(out.find("map_name=desert1\r\n") != std::string::npos);
+    CHECK(out.find("lookup_name=Klamath\r\n") != std::string::npos); // [Map 003] untouched
+
+    const MapsTxt parsed = parseMapsTxt(out);
+    const MapInfo* map0 = parsed.find(0);
+    REQUIRE(map0 != nullptr);
+    CHECK(map0->lookupName == "New Arroyo");
+}
+
+TEST_CASE("updateLookupName matches zero-padded sections and refuses missing ones", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_maps2.txt", kMapsTxt);
+    REQUIRE(writer::updateLookupName(path, 3, "Klamath Region")); // [Map 003] via stoi tolerance
+    CHECK(readAll(path).find("lookup_name=Klamath Region\r\n") != std::string::npos);
+
+    const fs::path missing = writeTemp("mrw_maps3.txt", kMapsTxt);
+    CHECK_FALSE(writer::updateLookupName(missing, 99, "Nope")); // no [Map 099]
+    CHECK(readAll(missing) == std::string{ kMapsTxt });         // left untouched (byte-for-byte)
+}
+
+TEST_CASE("updateDisplayName patches map.msg, preserves audio, appends when missing", "[mapregistry]") {
+    const fs::path path = writeTemp("mrw_map.msg", kMapMsg);
+
+    REQUIRE(writer::updateDisplayName(path, 0, 0, "Wasteland"));   // id 200
+    REQUIRE(writer::updateDisplayName(path, 3, 0, "New Klamath")); // id 209 (3*3+0+200), audio kept
+    REQUIRE(writer::updateDisplayName(path, 50, 0, "Brand New"));  // id 350, not present -> append
+
+    const std::string out = readAll(path);
+    CHECK(out.find("{200}{}{Wasteland}\r\n") != std::string::npos);
+    CHECK(out.find("{209}{snd}{New Klamath}\r\n") != std::string::npos); // audio field preserved
+    CHECK(out.find("{350}{}{Brand New}\r\n") != std::string::npos);      // appended at EOF
+    CHECK(out.find("# Map Names\r\n") != std::string::npos);             // comments preserved
+    CHECK(out.find("{200}{}{Desert}") == std::string::npos);             // old text gone
+
+    CHECK_FALSE(writer::updateDisplayName(path, 0, 5, "x"));  // elevation out of range
+    CHECK_FALSE(writer::updateDisplayName(path, -1, 0, "x")); // map not in the registry
+}

--- a/tests/general/test_writable_data_root.cpp
+++ b/tests/general/test_writable_data_root.cpp
@@ -1,0 +1,61 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "resource/DataFileSystem.h"
+#include "resource/WritableDataRoot.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+using namespace geck;
+namespace fs = std::filesystem;
+
+namespace {
+
+void writeFile(const fs::path& path, const std::string& contents) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+}
+
+std::string readAll(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+TEST_CASE("ensureWritableCopy copies a mounted file out (CRLF preserved) and is idempotent", "[writableroot]") {
+    const fs::path base = fs::path{ GECK_TEST_TMP_DIR } / "wr_test";
+    fs::remove_all(base);
+    const fs::path source = base / "source";
+    const fs::path root = base / "writable";
+    writeFile(source / "data" / "maps.txt", "HELLO\r\nWORLD\r\n");
+
+    resource::DataFileSystem files;
+    files.addDataPath(source.string());
+
+    const fs::path dest = resource::ensureWritableCopy(files, root, "data/maps.txt");
+    CHECK(dest == root / "data" / "maps.txt");
+    CHECK(readAll(dest) == "HELLO\r\nWORLD\r\n"); // bytes, including CRLF, verbatim
+
+    // Idempotent: an existing (edited) copy is returned untouched, not re-copied from the source.
+    writeFile(dest, "EDITED\r\n");
+    const fs::path again = resource::ensureWritableCopy(files, root, "data/maps.txt");
+    CHECK(again == dest);
+    CHECK(readAll(again) == "EDITED\r\n");
+
+    fs::remove_all(base);
+}
+
+TEST_CASE("ensureWritableCopy throws when the file is not in the mounted data", "[writableroot]") {
+    const fs::path root = fs::path{ GECK_TEST_TMP_DIR } / "wr_empty";
+    fs::remove_all(root);
+    resource::DataFileSystem files; // nothing mounted
+    CHECK_THROWS(resource::ensureWritableCopy(files, root, "data/nope.txt"));
+}

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -42,6 +42,10 @@
 #include "ui/Settings.h"
 #include "ui/panels/MapInfoPanel.h"
 #include "format/map/Map.h"
+#include <QLineEdit>
+#include <QPushButton>
+#include <fstream>
+#include <iterator>
 
 namespace {
 
@@ -694,34 +698,83 @@ TEST_CASE("Script console setSource loads the editor and feeds Run", "[qt][scrip
 
 // Phase A of the map-info editor work: the Map Info panel resolves the current map's friendly names
 // (maps.txt lookup_name + the per-elevation map.msg display name) read-only, reusing MapNameResolver.
+namespace {
+
+// A map whose header points at `mapName.map`, with an in-memory MapFile so the panel can resolve it.
+std::unique_ptr<geck::Map> makeMap(const std::string& mapName, int elevation = 0) {
+    auto map = std::make_unique<geck::Map>(mapName);
+    auto mapFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
+    mapFile->header.filename = mapName;
+    mapFile->header.player_default_elevation = static_cast<uint32_t>(elevation);
+    map->setMapFile(std::move(mapFile));
+    return map;
+}
+
+} // namespace
+
 TEST_CASE("MapInfoPanel shows resolved map.msg display name and maps.txt lookup name", "[qt][mapinfo]") {
     ResourceDataScope data;
-    data.writeGameMessageFile("maps.txt", "[Map 0]\nlookup_name=Test Town\nmap_name=testmap\n");
+    data.writeGameMessageFile("data/maps.txt", "[Map 0]\nlookup_name=Test Town\nmap_name=testmap\n");
     // displayName(index 0, elevation 0) reads map.msg[0*3 + 0 + 200] = 200.
     data.writeGameMessageFile("text/english/game/map.msg", messageLine(200, QStringLiteral("Test Display")));
     data.mount();
 
-    geck::Map map("testmap.map");
-    auto mapFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
-    mapFile->header.filename = "testmap.map";
-    mapFile->header.player_default_elevation = 0;
-    map.setMapFile(std::move(mapFile));
+    auto settings = std::make_shared<geck::Settings>();
+    auto map = makeMap("testmap.map");
 
-    geck::MapInfoPanel panel(data.resources());
-    panel.setMap(&map);
+    geck::MapInfoPanel panel(data.resources(), settings);
+    panel.setMap(map.get());
 
-    auto* displayLabel = panel.findChild<QLabel*>("mapDisplayName");
-    auto* lookupLabel = panel.findChild<QLabel*>("mapLookupName");
-    REQUIRE(displayLabel != nullptr);
-    REQUIRE(lookupLabel != nullptr);
-    CHECK(displayLabel->text() == QStringLiteral("Test Display"));
-    CHECK(lookupLabel->text() == QStringLiteral("Test Town"));
+    auto* displayEdit = panel.findChild<QLineEdit*>("mapDisplayName");
+    auto* lookupEdit = panel.findChild<QLineEdit*>("mapLookupName");
+    REQUIRE(displayEdit != nullptr);
+    REQUIRE(lookupEdit != nullptr);
+    CHECK(displayEdit->text() == QStringLiteral("Test Display"));
+    CHECK(lookupEdit->text() == QStringLiteral("Test Town"));
 
-    // A map not listed in maps.txt resolves to placeholders, not a crash.
-    geck::Map unknown("nosuch.map");
-    auto unknownFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
-    unknownFile->header.filename = "nosuch.map";
-    unknown.setMapFile(std::move(unknownFile));
-    panel.setMap(&unknown);
-    CHECK(lookupLabel->text() == QStringLiteral("(not in maps.txt)"));
+    // A map not listed in maps.txt resolves to a placeholder (read-only), not a crash.
+    auto unknown = makeMap("nosuch.map");
+    panel.setMap(unknown.get());
+    CHECK(lookupEdit->text() == QStringLiteral("(not in maps.txt)"));
+    CHECK(lookupEdit->isReadOnly());
+}
+
+TEST_CASE("MapInfoPanel saves an edited map name to the writable root and reflects it", "[qt][mapinfo]") {
+    ResourceDataScope data;
+    data.writeGameMessageFile("data/maps.txt", "[Map 0]\nlookup_name=Test Town\nmap_name=testmap\n");
+    data.writeGameMessageFile("text/english/game/map.msg", messageLine(200, QStringLiteral("Test Display")));
+    data.mount();
+
+    // A writable overlay mounted LAST so its edited copy shadows the source.
+    QTemporaryDir writableDir;
+    REQUIRE(writableDir.isValid());
+    const std::filesystem::path writableRoot = writableDir.path().toStdString();
+    data.resources().files().addDataPath(writableRoot.string());
+
+    auto settings = std::make_shared<geck::Settings>();
+    settings->setWritableDataRoot(writableRoot);
+
+    auto map = makeMap("testmap.map");
+    geck::MapInfoPanel panel(data.resources(), settings);
+    panel.setMap(map.get());
+
+    auto* lookupEdit = panel.findChild<QLineEdit*>("mapLookupName");
+    auto* saveButton = panel.findChild<QPushButton*>("saveNamesButton");
+    REQUIRE(lookupEdit != nullptr);
+    REQUIRE(saveButton != nullptr);
+    REQUIRE(lookupEdit->text() == QStringLiteral("Test Town"));
+
+    lookupEdit->setText("Renamed Town");
+    lookupEdit->setModified(true);
+    saveButton->click();
+
+    // Persisted: the patched copy lives under the writable root with the new lookup_name.
+    const std::filesystem::path savedMaps = writableRoot / "data" / "maps.txt";
+    REQUIRE(std::filesystem::exists(savedMaps));
+    std::ifstream in(savedMaps, std::ios::binary);
+    const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    CHECK(content.find("lookup_name=Renamed Town") != std::string::npos);
+
+    // Reflected: after the re-mount + resolver rebuild, the panel shows the new name.
+    CHECK(lookupEdit->text() == QStringLiteral("Renamed Town"));
 }

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -40,6 +40,8 @@
 #include "resource/GameResources.h"
 #include "util/FalloutEngineEnums.h"
 #include "ui/Settings.h"
+#include "ui/panels/MapInfoPanel.h"
+#include "format/map/Map.h"
 
 namespace {
 
@@ -689,3 +691,37 @@ TEST_CASE("Script console setSource loads the editor and feeds Run", "[qt][scrip
     CHECK(runSource == src);
 }
 #endif
+
+// Phase A of the map-info editor work: the Map Info panel resolves the current map's friendly names
+// (maps.txt lookup_name + the per-elevation map.msg display name) read-only, reusing MapNameResolver.
+TEST_CASE("MapInfoPanel shows resolved map.msg display name and maps.txt lookup name", "[qt][mapinfo]") {
+    ResourceDataScope data;
+    data.writeGameMessageFile("maps.txt", "[Map 0]\nlookup_name=Test Town\nmap_name=testmap\n");
+    // displayName(index 0, elevation 0) reads map.msg[0*3 + 0 + 200] = 200.
+    data.writeGameMessageFile("text/english/game/map.msg", messageLine(200, QStringLiteral("Test Display")));
+    data.mount();
+
+    geck::Map map("testmap.map");
+    auto mapFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
+    mapFile->header.filename = "testmap.map";
+    mapFile->header.player_default_elevation = 0;
+    map.setMapFile(std::move(mapFile));
+
+    geck::MapInfoPanel panel(data.resources());
+    panel.setMap(&map);
+
+    auto* displayLabel = panel.findChild<QLabel*>("mapDisplayName");
+    auto* lookupLabel = panel.findChild<QLabel*>("mapLookupName");
+    REQUIRE(displayLabel != nullptr);
+    REQUIRE(lookupLabel != nullptr);
+    CHECK(displayLabel->text() == QStringLiteral("Test Display"));
+    CHECK(lookupLabel->text() == QStringLiteral("Test Town"));
+
+    // A map not listed in maps.txt resolves to placeholders, not a crash.
+    geck::Map unknown("nosuch.map");
+    auto unknownFile = std::make_unique<geck::Map::MapFile>(geck::Map::createEmptyMapFile());
+    unknownFile->header.filename = "nosuch.map";
+    unknown.setMapFile(std::move(unknownFile));
+    panel.setMap(&unknown);
+    CHECK(lookupLabel->text() == QStringLiteral("(not in maps.txt)"));
+}


### PR DESCRIPTION
Completes the in-app **map name editing** feature. This branch stacks the two earlier slices and adds the editing half, so it contains everything:

- **#73** (commit `5975f02`) — Phase A: read-only Map name + Lookup name display.
- **#74** (commit `763f8cc`) — the byte-preserving `maps.txt`/`map.msg` patchers.
- **this PR** (`09fa6a2`) — the writable-overlay infra + the editable-fields UI.

## New in this PR

**Infra (Qt-free, unit-tested):**
- `Settings` gains a **writable data root** (default under `QStandardPaths::AppLocalDataLocation`, JSON-persisted).
- `DataPathLoader` mounts it **last**, so loose edited copies shadow the archived (DAT) originals.
- `resource::ensureWritableCopy` — copy-on-edit: copies a VFS file (DAT or dir) into the writable root, or returns an existing edited copy untouched.

**UI:**
- The two name fields become editable `QLineEdit`s + a **Save names** button (disabled / read-only when the map isn't in `maps.txt`).
- On save: only the edited field (`isModified`) is written via the patchers, after copy-on-edit; then the overlay is re-mounted (vfspp caches its listing), `map.msg` is dropped from the cache, the resolver is rebuilt, and the panel reflects the edit **live**.

## Tests
`test_writable_data_root` (copy-out + idempotence) and a `qt_tests` case that edits a name, saves, and asserts **both** the persisted writable copy and the live-reflected panel value. 256 tests pass.

## Merge note
Because this branch contains #73 and #74, the cleanest path is to **merge this PR and close #73/#74**. Alternatively merge #73 → #74 first and this will rebase down to just the infra+UI commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)