### PR TITLE
Map save: default to the writable maps/ folder, Save without reopening, add Save As

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -63,6 +63,15 @@ live with their library (`src/resource/`, `src/ui/`).
     drive it from the same command/action table proposed in #11 (stable action id → icon/label/handler),
     with a context-menu / Preferences UI to add, remove, and reorder buttons, persisted via `Settings`.
     Editor UX only; no map/format change.
+13. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
+    into the *last folder* in Data Paths — `findWritableDataPath` walks the list from the end and takes
+    the first real directory (archives skipped). That's implicit and order-dependent: reordering Data
+    Paths silently changes where saves land, and nothing in the UI shows which location is the writable
+    one. Map saves now default to that folder's `maps/` (Save / Save As), so the choice matters.
+    **Add an explicit default-writable marker:** a button in Settings → Data Paths to designate the
+    selected folder as the default writable location, shown with a badge in the list and persisted in
+    `Settings`; saves then target that folder regardless of list order. If none is marked, keep the
+    current last-folder fallback and hint the user to pick one. DAT archives can't be marked (read-only).
 
 ### Exit-grid shapes (rectangle-only) — limitation #2 in detail
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -448,33 +448,53 @@ ScriptResult EditorWidget::runScript(const std::string& source) {
 }
 #endif
 
-bool EditorWidget::saveMap() {
-    // Default the save dialog to the current map's file name.
-    const QString suggestedName = _session.map() ? QString::fromStdString(_session.map()->filename()) : QString();
-    QString destinationQString = QtDialogs::saveFile(this, "Save Map",
-        "Map Files (*.map);;All Files (*.*)", suggestedName);
+bool EditorWidget::saveMap(const std::filesystem::path& defaultDir) {
+    // "Save": once the map points at a real file (saved before, or opened from one), write straight to
+    // it without re-prompting. A map loaded from the game data carries a VFS-relative path, and a new
+    // map has no real target yet, so those fall through to "Save As".
+    if (_session.map() && _session.map()->path().is_absolute()) {
+        return writeMapTo(_session.map()->path().string());
+    }
+    return saveMapAs(defaultDir);
+}
 
+bool EditorWidget::saveMapAs(const std::filesystem::path& defaultDir) {
+    if (!_session.map()) {
+        return false;
+    }
+
+    // Default the dialog to <writable data path>/maps/<filename> when a writable location exists;
+    // otherwise just the file name (the dialog then seeds its last-used directory). Passing an absolute
+    // suggestion deliberately overrides that last-used directory.
+    const std::string filename = _session.map()->filename();
+    const QString suggested = defaultDir.empty()
+        ? QString::fromStdString(filename)
+        : QString::fromStdString((defaultDir / filename).string());
+
+    const QString destinationQString = QtDialogs::saveFile(this, "Save Map As",
+        "Map Files (*.map);;All Files (*.*)", suggested);
     if (destinationQString.isEmpty()) {
         return false; // user cancelled the dialog
     }
+    return writeMapTo(destinationQString.toStdString());
+}
 
-    std::string destination = destinationQString.toStdString();
-
+bool EditorWidget::writeMapTo(const std::string& destination) {
     try {
         if (const auto bytesWritten = saveMapToFile(_resources, _session.map()->getMapFile(), destination);
             bytesWritten.has_value()) {
             spdlog::info("Saved map {} ({} bytes)", destination, *bytesWritten);
-            // Repoint the map at the saved file so the window title reflects the chosen name.
+            // Repoint the map at the saved file so the title reflects the name and the next Save targets it.
             _session.map()->setPath(std::filesystem::path(destination));
             return true;
         }
         spdlog::error("Failed to save map {}", destination);
         QtDialogs::showError(this, "Save Failed",
-            QString("Failed to save map to:\n%1").arg(destinationQString));
+            QString("Failed to save map to:\n%1").arg(QString::fromStdString(destination)));
     } catch (const geck::FileWriterException& e) {
         spdlog::error("Failed to save map {}: {}", destination, e.what());
         QtDialogs::showError(this, "Save Failed",
-            QString("Failed to save map to:\n%1\n\n%2").arg(destinationQString, QString::fromStdString(e.what())));
+            QString("Failed to save map to:\n%1\n\n%2").arg(QString::fromStdString(destination), QString::fromStdString(e.what())));
     } catch (const std::exception& e) {
         spdlog::error("Unexpected error saving map {}: {}", destination, e.what());
     }

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -64,9 +64,14 @@ public:
 
     void createNewMap();
     void openMap();
