### PR TITLE
Name scripts from scrname.msg and browse them in an index/filename/name/comment table

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -436,6 +436,7 @@ add_library(gecko_resource STATIC
 
     resource/MapNameResolver.h
     resource/MapNameResolver.cpp
+    resource/ScriptNames.h
     resource/WritableDataRoot.h
     resource/WritableDataRoot.cpp
     resource/MapNameEditor.h

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -16,6 +16,7 @@
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 #include "resource/ResourcePaths.h"
+#include "resource/ScriptNames.h"
 #include "util/ProHelper.h"
 
 #include <nlohmann/json.hpp>
@@ -638,24 +639,6 @@ namespace {
     // Per-map header digest: player spawn, which elevations are enabled, darkness, the map script id,
     // the local-var pool size, and the map variables (MVARS) — each with its name from the .gam (the
     // .map stores only the value) so an agent reads the map's tracked state, not just a count.
-    // A script's human-readable name from scrname.msg. The display name for the script at 0-based
-    // scripts.lst programIndex is scrname.msg[programIndex + 101] — verified against the data and the
-    // engine's 1-based map script_id (the MAP_File_Format wiki's "[id + 101]" assumes id is already
-    // 0-based; with the raw 1-based header id it lands one entry too far). "" if unavailable.
-    std::string scriptDisplayName(resource::GameResources& resources, int programIndex) {
-        if (programIndex < 0) {
-            return {};
-        }
-        try {
-            if (Msg* msg = resources.repository().load<Msg>("text/english/game/scrname.msg"); msg != nullptr) {
-                return msg->message(programIndex + 101).text;
-            }
-        } catch (const std::exception& e) {
-            spdlog::debug("scriptDisplayName: scrname.msg unavailable: {}", e.what());
-        }
-        return {};
-    }
-
     ordered_json headerToJson(Map& map, const Gam* gam, const Lst* scriptsLst, resource::GameResources& resources) {
         const auto& header = map.getMapFile().header;
         ordered_json root;
@@ -682,7 +665,7 @@ namespace {
                 name = scriptsLst->at(programIndex);
             }
             root["mapScript"] = { { "programIndex", programIndex }, { "name", name },
-                { "displayName", scriptDisplayName(resources, programIndex) } };
+                { "displayName", resource::scriptDisplayName(resources, programIndex) } };
         } else {
             root["mapScript"] = nullptr;
         }

--- a/src/format/lst/Lst.cpp
+++ b/src/format/lst/Lst.cpp
@@ -10,6 +10,14 @@ const std::vector<std::string>& Lst::list() const {
     return _list;
 }
 
+void Lst::setComments(const std::vector<std::string>& comments) {
+    _comments = comments;
+}
+
+const std::vector<std::string>& Lst::comments() const {
+    return _comments;
+}
+
 const std::string& Lst::at(int line) const {
     // TODO: check boundaries
     return _list.at(line);

--- a/src/format/lst/Lst.h
+++ b/src/format/lst/Lst.h
@@ -10,6 +10,7 @@ namespace geck {
 class Lst : public IFile {
 private:
     std::vector<std::string> _list;
+    std::vector<std::string> _comments; // the trailing ';' comment of each entry, aligned with _list
 
 public:
     Lst(std::filesystem::path path)
@@ -17,6 +18,11 @@ public:
 
     const std::vector<std::string>& list() const;
     void setList(const std::vector<std::string>& list);
+
+    /// The per-entry trailing comment (the text after ';', e.g. a script's description in scripts.lst),
+    /// aligned 1:1 with list(). Empty where an entry has no comment.
+    const std::vector<std::string>& comments() const;
+    void setComments(const std::vector<std::string>& comments);
 
     const std::string& at(int line) const;
 };

--- a/src/reader/lst/LstReader.cpp
+++ b/src/reader/lst/LstReader.cpp
@@ -32,6 +32,24 @@ std::string parseLine(std::string line) {
     return line;
 }
 
+// The human-readable comment after ';' on an LST line (e.g. a script's description in scripts.lst), with
+// any trailing "# ..." metadata removed (scripts.lst appends "# local_vars=N") and both ends trimmed.
+// Empty when the line has no ';'. Case is preserved, unlike the lowercased entry name.
+std::string parseComment(const std::string& line) {
+    const auto semi = line.find(';');
+    if (semi == std::string::npos) {
+        return {};
+    }
+    std::string comment = line.substr(semi + 1);
+    if (const auto hash = comment.find('#'); hash != std::string::npos) {
+        comment.erase(hash);
+    }
+    const auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+    comment.erase(comment.begin(), std::find_if(comment.begin(), comment.end(), notSpace));
+    comment.erase(std::find_if(comment.rbegin(), comment.rend(), notSpace).base(), comment.end());
+    return comment;
+}
+
 std::unique_ptr<Lst> LstReader::read() {
     try {
         auto& utils = getBinaryUtils();
@@ -46,6 +64,7 @@ std::unique_ptr<Lst> LstReader::read() {
         }
 
         std::vector<std::string> list;
+        std::vector<std::string> comments;
         int lines_processed = 0;
         int valid_entries = 0;
 
@@ -69,6 +88,7 @@ std::unique_ptr<Lst> LstReader::read() {
 
                 if (!parsed_line.empty()) {
                     list.push_back(parsed_line);
+                    comments.push_back(parseComment(line)); // line is the raw text; parseLine took a copy
                     valid_entries++;
 
                     spdlog::trace("LST entry {}: '{}'", valid_entries, parsed_line);
@@ -81,6 +101,7 @@ std::unique_ptr<Lst> LstReader::read() {
 
         auto lst = std::make_unique<Lst>(_path);
         lst->setList(list);
+        lst->setComments(comments);
         return lst;
 
     } catch (const FileReaderException&) {

--- a/src/resource/ScriptNames.h
+++ b/src/resource/ScriptNames.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "format/msg/Msg.h"
+#include "resource/GameResources.h"
+
+#include <exception>
+#include <string>
+
+namespace geck::resource {
+
+/// The human-readable description for the script at 0-based scripts.lst `programIndex`, taken from
+/// scrname.msg (the display name is `scrname.msg[programIndex + 101]` — verified against the data and the
+/// engine's 1-based map script_id). Returns "" when scrname.msg isn't mounted or the entry is blank, so
+/// callers fall back to the bare .lst name.
+inline std::string scriptDisplayName(GameResources& resources, int programIndex) {
+    if (programIndex < 0) {
+        return {};
+    }
+    try {
+        if (Msg* msg = resources.repository().load<Msg>("text/english/game/scrname.msg"); msg != nullptr) {
+            // Use find() rather than message()/operator[], so a miss (a program index past scrname.msg)
+            // doesn't insert an empty entry into the cached Msg — this is called per scripts.lst entry.
+            const auto& messages = msg->getMessages();
+            if (const auto it = messages.find(programIndex + 101); it != messages.end()) {
+                return it->second.text;
+            }
+        }
+    } catch (const std::exception&) {
+        // scrname.msg not mounted -> no friendly name; callers use the .lst name.
+    }
+    return {};
+}
+
+} // namespace geck::resource

--- a/src/ui/dialogs/ScriptSelectorDialog.cpp
+++ b/src/ui/dialogs/ScriptSelectorDialog.cpp
@@ -1,16 +1,43 @@
 #include "ScriptSelectorDialog.h"
 
+#include "format/lst/Lst.h"
+#include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
+#include "resource/ScriptNames.h"
+
+#include <QHeaderView>
 #include <QLineEdit>
-#include <QListWidget>
+#include <QTableWidget>
 #include <QVBoxLayout>
 
 namespace geck {
 
-ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<std::string>& scriptNames,
-    int currentIndex, QWidget* parent)
+namespace {
+    enum Column {
+        COL_INDEX = 0,
+        COL_FILENAME = 1,
+        COL_NAME = 2,
+    };
+} // namespace
+
+std::vector<ScriptSelectorDialog::Entry> ScriptSelectorDialog::buildEntries(resource::GameResources& resources) {
+    std::vector<Entry> entries;
+    const Lst* lst = resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
+    if (lst == nullptr) {
+        return entries;
+    }
+    const auto& names = lst->list();
+    entries.reserve(names.size());
+    for (std::size_t i = 0; i < names.size(); ++i) {
+        entries.push_back({ static_cast<int>(i), names[i], resource::scriptDisplayName(resources, static_cast<int>(i)) });
+    }
+    return entries;
+}
+
+ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<Entry>& scripts, int currentIndex, QWidget* parent)
     : BaseDialog("Select Script", parent) {
 
-    resize(360, 460);
+    resize(560, 480);
 
     auto* mainLayout = new QVBoxLayout(this);
 
@@ -18,38 +45,68 @@ ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<std::string>& scrip
     _filterEdit->setPlaceholderText("Filter scripts...");
     mainLayout->addWidget(_filterEdit);
 
-    _listWidget = new QListWidget(this);
-    for (size_t i = 0; i < scriptNames.size(); ++i) {
-        // Show "index: name" but carry the program index in the item's data.
-        auto* item = new QListWidgetItem(
-            QString("%1: %2").arg(i).arg(QString::fromStdString(scriptNames[i])), _listWidget);
-        item->setData(Qt::UserRole, static_cast<int>(i));
-    }
-    mainLayout->addWidget(_listWidget);
+    _table = new QTableWidget(static_cast<int>(scripts.size()), 3, this);
+    _table->setHorizontalHeaderLabels({ "Index", "Filename", "Name" });
+    _table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    _table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    _table->setSelectionMode(QAbstractItemView::SingleSelection);
+    _table->verticalHeader()->setVisible(false);
+    _table->horizontalHeader()->setSectionResizeMode(COL_INDEX, QHeaderView::ResizeToContents);
+    _table->horizontalHeader()->setSectionResizeMode(COL_FILENAME, QHeaderView::ResizeToContents);
+    _table->horizontalHeader()->setSectionResizeMode(COL_NAME, QHeaderView::Stretch);
 
-    if (currentIndex >= 0 && currentIndex < _listWidget->count()) {
-        _listWidget->setCurrentRow(currentIndex);
+    for (int row = 0; row < static_cast<int>(scripts.size()); ++row) {
+        const Entry& entry = scripts[static_cast<size_t>(row)];
+
+        // The index cell carries the program index as an int (numeric display + sort), and selectedIndex
+        // reads it back — so the result is correct regardless of column sorting.
+        auto* indexItem = new QTableWidgetItem;
+        indexItem->setData(Qt::DisplayRole, entry.index);
+        _table->setItem(row, COL_INDEX, indexItem);
+        _table->setItem(row, COL_FILENAME, new QTableWidgetItem(QString::fromStdString(entry.filename)));
+        _table->setItem(row, COL_NAME, new QTableWidgetItem(QString::fromStdString(entry.name)));
     }
+    _table->setSortingEnabled(true);
+    _table->sortByColumn(COL_INDEX, Qt::AscendingOrder); // sensible default; the user can re-sort by any column
+
+    if (currentIndex >= 0) {
+        for (int row = 0; row < _table->rowCount(); ++row) {
+            const QTableWidgetItem* item = _table->item(row, COL_INDEX);
+            if (item != nullptr && item->data(Qt::DisplayRole).toInt() == currentIndex) {
+                _table->selectRow(row);
+                _table->scrollToItem(item);
+                break;
+            }
+        }
+    }
+    mainLayout->addWidget(_table);
 
     auto* buttonBox = createButtonBox();
-    connect(_listWidget, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
+    connect(_table, &QTableWidget::cellDoubleClicked, this, [this](int, int) { accept(); });
     connect(_filterEdit, &QLineEdit::textChanged, this, &ScriptSelectorDialog::onFilterChanged);
     mainLayout->addWidget(buttonBox);
 }
 
 void ScriptSelectorDialog::onFilterChanged(const QString& text) {
-    for (int i = 0; i < _listWidget->count(); ++i) {
-        auto* item = _listWidget->item(i);
-        item->setHidden(!text.isEmpty() && !item->text().contains(text, Qt::CaseInsensitive));
+    for (int row = 0; row < _table->rowCount(); ++row) {
+        bool match = text.isEmpty();
+        for (int col = 0; !match && col < _table->columnCount(); ++col) {
+            const QTableWidgetItem* item = _table->item(row, col);
+            if (item != nullptr && item->text().contains(text, Qt::CaseInsensitive)) {
+                match = true;
+            }
+        }
+        _table->setRowHidden(row, !match);
     }
 }
 
 int ScriptSelectorDialog::selectedIndex() const {
-    auto* item = _listWidget->currentItem();
-    if (!item || item->isHidden()) {
+    const int row = _table->currentRow();
+    if (row < 0 || _table->isRowHidden(row)) {
         return -1;
     }
-    return item->data(Qt::UserRole).toInt();
+    const QTableWidgetItem* item = _table->item(row, COL_INDEX);
+    return item != nullptr ? item->data(Qt::DisplayRole).toInt() : -1;
 }
 
 } // namespace geck

--- a/src/ui/dialogs/ScriptSelectorDialog.cpp
+++ b/src/ui/dialogs/ScriptSelectorDialog.cpp
@@ -17,6 +17,8 @@ namespace {
         COL_INDEX = 0,
         COL_FILENAME = 1,
         COL_NAME = 2,
+        COL_COMMENT = 3,
+        COL_COUNT = 4,
     };
 } // namespace
 
@@ -27,9 +29,12 @@ std::vector<ScriptSelectorDialog::Entry> ScriptSelectorDialog::buildEntries(reso
         return entries;
     }
     const auto& names = lst->list();
+    const auto& comments = lst->comments();
     entries.reserve(names.size());
     for (std::size_t i = 0; i < names.size(); ++i) {
-        entries.push_back({ static_cast<int>(i), names[i], resource::scriptDisplayName(resources, static_cast<int>(i)) });
+        std::string comment = i < comments.size() ? comments[i] : std::string{};
+        entries.push_back({ static_cast<int>(i), names[i],
+            resource::scriptDisplayName(resources, static_cast<int>(i)), std::move(comment) });
     }
     return entries;
 }
@@ -37,7 +42,7 @@ std::vector<ScriptSelectorDialog::Entry> ScriptSelectorDialog::buildEntries(reso
 ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<Entry>& scripts, int currentIndex, QWidget* parent)
     : BaseDialog("Select Script", parent) {
 
-    resize(560, 480);
+    resize(720, 480);
 
     auto* mainLayout = new QVBoxLayout(this);
 
@@ -45,15 +50,17 @@ ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<Entry>& scripts, in
     _filterEdit->setPlaceholderText("Filter scripts...");
     mainLayout->addWidget(_filterEdit);
 
-    _table = new QTableWidget(static_cast<int>(scripts.size()), 3, this);
-    _table->setHorizontalHeaderLabels({ "Index", "Filename", "Name" });
+    _table = new QTableWidget(static_cast<int>(scripts.size()), COL_COUNT, this);
+    _table->setHorizontalHeaderLabels({ "Index", "Filename", "Name", "Comment" });
     _table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     _table->setSelectionBehavior(QAbstractItemView::SelectRows);
     _table->setSelectionMode(QAbstractItemView::SingleSelection);
     _table->verticalHeader()->setVisible(false);
     _table->horizontalHeader()->setSectionResizeMode(COL_INDEX, QHeaderView::ResizeToContents);
     _table->horizontalHeader()->setSectionResizeMode(COL_FILENAME, QHeaderView::ResizeToContents);
+    // Name (scrname.msg) and Comment (scripts.lst) are the two descriptive columns; let them share width.
     _table->horizontalHeader()->setSectionResizeMode(COL_NAME, QHeaderView::Stretch);
+    _table->horizontalHeader()->setSectionResizeMode(COL_COMMENT, QHeaderView::Stretch);
 
     for (int row = 0; row < static_cast<int>(scripts.size()); ++row) {
         const Entry& entry = scripts[static_cast<size_t>(row)];
@@ -65,6 +72,7 @@ ScriptSelectorDialog::ScriptSelectorDialog(const std::vector<Entry>& scripts, in
         _table->setItem(row, COL_INDEX, indexItem);
         _table->setItem(row, COL_FILENAME, new QTableWidgetItem(QString::fromStdString(entry.filename)));
         _table->setItem(row, COL_NAME, new QTableWidgetItem(QString::fromStdString(entry.name)));
+        _table->setItem(row, COL_COMMENT, new QTableWidgetItem(QString::fromStdString(entry.comment)));
     }
     _table->setSortingEnabled(true);
     _table->sortByColumn(COL_INDEX, Qt::AscendingOrder); // sensible default; the user can re-sort by any column

--- a/src/ui/dialogs/ScriptSelectorDialog.h
+++ b/src/ui/dialogs/ScriptSelectorDialog.h
@@ -2,13 +2,17 @@
 
 #include "ui/common/BaseDialog.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
-class QListWidget;
+class QTableWidget;
 class QLineEdit;
 
 namespace geck {
+
+namespace resource {
+    class GameResources;
+}
 
 /// @brief Picks a script program from scripts.lst.
 ///
@@ -20,9 +24,21 @@ class ScriptSelectorDialog : public BaseDialog {
     Q_OBJECT
 
 public:
-    /// @param scriptNames  scripts.lst entries (index == program index)
+    /// One selectable script: its program index (0-based scripts.lst line), the scripts.lst filename,
+    /// and the scrname.msg description (may be empty).
+    struct Entry {
+        int index = 0;
+        std::string filename;
+        std::string name;
+    };
+
+    /// @param scripts      the rows to show (one per scripts.lst entry)
     /// @param currentIndex program index to preselect, or -1
-    ScriptSelectorDialog(const std::vector<std::string>& scriptNames, int currentIndex, QWidget* parent = nullptr);
+    ScriptSelectorDialog(const std::vector<Entry>& scripts, int currentIndex, QWidget* parent = nullptr);
+
+    /// Build a row for every scripts.lst entry, resolving each name via scrname.msg. Shared by the
+    /// object-script and spatial-script pickers so they show the same data.
+    static std::vector<Entry> buildEntries(resource::GameResources& resources);
 
     /// Selected program index, or -1 if none.
     int selectedIndex() const;
@@ -32,7 +48,7 @@ private slots:
 
 private:
     QLineEdit* _filterEdit;
-    QListWidget* _listWidget;
+    QTableWidget* _table;
 };
 
 } // namespace geck

--- a/src/ui/dialogs/ScriptSelectorDialog.h
+++ b/src/ui/dialogs/ScriptSelectorDialog.h
@@ -24,12 +24,13 @@ class ScriptSelectorDialog : public BaseDialog {
     Q_OBJECT
 
 public:
-    /// One selectable script: its program index (0-based scripts.lst line), the scripts.lst filename,
-    /// and the scrname.msg description (may be empty).
+    /// One selectable script: its program index (0-based scripts.lst line), the scripts.lst filename, the
+    /// scrname.msg display name, and the scripts.lst ';' comment. `name` and `comment` may each be empty.
     struct Entry {
         int index = 0;
         std::string filename;
         std::string name;
+        std::string comment;
     };
 
     /// @param scripts      the rows to show (one per scripts.lst entry)

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -15,9 +15,9 @@
 
 namespace geck {
 
-SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent)
+SpatialScriptDialog::SpatialScriptDialog(const std::vector<ScriptSelectorDialog::Entry>& scripts, QWidget* parent)
     : BaseDialog("Add Spatial Script", parent)
-    , _scriptNames(scriptNames) {
+    , _scripts(scripts) {
 
     auto* mainLayout = new QVBoxLayout(this);
     auto* formLayout = new QFormLayout();
@@ -54,7 +54,7 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<std::string>& scriptN
 }
 
 void SpatialScriptDialog::onChooseScript() {
-    ScriptSelectorDialog dialog(_scriptNames, _programIndex, this);
+    ScriptSelectorDialog dialog(_scripts, _programIndex, this);
     if (dialog.exec() != QDialog::Accepted) {
         return;
     }
@@ -63,8 +63,13 @@ void SpatialScriptDialog::onChooseScript() {
         return;
     }
     _programIndex = index;
-    if (static_cast<size_t>(index) < _scriptNames.size()) {
-        _scriptLabel->setText(QString("%1: %2").arg(index).arg(QString::fromStdString(_scriptNames[index])));
+    if (static_cast<size_t>(index) < _scripts.size()) {
+        const ScriptSelectorDialog::Entry& entry = _scripts[static_cast<size_t>(index)];
+        QString label = QString::fromStdString(entry.filename);
+        if (!entry.name.empty()) {
+            label += " — " + QString::fromStdString(entry.name);
+        }
+        _scriptLabel->setText(label);
     } else {
         _scriptLabel->setText(QString("Script #%1").arg(index));
     }

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "ui/common/BaseDialog.h"
+#include "ui/dialogs/ScriptSelectorDialog.h"
 
 #include <vector>
-#include <string>
 
 class QLabel;
 class QSpinBox;
@@ -20,7 +20,7 @@ class SpatialScriptDialog : public BaseDialog {
     Q_OBJECT
 
 public:
-    explicit SpatialScriptDialog(const std::vector<std::string>& scriptNames, QWidget* parent = nullptr);
+    explicit SpatialScriptDialog(const std::vector<ScriptSelectorDialog::Entry>& scripts, QWidget* parent = nullptr);
 
     int programIndex() const { return _programIndex; }
     int tile() const;
@@ -33,7 +33,7 @@ private slots:
     void onChooseScript();
 
 private:
-    std::vector<std::string> _scriptNames;
+    std::vector<ScriptSelectorDialog::Entry> _scripts;
     int _programIndex = -1;
 
     QLabel* _scriptLabel;

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -24,6 +24,7 @@
 #include "resource/ResourcePaths.h"
 #include "util/Coordinates.h"
 #include "ui/IconHelper.h"
+#include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/dialogs/SpatialScriptDialog.h"
 
 namespace geck {
@@ -969,7 +970,7 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
         return;
     }
 
-    SpatialScriptDialog dialog(scriptsLst->list(), this);
+    SpatialScriptDialog dialog(ScriptSelectorDialog::buildEntries(_resources), this);
     if (dialog.exec() != QDialog::Accepted || dialog.programIndex() < 0) {
         return;
     }

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -12,6 +12,7 @@
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
 #include "resource/ResourcePaths.h"
+#include "resource/ScriptNames.h"
 #include "format/map/MapScript.h"
 
 #include <algorithm>
@@ -1212,6 +1213,10 @@ void SelectionPanel::updateScriptSection() {
                     auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
                     if (lst && s.script_id < lst->list().size()) {
                         text = QString::fromStdString(lst->list().at(s.script_id));
+                        const std::string desc = resource::scriptDisplayName(_resources, static_cast<int>(s.script_id));
+                        if (!desc.empty()) {
+                            text += " — " + QString::fromStdString(desc);
+                        }
                     } else {
                         text = QString("Script #%1").arg(s.script_id);
                     }
@@ -1241,7 +1246,7 @@ void SelectionPanel::onAttachScriptClicked() {
         return;
     }
 
-    ScriptSelectorDialog dialog(scriptsLst->list(), -1, this);
+    ScriptSelectorDialog dialog(ScriptSelectorDialog::buildEntries(_resources), -1, this);
     if (dialog.exec() != QDialog::Accepted) {
         return;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(general_tests
     general/test_pattern_builder.cpp
     general/test_map_script_api.cpp
     general/test_resource_repository.cpp
+    general/test_script_names.cpp
     general/test_object_visibility.cpp
     general/test_dat_concurrency.cpp
     general/test_map_renderer.cpp

--- a/tests/general/test_reading_lst.cpp
+++ b/tests/general/test_reading_lst.cpp
@@ -35,6 +35,28 @@ TEST_CASE("LstReader trims comments, normalizes slashes, lowercases and skips bl
     CHECK(list[2] == "plain.frm");
 }
 
+TEST_CASE("LstReader captures the ';' comment per entry, dropping '#' metadata", "[lst]") {
+    const std::string content = "obj_dude.int    ; Player script.                # local_vars=7\r\n" // comment + '#' meta + CRLF
+                                "zclrat.int      ; Generic lesser rat            # local_vars=5\n"
+                                "plain.int\n"                           // no comment
+                                "; full-line comment\n"                 // skipped (no entry)
+                                "spaced.int   ;   padded comment   \n"; // trimmed both ends
+
+    LstReader reader;
+    auto lst = reader.openFile("synthetic.lst", bytesOf(content));
+    REQUIRE(lst != nullptr);
+
+    const auto& list = lst->list();
+    const auto& comments = lst->comments();
+    REQUIRE(list.size() == 4);
+    REQUIRE(comments.size() == list.size()); // aligned 1:1 with the entries
+
+    CHECK(comments[0] == "Player script."); // '#' metadata dropped, trimmed; case preserved
+    CHECK(comments[1] == "Generic lesser rat");
+    CHECK(comments[2].empty());             // plain.int has no comment
+    CHECK(comments[3] == "padded comment"); // interior preserved, ends trimmed
+}
+
 TEST_CASE("LstReader at() indexes entries from zero", "[lst]") {
     LstReader reader;
     auto lst = reader.openFile("x.lst", bytesOf("first.frm\nsecond.frm\n"));

--- a/tests/general/test_script_names.cpp
+++ b/tests/general/test_script_names.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "resource/GameResources.h"
+#include "resource/ScriptNames.h"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace geck;
+
+namespace fs = std::filesystem;
+
+namespace {
+void writeFile(const fs::path& path, const std::string& content) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << content;
+}
+} // namespace
+
+// scrname.msg names scripts at id (0-based scripts.lst index + 101). resource::scriptDisplayName must
+// apply exactly that offset, and degrade to "" when the file or entry is absent (callers then show the
+// bare .lst name).
+TEST_CASE("scriptDisplayName resolves scrname.msg[programIndex + 101]", "[scriptnames]") {
+    const fs::path root = fs::path(GECK_TEST_TMP_DIR) / "scriptnames_test";
+    fs::remove_all(root);
+    writeFile(root / "text/english/game/scrname.msg",
+        "{101}{}{Combat AI}\n"
+        "{102}{}{Door}\n");
+
+    resource::GameResources resources;
+    resources.files().addDataPath(root.string());
+
+    CHECK(resource::scriptDisplayName(resources, 0) == "Combat AI"); // index 0 -> id 101
+    CHECK(resource::scriptDisplayName(resources, 1) == "Door");      // index 1 -> id 102
+    CHECK(resource::scriptDisplayName(resources, -1).empty());       // no negative index
+    CHECK(resource::scriptDisplayName(resources, 50).empty());       // no id 151 in the file
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("scriptDisplayName is empty when scrname.msg isn't mounted", "[scriptnames]") {
+    resource::GameResources resources; // nothing mounted
+    CHECK(resource::scriptDisplayName(resources, 0).empty());
+}

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -593,20 +593,20 @@ TEST_CASE("Info panel derives display state from PRO data", "[qt][pro]") {
     REQUIRE(widget.windowTitleText() == "10mm JHP (Ammo) - PRO editor");
 }
 
-TEST_CASE("ScriptSelectorDialog shows index/filename/name columns and returns the program index", "[qt][script]") {
+TEST_CASE("ScriptSelectorDialog shows index/filename/name/comment columns and returns the program index", "[qt][script]") {
     const std::vector<geck::ScriptSelectorDialog::Entry> entries = {
-        { 0, "obj_dude.int", "The Chosen One" },
-        { 1, "obj_door.int", "" },
-        { 2, "raiders.int", "Raiders" },
+        { 0, "obj_dude.int", "The Chosen One", "Player script." },
+        { 1, "obj_door.int", "", "A door" },
+        { 2, "raiders.int", "Raiders", "" },
     };
     geck::ScriptSelectorDialog dialog(entries, /*currentIndex=*/2);
     auto* table = dialog.findChild<QTableWidget*>();
     REQUIRE(table != nullptr);
     REQUIRE(table->rowCount() == 3);
-    REQUIRE(table->columnCount() == 3);
+    REQUIRE(table->columnCount() == 4);
 
     // Find a row by its filename so the assertions don't depend on the (sortable) row order. Columns are
-    // index / filename / name.
+    // index / filename / name / comment.
     int dudeRow = -1;
     for (int row = 0; row < table->rowCount(); ++row) {
         if (table->item(row, 1)->text() == "obj_dude.int") {
@@ -617,6 +617,7 @@ TEST_CASE("ScriptSelectorDialog shows index/filename/name columns and returns th
     REQUIRE(dudeRow >= 0);
     CHECK(table->item(dudeRow, 0)->data(Qt::DisplayRole).toInt() == 0);
     CHECK(table->item(dudeRow, 2)->text() == "The Chosen One");
+    CHECK(table->item(dudeRow, 3)->text() == "Player script."); // scripts.lst comment column
 
     // currentIndex == 2 is preselected; selectedIndex returns the program index, not the row.
     CHECK(dialog.selectedIndex() == 2);

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -30,6 +30,7 @@
 #include "ui/core/MainWindow.h"
 #include "ui/dialogs/InventoryViewerDialog.h"
 #include "ui/dialogs/ItemSelectorDialog.h"
+#include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/widgets/DataPathsWidget.h"
 #include "ui/widgets/ObjectPreviewWidget.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
@@ -590,6 +591,37 @@ TEST_CASE("Info panel derives display state from PRO data", "[qt][pro]") {
     REQUIRE(widget.nameText() == "10mm JHP");
     REQUIRE(widget.filenameText() == "00000030.pro");
     REQUIRE(widget.windowTitleText() == "10mm JHP (Ammo) - PRO editor");
+}
+
+TEST_CASE("ScriptSelectorDialog shows index/filename/name columns and returns the program index", "[qt][script]") {
+    const std::vector<geck::ScriptSelectorDialog::Entry> entries = {
+        { 0, "obj_dude.int", "The Chosen One" },
+        { 1, "obj_door.int", "" },
+        { 2, "raiders.int", "Raiders" },
+    };
+    geck::ScriptSelectorDialog dialog(entries, /*currentIndex=*/2);
+    auto* table = dialog.findChild<QTableWidget*>();
+    REQUIRE(table != nullptr);
+    REQUIRE(table->rowCount() == 3);
+    REQUIRE(table->columnCount() == 3);
+
+    // Find a row by its filename so the assertions don't depend on the (sortable) row order. Columns are
+    // index / filename / name.
+    int dudeRow = -1;
+    for (int row = 0; row < table->rowCount(); ++row) {
+        if (table->item(row, 1)->text() == "obj_dude.int") {
+            dudeRow = row;
+            break;
+        }
+    }
+    REQUIRE(dudeRow >= 0);
+    CHECK(table->item(dudeRow, 0)->data(Qt::DisplayRole).toInt() == 0);
+    CHECK(table->item(dudeRow, 2)->text() == "The Chosen One");
+
+    // currentIndex == 2 is preselected; selectedIndex returns the program index, not the row.
+    CHECK(dialog.selectedIndex() == 2);
+    table->selectRow(dudeRow);
+    CHECK(dialog.selectedIndex() == 0);
 }
 
 TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][inventory]") {


### PR DESCRIPTION
The second half of the "engine numbers → human labels" theme: scripts were shown only by their raw `scripts.lst` filename. They now also carry the human description from `scrname.msg`, and the picker is a proper table.

## What

- **`resource::scriptDisplayName`** — a shared, header-only resolver for a script's `scrname.msg` description (`scrname.msg[programIndex + 101]`, verified against the engine), returning `""` (→ bare filename) when `scrname.msg` isn't mounted. Extracted from the CLI's private copy, which now calls it.
- **Attached-script label** (Selection panel) shows `filename — description`.
- **`ScriptSelectorDialog` is now a sortable, filterable table** with **Index / Filename / Name** columns instead of one combined line. `ScriptSelectorDialog::buildEntries()` builds the rows once and is shared by the object-script picker (`SelectionPanel`) and the spatial-script picker (`SpatialScriptDialog`) — both show the same data; the filter matches any column.

## Quality

- The resolver reads through the **const** message map, so a lookup miss never default-inserts into the cached `Msg` (caught by an adversarial review of an earlier revision — `Msg::message()` uses `operator[]`; harmless on shipped data since English + every localization are length-aligned with `scripts.lst`, but a real shared-state wart at ~1500 calls/dialog-open).
- New general test for the `+101` offset + empty fallbacks; new qt test for the table columns and that `selectedIndex` returns the program index regardless of sort order.
- 271 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2