### PR TITLE
Name the critter AI packet from ai.txt (picker instead of raw number)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -436,6 +436,7 @@ add_library(gecko_resource STATIC
 
     resource/MapNameResolver.h
     resource/MapNameResolver.cpp
+    resource/AiTxtLoader.h
     resource/WritableDataRoot.h
     resource/WritableDataRoot.cpp
     resource/MapNameEditor.h

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -12,7 +12,7 @@
 #include "format/map/Tile.h"
 #include "format/msg/Msg.h"
 #include "format/pro/Pro.h"
-#include "reader/ai/AiTxtReader.h"
+#include "resource/AiTxtLoader.h"
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 #include "resource/ResourcePaths.h"
@@ -196,17 +196,6 @@ namespace {
         std::unordered_map<uint32_t, bool> _resolved;
         std::unordered_map<uint32_t, uint32_t> _critterAiPackets;
     };
-
-    // Load data/ai.txt from the mounted data (empty AiTxt if absent — critters then report just the
-    // raw packet number). Tries the canonical path and a bare fallback for odd mounts.
-    AiTxt loadAiTxt(resource::GameResources& resources) {
-        for (const char* path : { "data/ai.txt", "ai.txt" }) {
-            if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
-                return parseAiTxt(std::string(bytes->begin(), bytes->end()));
-            }
-        }
-        return AiTxt{};
-    }
 
     // The mounted scripts.lst (script_id is a 0-based index into list()), or nullptr if absent.
     const Lst* loadScriptsLst(resource::GameResources& resources) {
@@ -843,7 +832,7 @@ int analyzeMaps(resource::GameResources& resources, const AnalyzeOptions& option
         return 0;
     }
     if (options.json) {
-        emitJson(mapPaths, resources, names, loadAiTxt(resources), out);
+        emitJson(mapPaths, resources, names, resource::loadAiTxt(resources), out);
         return 0;
     }
 

--- a/src/format/ai/AiPacket.h
+++ b/src/format/ai/AiPacket.h
@@ -35,6 +35,9 @@ public:
 
     [[nodiscard]] std::size_t size() const { return _byNum.size(); }
 
+    /// All packets keyed by packet_num — for enumerating them (e.g. populating a picker).
+    [[nodiscard]] const std::unordered_map<int, AiPacket>& packets() const { return _byNum; }
+
 private:
     std::unordered_map<int, AiPacket> _byNum;
 };

--- a/src/resource/AiTxtLoader.h
+++ b/src/resource/AiTxtLoader.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "format/ai/AiPacket.h"
+#include "reader/ai/AiTxtReader.h"
+#include "resource/GameResources.h"
+
+#include <string>
+
+namespace geck::resource {
+
+/// Load `data/ai.txt` (or a bare `ai.txt`) from the mounted game data into an AiTxt. Tries the canonical
+/// path and a bare fallback for odd mounts; returns an empty AiTxt when the file isn't present, so
+/// callers fall back to the raw packet number rather than inventing labels.
+inline AiTxt loadAiTxt(GameResources& resources) {
+    for (const char* path : { "data/ai.txt", "ai.txt" }) {
+        if (const auto bytes = resources.files().readRawBytes(path); bytes.has_value()) {
+            return parseAiTxt(std::string(bytes->begin(), bytes->end()));
+        }
+    }
+    return AiTxt{};
+}
+
+} // namespace geck::resource

--- a/src/ui/dialogs/CritterPropertiesDialog.cpp
+++ b/src/ui/dialogs/CritterPropertiesDialog.cpp
@@ -1,9 +1,11 @@
 #include "CritterPropertiesDialog.h"
 
 #include "format/ai/AiPacket.h"
+#include "ui/theme/ThemeManager.h"
 
 #include <QComboBox>
 #include <QFormLayout>
+#include <QLabel>
 #include <QSpinBox>
 #include <QVBoxLayout>
 
@@ -58,6 +60,10 @@ CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t tea
     }
     _aiPacketCombo->setCurrentIndex(currentIndex);
     formLayout->addRow("AI packet:", _aiPacketCombo);