-    /// Save the current map (always prompts for a destination). Returns true on a successful write,
-    /// false if the user cancelled the dialog or the write failed.
-    bool saveMap();
+    /// Save the current map. If it already points at a real file (saved before, or opened from one), it
+    /// writes straight there with no dialog; otherwise it behaves like Save As, defaulting the dialog to
+    /// `defaultDir` (the writable data path's maps/ folder). Returns true on a successful write, false if
+    /// the user cancelled or the write failed.
+    bool saveMap(const std::filesystem::path& defaultDir = {});
+    /// Always prompt for a destination (defaulting to `defaultDir`/<name>), then write and repoint the
+    /// map at the chosen file. Returns true on a successful write.
+    bool saveMapAs(const std::filesystem::path& defaultDir = {});
 
 #ifdef GECK_SCRIPTING_ENABLED
     // Runs a Luau generation script against the current map at the current elevation. The whole run
@@ -270,6 +275,10 @@ public slots:
     const UndoStack& getUndoStack() const { return _session.undoStack(); }
 
 private:
+    // Write the current map to `destination` (create-or-overwrite) and repoint the map at it; shared by
+    // saveMap (direct write) and saveMapAs (after the dialog). Reports errors and returns success.
+    bool writeMapTo(const std::string& destination);
+
     // One item's new selection entry after a drag-move: objects re-pointed to their refreshed
     // wrapper (by MapObject identity), tiles shifted by the whole-tile delta; nullopt to drop it.
     std::optional<selection::SelectedItem> remapSelectedItemAfterMove(

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -1119,6 +1119,9 @@ std::filesystem::path MainWindow::writableMapsDir() const {
     const std::filesystem::path mapsDir = *root / "maps";
     std::error_code ec;
     std::filesystem::create_directories(mapsDir, ec); // so the save dialog can default into it
+    if (!std::filesystem::is_directory(mapsDir, ec)) {
+        return {}; // couldn't create/use maps/ (permissions, or it's a file) -> fall back to last-used dir
+    }
     return mapsDir;
 }
 

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -32,6 +32,7 @@
 #include "format/map/Map.h"
 #include "util/Types.h"
 #include "ui/Settings.h"
+#include "resource/WritableDataRoot.h"
 #include "ui/QtDialogs.h"
 #include "ui/ExternalEditorLauncher.h"
 #include "reader/lst/LstReader.h"
@@ -230,12 +231,13 @@ void MainWindow::connectMenuSignals() {
         }
     });
     connect(this, &MainWindow::saveMapRequested, [this]() {
-        if (_currentEditorWidget && _currentEditorWidget->saveMap()) {
-            if (_mapInfoPanel) {
-                _mapInfoPanel->persistMapNames(); // flush any edited Map name / Lookup name alongside the .map
-            }
-            _mapModified = false;
-            updateWindowTitle(); // clears the "[*]" and reflects any Save As rename
+        if (_currentEditorWidget && _currentEditorWidget->saveMap(writableMapsDir())) {
+            handleMapSaved();
+        }
+    });
+    connect(this, &MainWindow::saveMapAsRequested, [this]() {
+        if (_currentEditorWidget && _currentEditorWidget->saveMapAs(writableMapsDir())) {
+            handleMapSaved();
         }
     });
     connect(this, &MainWindow::selectAllRequested, [this]() {
@@ -397,6 +399,7 @@ void MainWindow::setupMenuBar() {
     addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Open Map", &MainWindow::openMapRequested, QKeySequence::Open, "Open an existing map");
     addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Browse Maps...", &MainWindow::showMapBrowserDialog, QKeySequence("Ctrl+B"), "Browse available maps as thumbnails");
     addMenuAction(_fileMenu, ":/icons/actions/save.svg", "&Save Map", &MainWindow::saveMapRequested, QKeySequence::Save, "Save current map");
+    addMenuAction(_fileMenu, ":/icons/actions/save.svg", "Save Map &As...", &MainWindow::saveMapAsRequested, QKeySequence::SaveAs, "Save the current map to a chosen file");
 
     _fileMenu->addSeparator();
     addMenuAction(_fileMenu, ":/icons/actions/settings.svg", "&Preferences...", &MainWindow::showPreferences, QKeySequence::Preferences, "Open application preferences");
@@ -1105,6 +1108,28 @@ void MainWindow::setMapModified(bool modified) {
     updateWindowTitle(); // refresh the "*" in the title (and the native marker)
 }
 
+std::filesystem::path MainWindow::writableMapsDir() const {
+    if (!_settings) {
+        return {};
+    }
+    const auto root = resource::findWritableDataPath(_settings->getDataPaths());
+    if (!root) {
+        return {}; // no writable Data Path -> the save dialog falls back to its last-used directory
+    }
+    const std::filesystem::path mapsDir = *root / "maps";
+    std::error_code ec;
+    std::filesystem::create_directories(mapsDir, ec); // so the save dialog can default into it
+    return mapsDir;
+}
+
+void MainWindow::handleMapSaved() {
+    if (_mapInfoPanel) {
+        _mapInfoPanel->persistMapNames(); // flush any edited Map name / Lookup name alongside the .map
+    }
+    _mapModified = false;
+    updateWindowTitle(); // clear the "[*]" and reflect any Save As rename
+}
+
 bool MainWindow::maybeSaveChanges() {
     if (!_mapModified || !_currentEditorWidget || !_currentEditorWidget->getMap()) {
         return true; // nothing unsaved to lose
@@ -1115,12 +1140,8 @@ bool MainWindow::maybeSaveChanges() {
         QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Save);
 
     if (choice == QMessageBox::Save) {
-        if (_currentEditorWidget->saveMap()) {
-            if (_mapInfoPanel) {
-                _mapInfoPanel->persistMapNames(); // flush any edited Map name / Lookup name alongside the .map
-            }
-            setMapModified(false);
-            updateWindowTitle();
+        if (_currentEditorWidget->saveMap(writableMapsDir())) {
+            handleMapSaved();
             return true;
         }
         return false; // save cancelled or failed — abort rather than discard

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -84,6 +84,7 @@ signals:
     void newMapRequested();
     void openMapRequested();
     void saveMapRequested();
+    void saveMapAsRequested();
     void selectAllRequested();
     void deselectAllRequested();
     void showObjectsToggled(bool enabled);
@@ -168,6 +169,13 @@ private:
     void replaceDockPanelWidget(QDockWidget* dock, QWidget* panel, QSizePolicy::Policy verticalPolicy);
     void rebuildResourcePanels();
     void rebuildGameResourcesFromSettings();
+
+    // The writable data path's maps/ folder (created if needed), used as the default save target; empty
+    // when no writable Data Path is configured.
+    std::filesystem::path writableMapsDir() const;
+    // Post-save housekeeping shared by Save / Save As: flush map-name edits, clear the modified flag, and
+    // refresh the title (which also picks up a Save As rename).
+    void handleMapSaved();
 
     // Dock widget state management
     void saveDockWidgetState();

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -1001,7 +1001,13 @@ void MapInfoPanel::persistMapNames() {
 
     const int index = _mapNames->indexOf(_map->filename()); // by basename, not the NUL-padded header field
     if (index < 0) {
-        return; // not in maps.txt -> the fields are read-only, so there is nothing to persist
+        // We only get here with pending edits (checked above). The map's current name isn't in maps.txt
+        // — typically because Save As renamed it to a file with no registry entry — so there's nowhere to
+        // write the edits. Warn rather than dropping them silently.
+        QMessageBox::warning(this, "Save Map Names",
+            QString("Map name edits weren't saved: \"%1\" isn't registered in maps.txt.")
+                .arg(QString::fromStdString(_map->filename())));
+        return;
     }
 
     // Write into a writable folder from the user's Data Paths (no hidden location). If there's none, the


### PR DESCRIPTION
## What

Reworks the map save flow so it behaves like a normal editor's Save / Save As.

- **Save (Ctrl+S)** writes straight to the map's file once it points at a real (absolute) path — after the first save, or when the map was opened from a real file — with **no dialog**. A map loaded from the game data (a VFS-relative path) or a brand-new map still prompts.
- **The save dialog defaults to `<writable data path>/maps/<name>`** (`MainWindow::writableMapsDir()` = `findWritableDataPath(dataPaths)/maps`, created on demand). With no writable Data Path it falls back to the last-used directory.
- **Save Map As… (Ctrl+Shift+S)** — new; always prompts (same writable `maps/` default), writes, and repoints the map so the next Save targets it.
- Shared post-save housekeeping (persist map names, clear modified, refresh title incl. a Save As rename) factored into `handleMapSaved()`.

## Commits

1. **`feat(ui)`** — the save-flow change above + **PLAN.md #13**: a planned Settings button to explicitly mark a data location as the default writable target (replacing the implicit "last folder wins").
2. **`fix(ui)`** — warn instead of silently dropping map-name edits when Save As renames a registered map to one with no `maps.txt` entry (surfaced by the review below).

## Quality

Adversarial multi-agent review (4 lenses — behavior, path/fs, Qt-consistency, regression; 20 findings, each independently verified → 1 confirmed, folded in as commit 2). 269 tests pass.

> The save flow is dialog-driven (modal), so it's verified by the review + manual testing rather than a unit test; the underlying write (`saveMapToFile`) and `findWritableDataPath` are already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2