### PR TITLE
Fix saving a game-data map writing to the read-only VFS path (/maps)

### DIFF
--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -448,11 +448,18 @@ ScriptResult EditorWidget::runScript(const std::string& source) {
 }
 #endif
 
+bool EditorWidget::canSaveInPlace(const std::filesystem::path& mapPath) {
+    // Save-in-place is only valid when the map already lives at a real, existing on-disk file (opened
+    // from disk, or saved here before). A map opened from the game data carries a VFS path such as
+    // "/maps/arbridge.map" — which looks absolute but is not a writable filesystem location (writing it
+    // would try to create "/maps" at the filesystem root) — and a brand-new map has no file yet. Both of
+    // those must go to "Save As" instead, which defaults into the writable data path.
+    std::error_code ec;
+    return mapPath.is_absolute() && std::filesystem::exists(mapPath, ec);
+}
+
 bool EditorWidget::saveMap(const std::filesystem::path& defaultDir) {
-    // "Save": once the map points at a real file (saved before, or opened from one), write straight to
-    // it without re-prompting. A map loaded from the game data carries a VFS-relative path, and a new
-    // map has no real target yet, so those fall through to "Save As".
-    if (_session.map() && _session.map()->path().is_absolute()) {
+    if (_session.map() && canSaveInPlace(_session.map()->path())) {
         return writeMapTo(_session.map()->path().string());
     }
     return saveMapAs(defaultDir);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -69,6 +69,11 @@ public:
     /// `defaultDir` (the writable data path's maps/ folder). Returns true on a successful write, false if
     /// the user cancelled or the write failed.
     bool saveMap(const std::filesystem::path& defaultDir = {});
+    /// Whether "Save" may write straight to `mapPath` rather than prompting: true only for a real,
+    /// existing on-disk file. A VFS path from the game data (e.g. "/maps/arbridge.map") looks absolute
+    /// but is not a writable location, and a new map has no file yet — both return false. Static so it is
+    /// unit-testable without a live widget.
+    static bool canSaveInPlace(const std::filesystem::path& mapPath);
     /// Always prompt for a destination (defaulting to `defaultDir`/<name>), then write and repoint the
     /// map at the chosen file. Returns true on a successful write.
     bool saveMapAs(const std::filesystem::path& defaultDir = {});

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 #include <string_view>
@@ -27,6 +28,7 @@
 
 #include "format/map/MapObject.h"
 #include "format/pro/Pro.h"
+#include "ui/core/EditorWidget.h"
 #include "ui/core/MainWindow.h"
 #include "ui/dialogs/InventoryViewerDialog.h"
 #include "ui/dialogs/ItemSelectorDialog.h"
@@ -590,6 +592,25 @@ TEST_CASE("Info panel derives display state from PRO data", "[qt][pro]") {
     REQUIRE(widget.nameText() == "10mm JHP");
     REQUIRE(widget.filenameText() == "00000030.pro");
     REQUIRE(widget.windowTitleText() == "10mm JHP (Ammo) - PRO editor");
+}
+
+TEST_CASE("EditorWidget::canSaveInPlace accepts only real on-disk files, not VFS paths", "[qt][save]") {
+    // A map opened from the game data carries a vfspp path that looks absolute but is not a writable
+    // filesystem location — saving it in place would try to create "/maps" at the root (the reported bug).
+    CHECK_FALSE(geck::EditorWidget::canSaveInPlace("/maps/arbridge.map"));
+    // A brand-new / unsaved map has no real file yet.
+    CHECK_FALSE(geck::EditorWidget::canSaveInPlace("arbridge.map"));
+    CHECK_FALSE(geck::EditorWidget::canSaveInPlace(std::filesystem::path{}));
+
+    // A real, existing file can be saved straight back.
+    QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const std::filesystem::path real = std::filesystem::path(dir.path().toStdString()) / "saved.map";
+    {
+        std::ofstream out(real);
+        out << "map";
+    }
+    CHECK(geck::EditorWidget::canSaveInPlace(real));
 }
 
 TEST_CASE("ItemSelectorDialog lists items.lst entries by their item PID", "[qt][inventory]") {


### PR DESCRIPTION
## Bug

Saving a map opened from the game data fails:

> Failed to save map to: /maps/arbridge.map
> Permission error: Cannot create parent directory: ... Read-only file system ["/maps"]

— even with a writable folder mounted as a Data Path.

## Cause

A map opened from the game data carries a **vfspp VFS path** like `/maps/arbridge.map` (see `MapLoad.cpp` / `MapBrowserDialog`). That path is absolute, so `EditorWidget::saveMap` treated it as a real on-disk file and wrote **straight to it** — `create_directories("/maps")` at the filesystem root → read-only failure. The writable Data Path was never consulted because the flow never reached Save As.

## Fix

Save in place only when the map's path is a real, **existing** on-disk file (opened from disk, or saved here before). Otherwise fall through to **Save As**, which already defaults into the writable Data Path's `maps/` folder. The predicate is factored into a static, unit-testable `EditorWidget::canSaveInPlace`.

## Test

New qt test covers a VFS path (`/maps/arbridge.map` → false), a new/unsaved map (false), and a real existing file (true). 271 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2