+
+    auto* aiPacketHint = new QLabel("Pick a packet by name, or type a number.", this);
+    aiPacketHint->setStyleSheet(ui::theme::styles::smallLabel());
+    formLayout->addRow("", aiPacketHint);
 
     _teamSpin = makeSpin(this, static_cast<int>(team), 32000);
     formLayout->addRow("Team:", _teamSpin);

--- a/src/ui/dialogs/CritterPropertiesDialog.cpp
+++ b/src/ui/dialogs/CritterPropertiesDialog.cpp
@@ -91,8 +91,8 @@ uint32_t CritterPropertiesDialog::getAiPacket() const {
     if (ok && typed >= 0) {
         return static_cast<uint32_t>(typed);
     }
-    const QVariant data = _aiPacketCombo->currentData();
-    return data.isValid() ? static_cast<uint32_t>(data.toInt()) : _originalAiPacket;
+    const QVariant itemData = _aiPacketCombo->currentData();
+    return itemData.isValid() ? static_cast<uint32_t>(itemData.toInt()) : _originalAiPacket;
 }
 uint32_t CritterPropertiesDialog::getTeam() const { return static_cast<uint32_t>(_teamSpin->value()); }
 uint32_t CritterPropertiesDialog::getHp() const { return static_cast<uint32_t>(_hpSpin->value()); }

--- a/src/ui/dialogs/CritterPropertiesDialog.cpp
+++ b/src/ui/dialogs/CritterPropertiesDialog.cpp
@@ -1,8 +1,14 @@
 #include "CritterPropertiesDialog.h"
 
+#include "format/ai/AiPacket.h"
+
+#include <QComboBox>
 #include <QFormLayout>
 #include <QSpinBox>
 #include <QVBoxLayout>
