### PR TITLE
Inventory item picker (replace raw PID entry)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ set(GECK_APP_SOURCES
     # Qt6 UI Dialogs
     ui/dialogs/FrmSelectorDialog.h
     ui/dialogs/FrmSelectorDialog.cpp
+    ui/dialogs/ItemSelectorDialog.h
+    ui/dialogs/ItemSelectorDialog.cpp
     ui/dialogs/SettingsDialog.h
     ui/dialogs/SettingsDialog.cpp
     ui/dialogs/ProEditorDialog.h

--- a/src/ui/common/InventoryItemUiHelper.cpp
+++ b/src/ui/common/InventoryItemUiHelper.cpp
@@ -165,6 +165,7 @@ ItemDetails describeItem(resource::GameResources& resources, uint32_t pid) {
     try {
         Pro* pro = loadPro(resources, pid);
         if (!pro) {
+            details.resolved = false;
             return details;
         }
 
@@ -172,6 +173,7 @@ ItemDetails describeItem(resource::GameResources& resources, uint32_t pid) {
         details.typeName = typeNameForPro(resources, *pro);
     } catch (const std::exception& e) {
         spdlog::warn("InventoryItemUiHelper::describeItem: Failed to describe PID {}: {}", pid, e.what());
+        details.resolved = false;
     }
 
     return details;

--- a/src/ui/common/InventoryItemUiHelper.h
+++ b/src/ui/common/InventoryItemUiHelper.h
@@ -23,6 +23,7 @@ namespace ui::inventory {
         QString name;
         QString typeName;
         QString pidText;
+        bool resolved = true; ///< false when the proto/name couldn't be resolved (name+typeName are placeholders)
     };
 
     uint32_t displayAmount(resource::GameResources& resources, const MapObject& item);
@@ -44,13 +45,13 @@ namespace ui::inventory {
     /// Per-view knobs for populateInventoryTree. Defaults match a read-only,
     /// index-keyed view; SelectionPanel overrides them for its editable, PID-keyed tree.
     struct InventoryTreeOptions {
-        int iconSize = 0;             ///< forwarded to loadItemIcon when no iconProvider is set
-        bool fixedCanvas = false;     ///< pad the icon onto a fixed iconSize canvas
-        bool showPidColumn = false;   ///< write details.pidText into COLUMN_PID
-        bool editable = false;        ///< add Qt::ItemIsEditable to each row
-        bool setIconSizeHint = false; ///< pin COLUMN_ICON size hint to iconSize
-        bool userRoleIsPid = false;   ///< UserRole payload: item PID (true) or inventory index (false)
-        int userRoleColumn = COLUMN_NAME; ///< column carrying the UserRole payload
+        int iconSize = 0;                                      ///< forwarded to loadItemIcon when no iconProvider is set
+        bool fixedCanvas = false;                              ///< pad the icon onto a fixed iconSize canvas
+        bool showPidColumn = false;                            ///< write details.pidText into COLUMN_PID
+        bool editable = false;                                 ///< add Qt::ItemIsEditable to each row
+        bool setIconSizeHint = false;                          ///< pin COLUMN_ICON size hint to iconSize
+        bool userRoleIsPid = false;                            ///< UserRole payload: item PID (true) or inventory index (false)
+        int userRoleColumn = COLUMN_NAME;                      ///< column carrying the UserRole payload
         std::function<QPixmap(const MapObject&)> iconProvider; ///< optional icon override
     };
 

--- a/src/ui/dialogs/InventoryViewerDialog.cpp
+++ b/src/ui/dialogs/InventoryViewerDialog.cpp
@@ -2,13 +2,13 @@
 #include "editor/Object.h"
 #include "format/map/MapObject.h"
 #include "ui/common/InventoryItemUiHelper.h"
-#include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
 
 #include <QApplication>
 #include <QHeaderView>
 #include <QMessageBox>
+#include <QInputDialog>
 #include <spdlog/spdlog.h>
 
 namespace geck {
@@ -315,35 +315,53 @@ void InventoryViewerDialog::updateStatusLabel() {
 }
 
 void InventoryViewerDialog::onAddItemClicked() {
-    ItemSelectorDialog dialog(_resources, this);
-    if (dialog.exec() != QDialog::Accepted) {
-        return;
-    }
-    const auto pid = dialog.selectedPid();
-    if (!pid) {
-        return;
-    }
-    const int amount = dialog.selectedAmount();
+    bool ok;
+    QString pidText = QInputDialog::getText(this, "Add Item", "Enter item PID (hex or decimal):", QLineEdit::Normal, "", &ok);
 
-    // The picker only lists real protos, but guard anyway in case a proto failed to resolve.
-    if (!ui::inventory::itemExists(_resources, *pid)) {
-        QMessageBox::warning(this, "Invalid Item", QString("Item with PID 0x%1 not found in game data.").arg(*pid, 8, 16, QChar('0')));
+    if (!ok || pidText.isEmpty()) {
+        return;
+    }
+
+    // Parse PID (support both hex and decimal)
+    uint32_t pid = 0;
+    if (pidText.startsWith("0x") || pidText.startsWith("0X")) {
+        pid = pidText.mid(2).toUInt(&ok, 16);
+    } else {
+        pid = pidText.toUInt(&ok, 10);
+        if (!ok) {
+            // Try hex if decimal fails
+            pid = pidText.toUInt(&ok, 16);
+        }
+    }
+
+    if (!ok || pid == 0) {
+        QMessageBox::warning(this, "Invalid PID", "Please enter a valid PID in decimal or hex format (e.g., 16777216 or 0x01000000)");
+        return;
+    }
+
+    int amount = QInputDialog::getInt(this, "Add Item", "Enter amount:", 1, 1, 99999, 1, &ok);
+    if (!ok) {
+        return;
+    }
+
+    if (!ui::inventory::itemExists(_resources, pid)) {
+        QMessageBox::warning(this, "Invalid Item", QString("Item with PID 0x%1 not found in game data.").arg(pid, 8, 16, QChar('0')));
         return;
     }
 
     try {
-        auto newItem = ui::inventory::createMapInventoryItem(_resources, *pid, amount);
+        auto newItem = ui::inventory::createMapInventoryItem(_resources, pid, amount);
         _mapObject->inventory.push_back(std::move(newItem));
         _mapObject->objects_in_inventory = static_cast<uint32_t>(_mapObject->inventory.size());
 
         populateInventoryTree();
         updateStatusLabel();
 
-        spdlog::info("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", *pid, amount);
+        spdlog::info("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", pid, amount);
 
     } catch (const std::exception& e) {
         QMessageBox::warning(this, "Error", QString("Failed to add item: %1").arg(e.what()));
-        spdlog::error("InventoryViewerDialog::onAddItemClicked: Error adding item PID {}: {}", *pid, e.what());
+        spdlog::error("InventoryViewerDialog::onAddItemClicked: Error adding item PID {}: {}", pid, e.what());
     }
 }
 

--- a/src/ui/dialogs/InventoryViewerDialog.cpp
+++ b/src/ui/dialogs/InventoryViewerDialog.cpp
@@ -2,13 +2,13 @@
 #include "editor/Object.h"
 #include "format/map/MapObject.h"
 #include "ui/common/InventoryItemUiHelper.h"
+#include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
 
 #include <QApplication>
 #include <QHeaderView>
 #include <QMessageBox>
-#include <QInputDialog>
 #include <spdlog/spdlog.h>
 
 namespace geck {
@@ -315,53 +315,35 @@ void InventoryViewerDialog::updateStatusLabel() {
 }
 
 void InventoryViewerDialog::onAddItemClicked() {
-    bool ok;
-    QString pidText = QInputDialog::getText(this, "Add Item", "Enter item PID (hex or decimal):", QLineEdit::Normal, "", &ok);
-
-    if (!ok || pidText.isEmpty()) {
+    ItemSelectorDialog dialog(_resources, this);
+    if (dialog.exec() != QDialog::Accepted) {
         return;
     }
-
-    // Parse PID (support both hex and decimal)
-    uint32_t pid = 0;
-    if (pidText.startsWith("0x") || pidText.startsWith("0X")) {
-        pid = pidText.mid(2).toUInt(&ok, 16);
-    } else {
-        pid = pidText.toUInt(&ok, 10);
-        if (!ok) {
-            // Try hex if decimal fails
-            pid = pidText.toUInt(&ok, 16);
-        }
-    }
-
-    if (!ok || pid == 0) {
-        QMessageBox::warning(this, "Invalid PID", "Please enter a valid PID in decimal or hex format (e.g., 16777216 or 0x01000000)");
+    const auto pid = dialog.selectedPid();
+    if (!pid) {
         return;
     }
+    const int amount = dialog.selectedAmount();
 
-    int amount = QInputDialog::getInt(this, "Add Item", "Enter amount:", 1, 1, 99999, 1, &ok);
-    if (!ok) {
-        return;
-    }
-
-    if (!ui::inventory::itemExists(_resources, pid)) {
-        QMessageBox::warning(this, "Invalid Item", QString("Item with PID 0x%1 not found in game data.").arg(pid, 8, 16, QChar('0')));
+    // The picker only lists real protos, but guard anyway in case a proto failed to resolve.
+    if (!ui::inventory::itemExists(_resources, *pid)) {
+        QMessageBox::warning(this, "Invalid Item", QString("Item with PID 0x%1 not found in game data.").arg(*pid, 8, 16, QChar('0')));
         return;
     }
 
     try {
-        auto newItem = ui::inventory::createMapInventoryItem(_resources, pid, amount);
+        auto newItem = ui::inventory::createMapInventoryItem(_resources, *pid, amount);
         _mapObject->inventory.push_back(std::move(newItem));
         _mapObject->objects_in_inventory = static_cast<uint32_t>(_mapObject->inventory.size());
 
         populateInventoryTree();
         updateStatusLabel();
 
-        spdlog::info("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", pid, amount);
+        spdlog::info("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", *pid, amount);
 
     } catch (const std::exception& e) {
         QMessageBox::warning(this, "Error", QString("Failed to add item: %1").arg(e.what()));
-        spdlog::error("InventoryViewerDialog::onAddItemClicked: Error adding item PID {}: {}", pid, e.what());
+        spdlog::error("InventoryViewerDialog::onAddItemClicked: Error adding item PID {}: {}", *pid, e.what());
     }
 }
 

--- a/src/ui/dialogs/ItemSelectorDialog.cpp
+++ b/src/ui/dialogs/ItemSelectorDialog.cpp
@@ -163,9 +163,13 @@ void ItemSelectorDialog::onSearchTextChanged(const QString& text) {
     const QString needle = text.trimmed();
     for (int i = 0; i < _tree->topLevelItemCount(); ++i) {
         QTreeWidgetItem* item = _tree->topLevelItem(i);
+        const auto pid = static_cast<uint32_t>(item->data(COL_NAME, PID_ROLE).toULongLong());
+        // Match the name, the displayed hex PID, and the decimal PID — the old prompt accepted a PID
+        // in either base, so a pasted hex or decimal value should still find the item.
         const bool match = needle.isEmpty()
             || item->text(COL_NAME).contains(needle, Qt::CaseInsensitive)
-            || item->text(COL_PID).contains(needle, Qt::CaseInsensitive);
+            || item->text(COL_PID).contains(needle, Qt::CaseInsensitive)
+            || QString::number(pid).contains(needle);
         item->setHidden(!match);
     }
 }

--- a/src/ui/dialogs/ItemSelectorDialog.cpp
+++ b/src/ui/dialogs/ItemSelectorDialog.cpp
@@ -1,0 +1,222 @@
+#include "ui/dialogs/ItemSelectorDialog.h"
+
+#include "format/lst/Lst.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
+#include "ui/common/InventoryItemUiHelper.h"
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPixmap>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QSplitter>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+
+#include <spdlog/spdlog.h>
+
+#include <cstddef>
+#include <string>
+
+namespace geck {
+
+namespace {
+    constexpr int PREVIEW_ICON_SIZE = 96;
+    constexpr int PID_ROLE = Qt::UserRole + 1;
+
+    enum Column {
+        COL_NAME = 0,
+        COL_TYPE = 1,
+        COL_PID = 2,
+    };
+} // namespace
+
+ItemSelectorDialog::ItemSelectorDialog(resource::GameResources& resources, QWidget* parent)
+    : QDialog(parent)
+    , _resources(resources) {
+    setupUI();
+    populate();
+}
+
+int ItemSelectorDialog::selectedAmount() const {
+    return _amountSpin->value();
+}
+
+void ItemSelectorDialog::setupUI() {
+    setWindowTitle("Add Item");
+    setModal(true);
+    resize(640, 460);
+
+    _search = new QLineEdit(this);
+    _search->setPlaceholderText("Filter items by name or PID…");
+    _search->setClearButtonEnabled(true);
+
+    _tree = new QTreeWidget(this);
+    _tree->setColumnCount(3);
+    _tree->setHeaderLabels({ "Name", "Type", "PID" });
+    _tree->setRootIsDecorated(false);
+    _tree->setAlternatingRowColors(true);
+    _tree->setSelectionMode(QAbstractItemView::SingleSelection);
+    _tree->setUniformRowHeights(true);
+    _tree->header()->setStretchLastSection(false);
+    _tree->header()->setSectionResizeMode(COL_NAME, QHeaderView::Stretch);
+    _tree->header()->setSectionResizeMode(COL_TYPE, QHeaderView::ResizeToContents);
+    _tree->header()->setSectionResizeMode(COL_PID, QHeaderView::ResizeToContents);
+
+    auto* listPanel = new QWidget(this);
+    auto* listLayout = new QVBoxLayout(listPanel);
+    listLayout->setContentsMargins(0, 0, 0, 0);
+    listLayout->addWidget(_search);
+    listLayout->addWidget(_tree, 1);
+
+    _previewIcon = new QLabel(this);
+    _previewIcon->setAlignment(Qt::AlignCenter);
+    _previewIcon->setMinimumSize(PREVIEW_ICON_SIZE, PREVIEW_ICON_SIZE);
+    _previewName = new QLabel("—", this);
+    _previewName->setWordWrap(true);
+    _previewType = new QLabel("—", this);
+    _previewPid = new QLabel("—", this);
+
+    _amountSpin = new QSpinBox(this);
+    _amountSpin->setRange(1, 99999);
+    _amountSpin->setValue(1);
+
+    auto* detailsGroup = new QGroupBox("Item", this);
+    auto* detailsLayout = new QFormLayout(detailsGroup);
+    detailsLayout->addRow(_previewIcon);
+    detailsLayout->addRow("Name:", _previewName);
+    detailsLayout->addRow("Type:", _previewType);
+    detailsLayout->addRow("PID:", _previewPid);
+    detailsLayout->addRow("Amount:", _amountSpin);
+
+    auto* previewPanel = new QWidget(this);
+    auto* previewLayout = new QVBoxLayout(previewPanel);
+    previewLayout->setContentsMargins(0, 0, 0, 0);
+    previewLayout->addWidget(detailsGroup);
+    previewLayout->addStretch(1);
+
+    auto* splitter = new QSplitter(this);
+    splitter->addWidget(listPanel);
+    splitter->addWidget(previewPanel);
+    splitter->setStretchFactor(0, 3);
+    splitter->setStretchFactor(1, 2);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    _okButton = buttons->button(QDialogButtonBox::Ok);
+    _okButton->setText("Add");
+    _okButton->setEnabled(false);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(splitter, 1);
+    layout->addWidget(buttons);
+
+    connect(_search, &QLineEdit::textChanged, this, &ItemSelectorDialog::onSearchTextChanged);
+    connect(_tree, &QTreeWidget::itemSelectionChanged, this, &ItemSelectorDialog::onSelectionChanged);
+    connect(_tree, &QTreeWidget::itemActivated, this, &ItemSelectorDialog::onItemActivated);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+void ItemSelectorDialog::populate() {
+    const Lst* lst = nullptr;
+    try {
+        lst = _resources.repository().load<Lst>(std::string(ResourcePaths::Lst::PROTO_ITEMS));
+    } catch (const std::exception& e) {
+        spdlog::warn("ItemSelectorDialog: could not load items.lst: {}", e.what());
+    }
+    if (lst == nullptr) {
+        return;
+    }
+
+    // Resolving every item's name + type means loading its proto, so this loop touches every item
+    // proto once. Show a wait cursor for the one-time cost (protos are cached, so reopening is fast).
+    const auto& files = lst->list();
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    for (std::size_t i = 0; i < files.size(); ++i) {
+        // An item PID's low 24 bits are the 1-based items.lst line; the type (ITEM) is the high byte.
+        const uint32_t pid = Pro::makePid(Pro::OBJECT_TYPE::ITEM, static_cast<uint32_t>(i + 1));
+
+        const ui::inventory::ItemDetails details = ui::inventory::describeItem(_resources, pid);
+        // describeItem yields a placeholder name when a proto can't be resolved; prefer the real .pro
+        // filename in that case so the row stays a meaningful identifier.
+        const QString name = details.resolved ? details.name : QString::fromStdString(files[i]);
+
+        auto* row = new QTreeWidgetItem(_tree);
+        row->setText(COL_NAME, name);
+        row->setText(COL_TYPE, details.typeName);
+        row->setText(COL_PID, details.pidText);
+        row->setData(COL_NAME, PID_ROLE, static_cast<qulonglong>(pid));
+    }
+    QApplication::restoreOverrideCursor();
+    _tree->sortItems(COL_NAME, Qt::AscendingOrder);
+}
+
+void ItemSelectorDialog::onSearchTextChanged(const QString& text) {
+    const QString needle = text.trimmed();
+    for (int i = 0; i < _tree->topLevelItemCount(); ++i) {
+        QTreeWidgetItem* item = _tree->topLevelItem(i);
+        const bool match = needle.isEmpty()
+            || item->text(COL_NAME).contains(needle, Qt::CaseInsensitive)
+            || item->text(COL_PID).contains(needle, Qt::CaseInsensitive);
+        item->setHidden(!match);
+    }
+}
+
+void ItemSelectorDialog::onSelectionChanged() {
+    const QList<QTreeWidgetItem*> selection = _tree->selectedItems();
+    if (selection.isEmpty()) {
+        _selectedPid.reset();
+        _okButton->setEnabled(false);
+        updatePreview(nullptr);
+        return;
+    }
+    QTreeWidgetItem* item = selection.first();
+    _selectedPid = static_cast<uint32_t>(item->data(COL_NAME, PID_ROLE).toULongLong());
+    _okButton->setEnabled(true);
+    updatePreview(item);
+}
+
+void ItemSelectorDialog::onItemActivated(QTreeWidgetItem* item, int /*column*/) {
+    if (item == nullptr) {
+        return;
+    }
+    _selectedPid = static_cast<uint32_t>(item->data(COL_NAME, PID_ROLE).toULongLong());
+    accept(); // double-click / Enter picks the item
+}
+
+void ItemSelectorDialog::updatePreview(const QTreeWidgetItem* item) {
+    if (item == nullptr) {
+        _previewIcon->clear();
+        _previewName->setText("—");
+        _previewType->setText("—");
+        _previewPid->setText("—");
+        return;
+    }
+
+    _previewName->setText(item->text(COL_NAME));
+    _previewType->setText(item->text(COL_TYPE));
+    _previewPid->setText(item->text(COL_PID));
+
+    const auto pid = static_cast<uint32_t>(item->data(COL_NAME, PID_ROLE).toULongLong());
+    QPixmap icon;
+    try {
+        icon = ui::inventory::loadItemIcon(_resources, pid, PREVIEW_ICON_SIZE, /*fixedCanvas=*/true);
+    } catch (const std::exception& e) {
+        spdlog::debug("ItemSelectorDialog: no icon for PID {}: {}", pid, e.what());
+    }
+    if (!icon.isNull()) {
+        _previewIcon->setPixmap(icon);
+    } else {
+        _previewIcon->clear();
+    }
+}
+
+} // namespace geck

--- a/src/ui/dialogs/ItemSelectorDialog.h
+++ b/src/ui/dialogs/ItemSelectorDialog.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QDialog>
+
+#include <cstdint>
+#include <optional>
+
+class QLineEdit;
+class QTreeWidget;
+class QTreeWidgetItem;
+class QLabel;
+class QSpinBox;
+class QPushButton;
+
+namespace geck {
+
+namespace resource {
+    class GameResources;
+}
+
+/// Browsable picker for an inventory item: lists every item proto (from proto/items/items.lst) by name,
+/// type and PID with a search filter and a sprite preview, plus an amount spinner. Replaces the raw
+/// "enter a PID in hex or decimal" prompt in the inventory editor. Returns the chosen item PID + amount.
+class ItemSelectorDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ItemSelectorDialog(resource::GameResources& resources, QWidget* parent = nullptr);
+
+    /// The selected item PID, or nullopt if the dialog was cancelled / nothing was chosen.
+    std::optional<uint32_t> selectedPid() const { return _selectedPid; }
+    /// The chosen amount (>= 1). Only meaningful when selectedPid() has a value.
+    int selectedAmount() const;
+
+private slots:
+    void onSearchTextChanged(const QString& text);
+    void onSelectionChanged();
+    void onItemActivated(QTreeWidgetItem* item, int column);
+
+private:
+    void setupUI();
+    void populate();
+    void updatePreview(const QTreeWidgetItem* item);
+
+    resource::GameResources& _resources;
+
+    QLineEdit* _search = nullptr;
+    QTreeWidget* _tree = nullptr;
+    QLabel* _previewIcon = nullptr;
+    QLabel* _previewName = nullptr;
+    QLabel* _previewType = nullptr;
+    QLabel* _previewPid = nullptr;
+    QSpinBox* _amountSpin = nullptr;
+    QPushButton* _okButton = nullptr;
+
+    std::optional<uint32_t> _selectedPid;
+};
+
+} // namespace geck

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -8,6 +8,7 @@
 #include "ui/dialogs/InstancePropertiesDialog.h"
 #include "ui/dialogs/CritterPropertiesDialog.h"
 #include "ui/dialogs/ScriptSelectorDialog.h"
+#include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
 #include "resource/ResourcePaths.h"
@@ -22,7 +23,6 @@
 #include <QPainter>
 #include <QHeaderView>
 #include <QMessageBox>
-#include <QInputDialog>
 #include <QSpinBox>
 #include <QEnterEvent>
 #include <spdlog/spdlog.h>
@@ -1308,33 +1308,33 @@ void SelectionPanel::onAddInventoryClicked() {
         return;
     }
 
-    bool ok = false;
-    const int index = QInputDialog::getInt(this, "Add Inventory Item",
-        "Item proto index:", 1, 1, 0x00FFFFFF, 1, &ok);
-    if (!ok) {
+    ItemSelectorDialog dialog(_resources, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    const auto itemPid = dialog.selectedPid();
+    if (!itemPid) {
         return;
     }
 
-    const uint32_t itemPid = Pro::makePid(Pro::OBJECT_TYPE::ITEM, static_cast<uint32_t>(index));
-
     Pro* pro = nullptr;
     try {
-        pro = _resources.loadPro(itemPid);
+        pro = _resources.loadPro(*itemPid);
     } catch (const std::exception& e) {
-        spdlog::warn("onAddInventoryClicked: failed to load proto for pid {}: {}", itemPid, e.what());
+        spdlog::warn("onAddInventoryClicked: failed to load proto for pid {}: {}", *itemPid, e.what());
     }
     if (!pro) {
         QMessageBox::warning(this, "Add Inventory Item",
-            QString("No item prototype found for index %1.").arg(index));
+            QString("No item prototype found for PID 0x%1.").arg(*itemPid, 8, 16, QChar('0')));
         return;
     }
 
     auto before = ObjectCommandController::cloneInventory(holder->inventory);
 
     auto item = std::make_unique<MapObject>();
-    item->pro_pid = itemPid;
+    item->pro_pid = *itemPid;
     item->frm_pid = pro->header.FID;
-    item->amount = 1;
+    item->amount = static_cast<uint32_t>(dialog.selectedAmount());
     item->elevation = holder->elevation;
     item->position = holder->position;
 

--- a/src/util/ProHelper.cpp
+++ b/src/util/ProHelper.cpp
@@ -64,9 +64,10 @@ Lst* ProHelper::lstFile(resource::GameResources& resources, uint32_t PID) {
 std::string ProHelper::basePath(resource::GameResources& resources, uint32_t PID) {
     const ProtoTypePaths& paths = protoTypePaths(Pro::typeOfPid(PID));
 
-    // The low 12 bits of a PID are the 1-based line number in the type's LST, so
-    // index 0 is not a valid proto and would underflow the index - 1 lookup below.
-    unsigned int index = 0x00000FFF & PID;
+    // The low 24 bits of a PID are the 1-based line number in the type's LST (matching the engine's
+    // proto-number decode `pid & 0xFFFFFF` in proto.cc and Pro::makePid); index 0 is not a valid proto
+    // and would underflow the index - 1 lookup below.
+    unsigned int index = 0x00FFFFFF & PID;
     auto lst = ProHelper::lstFile(resources, PID);
     if (index == 0 || index > lst->list().size()) {
         throw std::runtime_error{ "PID index out of range (expected 1.."

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -29,6 +29,7 @@
 #include "format/pro/Pro.h"
 #include "ui/core/MainWindow.h"
 #include "ui/dialogs/InventoryViewerDialog.h"
+#include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
 #include "ui/widgets/ObjectPreviewWidget.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
@@ -589,6 +590,44 @@ TEST_CASE("Info panel derives display state from PRO data", "[qt][pro]") {
     REQUIRE(widget.nameText() == "10mm JHP");
     REQUIRE(widget.filenameText() == "00000030.pro");
     REQUIRE(widget.windowTitleText() == "10mm JHP (Ammo) - PRO editor");
+}
+
+TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][inventory]") {
+    ResourceDataScope resources;
+    resources.writeGameMessageFile("proto/items/items.lst", "aaa.pro\nbbb.pro\nccc.pro\n");
+    resources.mount();
+
+    geck::ItemSelectorDialog dialog(resources.resources());
+    auto* tree = dialog.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+    REQUIRE(tree->topLevelItemCount() == 3);
+
+    // No .pro files are mounted, so describeItem cannot resolve a name; the dialog falls back to the
+    // .pro filename and still stores the correct item PID = makePid(ITEM, 1-based items.lst line).
+    constexpr int PID_ROLE = Qt::UserRole + 1; // mirrors ItemSelectorDialog's internal storage role
+    struct Expect {
+        const char* name;
+        uint32_t pid;
+    };
+    const Expect expected[] = {
+        { "aaa.pro", geck::Pro::makePid(geck::Pro::OBJECT_TYPE::ITEM, 1) },
+        { "bbb.pro", geck::Pro::makePid(geck::Pro::OBJECT_TYPE::ITEM, 2) },
+        { "ccc.pro", geck::Pro::makePid(geck::Pro::OBJECT_TYPE::ITEM, 3) },
+    };
+    for (int i = 0; i < 3; ++i) {
+        QTreeWidgetItem* row = tree->topLevelItem(i); // sorted by name -> aaa, bbb, ccc
+        CHECK(row->text(0).toStdString() == expected[i].name);
+        CHECK(static_cast<uint32_t>(row->data(0, PID_ROLE).toULongLong()) == expected[i].pid);
+    }
+
+    // Nothing chosen yet; the amount defaults to 1.
+    CHECK_FALSE(dialog.selectedPid().has_value());
+    CHECK(dialog.selectedAmount() == 1);
+
+    // Selecting a row exposes that row's PID.
+    tree->setCurrentItem(tree->topLevelItem(0));
+    REQUIRE(dialog.selectedPid().has_value());
+    CHECK(dialog.selectedPid().value() == expected[0].pid);
 }
 
 TEST_CASE("Preview panel uses dual item previews and a single object preview", "[qt][pro]") {

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -603,8 +603,7 @@ TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][
     REQUIRE(tree->topLevelItemCount() == 3);
 
     // No .pro files are mounted, so describeItem cannot resolve a name; the dialog falls back to the
-    // .pro filename and still stores the correct item PID = makePid(ITEM, 1-based items.lst line).
-    constexpr int PID_ROLE = Qt::UserRole + 1; // mirrors ItemSelectorDialog's internal storage role
+    // .pro filename and shows the item PID = makePid(ITEM, 1-based items.lst line) in the PID column.
     struct Expect {
         const char* name;
         uint32_t pid;
@@ -616,15 +615,16 @@ TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][
     };
     for (int i = 0; i < 3; ++i) {
         QTreeWidgetItem* row = tree->topLevelItem(i); // sorted by name -> aaa, bbb, ccc
-        CHECK(row->text(0).toStdString() == expected[i].name);
-        CHECK(static_cast<uint32_t>(row->data(0, PID_ROLE).toULongLong()) == expected[i].pid);
+        const QString expectedPid = QString("0x%1").arg(expected[i].pid, 8, 16, QChar('0'));
+        CHECK(row->text(0).toStdString() == expected[i].name);          // Name column (filename fallback)
+        CHECK(row->text(2).toStdString() == expectedPid.toStdString()); // PID column (visible)
     }
 
     // Nothing chosen yet; the amount defaults to 1.
     CHECK_FALSE(dialog.selectedPid().has_value());
     CHECK(dialog.selectedAmount() == 1);
 
-    // Selecting a row exposes that row's PID.
+    // Selecting a row exposes that row's PID through the public API.
     tree->setCurrentItem(tree->topLevelItem(0));
     REQUIRE(dialog.selectedPid().has_value());
     CHECK(dialog.selectedPid().value() == expected[0].pid);


### PR DESCRIPTION
Implements PLAN #8 — the first half of the "engine numbers → human labels" track.

## What

Adding an item to a container/critter's inventory used a numeric proto-index prompt (`QInputDialog`) in the **Selection panel's "Add Item"** button. This adds **`ItemSelectorDialog`**, a browsable picker:

- Lists every item proto from `proto/items/items.lst` with **name, type, and PID**, resolved via the existing `ui::inventory` helpers (no new parsing).
- **Search** by name, hex PID, or decimal PID; a **sprite preview**; an **amount** spinner. Double-click / Enter picks.
- An item PID is `Pro::makePid(ITEM, lstLine)`, matching the engine + `ProHelper`.

`SelectionPanel::onAddInventoryClicked` now opens the picker (and honors the chosen amount — the old flow hardcoded `amount = 1`), keeping the undo-aware commit path.

> Note: an earlier revision wired this into `InventoryViewerDialog`, which turned out to be dead/unwired code (per `ARCHITECTURE_REVIEW.md`). Corrected to the live Selection-panel flow; the dead dialog is left untouched.

## Commits

1. **`fix(proto)`** — `ProHelper::basePath` decoded the PID index as 12 bits; the engine + `Pro::makePid` use 24. Harmless for vanilla data, but the picker enumerates the full `items.lst` range, so align it.
2. **`feat(ui)`** — the picker + `ItemDetails::resolved` (honest `.pro`-filename fallback instead of an `"Item <pid>"` placeholder).
3. **review fixes** — decimal-PID filter match; test asserts the visible PID column + public API.
4. **`fix(ui)`** — wire the picker into the live `SelectionPanel` Add flow (the correction above).

## Quality

Adversarial multi-agent review (4 lenses, 21 findings, each verified → 4 folded in: dead-fallback fix, wait cursor, setModal). Both Copilot comments addressed. New `qt_tests` case covers enumeration, PID mapping, and the filename fallback. 269 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2