### PR TITLE
Clarify map script-section parsing; stop logging padding slots as errors

### DIFF
--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -207,8 +207,17 @@ std::unique_ptr<Map> MapReader::read() {
         }
     }
 
-    // SCRIPTS SECTION
-    // Each section contains 16 slots for scripts
+    // SCRIPTS SECTION. Per section: a count, then the scripts stored in blocks of 16 — the count is
+    // rounded UP to a multiple of 16, so a partial last block is padded out to 16 slots. Every slot,
+    // real or padding, is a full but VARIABLE-SIZE record: pid + next_script, then type-specific fields
+    // keyed off the pid's top byte (SPATIAL adds 2 ints, TIMER adds 1, everything else adds 0), then a
+    // fixed 14-int trailer. After each block of 16 come 2 more ints (per-block count + an unused word).
+    // This mirrors the engine's scriptListExtentRead/scriptRead (scripts.cc) exactly.
+    //
+    // IMPORTANT: a slot's size depends on its OWN pid, so you cannot stride over slots by a fixed size
+    // or by `remaining * sizeof(type)`. Read every slot's pid first — including the padding slots, whose
+    // pids are leftover/garbage that the engine reads back with the same per-type rule (so they round
+    // trip even though they aren't meaningful scripts).
     spdlog::info("Loading map scripts");
     for (unsigned script_section = 0; script_section < Map::SCRIPT_SECTIONS; script_section++) {
         uint32_t script_section_count = read_be_u32();
@@ -247,7 +256,14 @@ std::unique_ptr<Map> MapReader::read() {
                     case MapScript::ScriptType::CRITTER:
                         break;
                     default:
-                        spdlog::error("Unknown script PID = {}", (pid & 0xFF000000) >> 24);
+                        // A pid whose top byte isn't a known script type. For a padding slot
+                        // (j >= count) this is just leftover bytes in the 16-slot block — the engine
+                        // reads them the same way (no type-specific fields), so it's expected, not an
+                        // error. Only surface it for a real (kept) script.
+                        if (j < script_section_count) {
+                            spdlog::warn("Map script {} of section {} has an unknown type (pid top byte {})",
+                                j, script_section, (pid & 0xFF000000) >> 24);
+                        }
                         break;
                 }
 

--- a/tests/general/test_reading_map.cpp
+++ b/tests/general/test_reading_map.cpp
@@ -8,6 +8,10 @@
 #include "reader/map/MapReader.h"
 #include "support/Fixtures.h"
 #include "support/ProStubProvider.h"
+#include "support/TempFile.h"
+
+#include <fstream>
+#include <vector>
 
 using namespace geck;
 
@@ -59,4 +63,104 @@ TEST_CASE("MapReader parses the real sfshutl2 map", "[map]") {
         REQUIRE(object != nullptr);
         CHECK(object->elevation == 0u);
     }
+}
+
+// Each script section stores its scripts in a block of 16 (the count rounded up). The real scripts in a
+// section are all one type, but the PADDING slots beyond `count` hold leftover/garbage pids of arbitrary
+// types — and a slot's on-disk size depends on its OWN pid's top byte (SPATIAL +2 ints, TIMER +1, else
+// +0), matching the engine's scriptRead (scripts.cc). A parser that strides over the block by a fixed
+// per-script size (e.g. `remaining * sizeof(section_type)`) desyncs on mixed-type padding and lands at
+// the wrong offset for the following objects section. This crafts exactly that case — one real spatial
+// script followed by 15 mixed-type padding slots — and checks the objects section is still reached.
+TEST_CASE("MapReader walks a partial script block with mixed-type padding", "[map][scripts]") {
+    std::vector<uint8_t> bytes;
+    const auto u32 = [&](uint32_t v) {
+        bytes.push_back(static_cast<uint8_t>(v >> 24));
+        bytes.push_back(static_cast<uint8_t>(v >> 16));
+        bytes.push_back(static_cast<uint8_t>(v >> 8));
+        bytes.push_back(static_cast<uint8_t>(v));
+    };
+    const auto str = [&](const std::string& s, size_t len) {
+        for (size_t i = 0; i < len; ++i) {
+            bytes.push_back(i < s.size() ? static_cast<uint8_t>(s[i]) : uint8_t{ 0 });
+        }
+    };
+    const auto zeros = [&](size_t n) { bytes.insert(bytes.end(), n, uint8_t{ 0 }); };
+
+    // One on-disk script slot of the given type (pid top byte), mirroring MapReader/scriptRead exactly:
+    // pid + next, type-specific fields (SPATIAL +2, TIMER +1, else +0), then the fixed 14-int trailer.
+    const auto slot = [&](uint8_t typeByte, uint32_t index) {
+        u32((static_cast<uint32_t>(typeByte) << 24) | index); // pid
+        u32(0);                                               // next_script
+        if (typeByte == 1) {                                  // SPATIAL
+            u32(0x1234);                                      // built_tile
+            u32(7);                                           // radius
+        } else if (typeByte == 2) {                           // TIMER
+            u32(0x5678);                                      // time
+        }
+        for (int i = 0; i < 14; ++i) {
+            u32(0); // trailer
+        }
+    };
+
+    // Header.
+    u32(20);              // version
+    str("MIXED.MAP", 16); // filename
+    u32(0);               // player_default_position
+    u32(0);               // player_default_elevation
+    u32(0);               // player_default_orientation
+    u32(0);               // num_local_vars
+    u32(0xFFFFFFFFu);     // script_id (-1)
+    u32(0x0Eu);           // flags: elevations 0/1/2 all marked absent -> no tile blocks
+    u32(0);               // darkness
+    u32(0);               // num_global_vars
+    u32(0);               // map_id
+    u32(0);               // timestamp
+    zeros(4 * 44);        // header padding (MapReader skips 44 words)
+    // No global/local vars and no tiles (every elevation is absent).
+
+    // Scripts: 5 sections. Section 1 (spatial) carries one real script + 15 mixed-type padding slots.
+    u32(0);                                                                       // section 0 (system): empty
+    u32(1);                                                                       // section 1 (spatial): count
+    slot(1, 100);                                                                 // the one real spatial script
+    const uint8_t padding[15] = { 0, 2, 5, 1, 0, 3, 2, 4, 0, 99, 1, 2, 0, 0, 7 }; // mixed -> varying sizes
+    for (uint8_t type : padding) {
+        slot(type, 0xDEADu);
+    }
+    u32(1); // per-block check: must equal the section count (the reader validates the sum)
+    u32(0); // per-block unused word
+    u32(0); // section 2 (timer): empty
+    u32(0); // section 3 (item): empty
+    u32(0); // section 4 (critter): empty
+
+    // Objects: total + three per-elevation counts, all zero.
+    u32(0);
+    u32(0);
+    u32(0);
+    u32(0);
+
+    geck::test::TempFile mapFile{ "geck_map_mixed_script_padding", ".map" };
+    {
+        std::ofstream out(mapFile.path(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+
+    MapReader reader{ [](uint32_t) -> Pro* { return nullptr; } }; // no objects -> the callback is never used
+    auto map = reader.openFile(mapFile.path());
+    REQUIRE(map != nullptr);
+    const auto& mf = map->getMapFile();
+
+    // The single real spatial script parsed, type-specific fields intact; padding slots aren't kept.
+    REQUIRE(mf.map_scripts[1].size() == 1);
+    CHECK(mf.map_scripts[1][0].pid == ((1u << 24) | 100u));
+    CHECK(mf.map_scripts[1][0].timer == 0x1234u);
+    CHECK(mf.map_scripts[1][0].spatial_radius == 7u);
+    CHECK(mf.map_scripts[0].empty());
+    CHECK(mf.map_scripts[2].empty());
+
+    // The objects section was reached at exactly the right offset despite the mixed-size padding — a
+    // fixed-stride parser would land in garbage here and throw or mis-count.
+    CHECK(mf.map_objects.at(0).empty());
+    CHECK(mf.map_objects.at(1).empty());
+    CHECK(mf.map_objects.at(2).empty());
 }


### PR DESCRIPTION
Prompted by a question about parsing the map script section: our `MapReader` parses the script *type* from each slot's pid — even padding slots — and advances by a type-dependent size. I verified this against the engine (`fallout2-ce` `scripts.cc`).

## Finding: our parser is correct

The engine's `scriptRead` switches on `SID_TYPE(sid) = sid >> 24` and reads type-specific fields — **SPATIAL +2 ints, TIMED +1, everything else +0** — then a fixed **14-int trailer**; extents are blocks of 16 with 2 trailing ints. Our `MapReader` (`fromPid` = `(pid>>24)&0xFF`, same type values; 14-field trailer; 2 ints per block) matches byte-for-byte. So the per-slot size is genuinely **variable**, and unused slots aren't dropped/fixed-size — they're full records the engine reads with the same per-type rule.

## Change (docs + log only, no behaviour change)

- Document the exact on-disk layout at the parse site, including the "you can't stride slots by a fixed size" trap and why padding slots are parsed by type too.
- Downgrade the per-slot "unknown type" log from `error` to a `warn` that only fires for a *real* (kept) script — padding slots legitimately contain garbage pids, so a normal map with partial script blocks no longer logs spurious errors.

269 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2