+
+#include <algorithm>
+#include <vector>
 
 namespace geck {
 
@@ -16,15 +22,42 @@ namespace {
 } // namespace
 
 CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t team, uint32_t hp,
-    uint32_t radiation, uint32_t poison, QWidget* parent)
+    uint32_t radiation, uint32_t poison, const AiTxt& aiTxt, QWidget* parent)
     : BaseDialog("Critter Properties", parent) {
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
 
-    _aiPacketSpin = makeSpin(this, static_cast<int>(aiPacket), 32000);
-    _aiPacketSpin->setToolTip("Raw AI packet number (from the game's AI definitions).");
-    formLayout->addRow("AI packet:", _aiPacketSpin);
+    // AI packet picker: every packet ai.txt defines, by name, ordered by packet number, with the packet
+    // number as the item data. If the critter's current packet isn't in ai.txt (or none is mounted), add
+    // a raw entry for it so the value round-trips unchanged. The combo is editable so a packet number can
+    // still be typed directly (e.g. with no ai.txt mounted, or when authoring against another build).
+    _originalAiPacket = aiPacket;
+    _aiPacketCombo = new QComboBox(this);
+    _aiPacketCombo->setEditable(true);
+    _aiPacketCombo->setInsertPolicy(QComboBox::NoInsert);
+    _aiPacketCombo->setToolTip("AI behaviour packet: pick by name (from the game's ai.txt) or type a packet number.");
+
+    std::vector<const AiPacket*> packets;
+    packets.reserve(aiTxt.packets().size());
+    for (const auto& [num, packet] : aiTxt.packets()) {
+        packets.push_back(&packet);
+    }
+    std::sort(packets.begin(), packets.end(),
+        [](const AiPacket* a, const AiPacket* b) { return a->packetNum < b->packetNum; });
+    for (const AiPacket* packet : packets) {
+        _aiPacketCombo->addItem(
+            QString("%1 (%2)").arg(QString::fromStdString(packet->name)).arg(packet->packetNum),
+            packet->packetNum);
+    }
+
+    int currentIndex = _aiPacketCombo->findData(static_cast<int>(aiPacket));
+    if (currentIndex < 0) {
+        _aiPacketCombo->addItem(QString("Packet %1 (not in ai.txt)").arg(aiPacket), static_cast<int>(aiPacket));
+        currentIndex = _aiPacketCombo->count() - 1;
+    }
+    _aiPacketCombo->setCurrentIndex(currentIndex);
+    formLayout->addRow("AI packet:", _aiPacketCombo);
 
     _teamSpin = makeSpin(this, static_cast<int>(team), 32000);
     formLayout->addRow("Team:", _teamSpin);
@@ -43,7 +76,18 @@ CritterPropertiesDialog::CritterPropertiesDialog(uint32_t aiPacket, uint32_t tea
     mainLayout->addWidget(createButtonBox());
 }
 
-uint32_t CritterPropertiesDialog::getAiPacket() const { return static_cast<uint32_t>(_aiPacketSpin->value()); }
+uint32_t CritterPropertiesDialog::getAiPacket() const {
+    // A number typed into the editable combo wins; otherwise use the picked item's packet number (its
+    // text is "name (num)", which isn't a bare number so it falls through here); empty/garbage keeps the
+    // original value so it's never lost.
+    bool ok = false;
+    const long long typed = _aiPacketCombo->currentText().toLongLong(&ok);
+    if (ok && typed >= 0) {
+        return static_cast<uint32_t>(typed);
+    }
+    const QVariant data = _aiPacketCombo->currentData();
+    return data.isValid() ? static_cast<uint32_t>(data.toInt()) : _originalAiPacket;
+}
 uint32_t CritterPropertiesDialog::getTeam() const { return static_cast<uint32_t>(_teamSpin->value()); }
 uint32_t CritterPropertiesDialog::getHp() const { return static_cast<uint32_t>(_hpSpin->value()); }
 uint32_t CritterPropertiesDialog::getRadiation() const { return static_cast<uint32_t>(_radiationSpin->value()); }

--- a/src/ui/dialogs/CritterPropertiesDialog.h
+++ b/src/ui/dialogs/CritterPropertiesDialog.h
@@ -5,22 +5,26 @@
 #include <cstdint>
 
 class QSpinBox;
+class QComboBox;
 
 namespace geck {
+
+class AiTxt;
 
 /// @brief Editor for a critter instance's combat/state fields.
 ///
 /// Edits the per-instance critter data the engine stores on the object and the
 /// .map already round-trips: AI packet, team/group, current HP, radiation and
 /// poison (see mp_instance.cc protoInstCritterEdit, object.cc critter data).
-/// The AI packet is shown as its raw engine number rather than a name table, to
-/// avoid inventing labels that may not match the loaded game data.
+/// The AI packet is picked by name from the loaded ai.txt (the actual game data,
+/// not an invented label table); an unknown packet — or none mounted — falls back
+/// to its raw number so the value is never lost.
 class CritterPropertiesDialog : public BaseDialog {
     Q_OBJECT
 
 public:
     CritterPropertiesDialog(uint32_t aiPacket, uint32_t team, uint32_t hp,
-        uint32_t radiation, uint32_t poison, QWidget* parent = nullptr);
+        uint32_t radiation, uint32_t poison, const AiTxt& aiTxt, QWidget* parent = nullptr);
 
     uint32_t getAiPacket() const;
     uint32_t getTeam() const;
@@ -29,7 +33,8 @@ public:
     uint32_t getPoison() const;
 
 private:
-    QSpinBox* _aiPacketSpin;
+    QComboBox* _aiPacketCombo;
+    uint32_t _originalAiPacket = 0; // fallback if the editable combo is left with unparseable text
     QSpinBox* _teamSpin;
     QSpinBox* _hpSpin;
     QSpinBox* _radiationSpin;

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -11,6 +11,7 @@
 #include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
+#include "resource/AiTxtLoader.h"
 #include "resource/ResourcePaths.h"
 #include "format/map/MapScript.h"
 
@@ -1164,8 +1165,9 @@ void SelectionPanel::onEditCritterClicked() {
         return;
     }
 
+    const AiTxt aiTxt = resource::loadAiTxt(_resources); // names the AI packet combo; empty -> raw number
     CritterPropertiesDialog dialog(mapObject->ai_packet, mapObject->group_id,
-        mapObject->current_hp, mapObject->current_rad, mapObject->current_poison, this);
+        mapObject->current_hp, mapObject->current_rad, mapObject->current_poison, aiTxt, this);
     if (dialog.exec() != QDialog::Accepted) {
         return;
     }

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -25,9 +25,11 @@
 #include <string_view>
 #include <utility>
 
+#include "format/ai/AiPacket.h"
 #include "format/map/MapObject.h"
 #include "format/pro/Pro.h"
 #include "ui/core/MainWindow.h"
+#include "ui/dialogs/CritterPropertiesDialog.h"
 #include "ui/dialogs/InventoryViewerDialog.h"
 #include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
@@ -590,6 +592,39 @@ TEST_CASE("Info panel derives display state from PRO data", "[qt][pro]") {
     REQUIRE(widget.nameText() == "10mm JHP");
     REQUIRE(widget.filenameText() == "00000030.pro");
     REQUIRE(widget.windowTitleText() == "10mm JHP (Ammo) - PRO editor");
+}
+
+TEST_CASE("CritterPropertiesDialog names the AI packet from ai.txt and falls back to the raw number", "[qt][critter]") {
+    geck::AiTxt aiTxt;
+    aiTxt.add(geck::AiPacket{ .packetNum = 5, .name = "Coward" });
+    aiTxt.add(geck::AiPacket{ .packetNum = 21, .name = "Berserker" });
+
+    SECTION("current packet is in ai.txt -> shown by name, value round-trips") {
+        geck::CritterPropertiesDialog dialog(21, 1, 100, 0, 0, aiTxt);
+        auto* combo = dialog.findChild<QComboBox*>();
+        REQUIRE(combo != nullptr);
+        CHECK(combo->count() == 2); // the two packets, no raw fallback entry
+        CHECK(combo->currentText().contains("Berserker"));
+        CHECK(dialog.getAiPacket() == 21u);
+    }
+
+    SECTION("current packet not in ai.txt -> a raw fallback entry preserves the value") {
+        geck::CritterPropertiesDialog dialog(99, 1, 100, 0, 0, aiTxt);
+        auto* combo = dialog.findChild<QComboBox*>();
+        REQUIRE(combo != nullptr);
+        CHECK(combo->count() == 3); // two packets + a raw "Packet 99" entry
+        CHECK(combo->currentText().contains("99"));
+        CHECK(dialog.getAiPacket() == 99u);
+    }
+
+    SECTION("an arbitrary number can be typed into the editable combo") {
+        geck::CritterPropertiesDialog dialog(5, 1, 100, 0, 0, aiTxt);
+        auto* combo = dialog.findChild<QComboBox*>();
+        REQUIRE(combo != nullptr);
+        REQUIRE(combo->isEditable());
+        combo->setCurrentText("150"); // not a named packet -> a freely-typed raw number
+        CHECK(dialog.getAiPacket() == 150u);
+    }
 }
 
 TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][inventory]") {


### PR DESCRIPTION
Implements the AI-packet half of PLAN #3 — continues the "engine numbers → human labels" theme.

## What

`CritterPropertiesDialog` (Selection panel → **Edit Critter...**) showed the AI packet as a bare number spinbox. It now offers a **combo of the packets `ai.txt` actually defines** — e.g. `Berserker (21)` — sorted by packet number, with the critter's current packet pre-selected by name. The packet number is the item data.

- The names come from the **loaded `ai.txt`** (real game data), not an invented table — so it keeps the dialog's original engine-fidelity intent.
- The combo is **editable**: you can still type a packet number directly (for the no-`ai.txt`-mounted case, or authoring against a different build's table). A typed number wins; otherwise the picked item's number is used.
- An **unknown** current packet (not in `ai.txt`, or none mounted) is kept as a raw `Packet N` entry, so the value round-trips unchanged.

## Commits

1. **`refactor`** — extract a header-only `resource::loadAiTxt` (the CLI had a local copy); `MapAnalyzer` now uses the shared one. No behaviour change.
2. **`feat(ui)`** — the picker, plus `AiTxt::packets()` and the `SelectionPanel` wiring.

## Quality

Adversarial multi-agent review (4 lenses, 16 findings, each independently verified → 1 confirmed: the editable-combo affordance, added here after you chose "names + allow a raw number"). New `qt_tests` `[critter]` case covers named selection, the raw fallback, and typed entry. 269 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2