### PR TITLE
analyze: full script view + local variables; quiet routine logging

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -164,17 +164,12 @@ void Application::checkFirstRun() {
         spdlog::info("First run detected, showing settings dialog");
 
         SettingsDialog dialog(_settings, _mainWindow.get());
-        int result = dialog.exec();
+        dialog.exec();
 
-        // Save even if cancelled so we keep at least the default data path from the command line.
+        // Save and reload data paths whether or not the dialog was accepted, so we keep at least the
+        // default data path from the command line and the app is usable either way.
         settings.save();
-
-        if (result == QDialog::Accepted) {
-            loadDataPaths();
-        } else {
-            // Load data paths even if cancelled, so the app is usable.
-            loadDataPaths();
-        }
+        loadDataPaths();
     } else {
         loadDataPaths();
     }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -170,10 +170,8 @@ void Application::checkFirstRun() {
         settings.save();
 
         if (result == QDialog::Accepted) {
-            spdlog::info("Settings dialog accepted, configuration saved");
             loadDataPaths();
         } else {
-            spdlog::info("Settings dialog cancelled, saving default configuration");
             // Load data paths even if cancelled, so the app is usable.
             loadDataPaths();
         }
@@ -206,7 +204,7 @@ void Application::loadDataPaths() {
         _mainWindow->showFileBrowserPanel();
     }
 
-    spdlog::info("Data paths loaded successfully");
+    spdlog::debug("Data paths loaded successfully");
 }
 
 std::filesystem::path Application::getResourcesPath() {

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -97,7 +97,7 @@ namespace {
     public:
         explicit NameResolver(resource::GameResources& resources)
             : _resources(resources)
-            , _tilesLst(resources.repository().load<Lst>("art/tiles/tiles.lst")) {
+            , _tilesLst(loadTilesLst(resources)) {
         }
 
         std::string tileName(uint16_t id) const {
@@ -151,6 +151,18 @@ namespace {
         }
 
     private:
+        // tiles.lst (tile id -> name), or nullptr when it isn't mounted — tileName() falls back to a
+        // "tile#N" label, so analyze still runs on a bare .map (e.g. one just generated) without the
+        // full game data. Tolerant for the same reason loadScriptsLst() is.
+        static const Lst* loadTilesLst(resource::GameResources& resources) {
+            try {
+                return resources.repository().load<Lst>("art/tiles/tiles.lst");
+            } catch (const std::exception& e) {
+                spdlog::debug("loadTilesLst: {}", e.what());
+                return nullptr;
+            }
+        }
+
         // Load the proto once and cache whether it resolved and its OBJECT_FLAT flag.
         void characterize(uint32_t pid) {
             if (_resolved.find(pid) != _resolved.end()) {
@@ -234,8 +246,31 @@ namespace {
         return std::nullopt;
     }
 
+    // The MapScript an object's map_scripts_pid (SID) points at, or nullptr if the object has no
+    // script. Mirrors resolveObjectScript's lookup (the SID's section + a pid match), so the caller
+    // can read the script's local variables without re-deriving the section.
+    const MapScript* findObjectScript(Map& map, int32_t mapScriptsPid) {
+        if (mapScriptsPid < 0) {
+            return nullptr;
+        }
+        const auto sid = static_cast<uint32_t>(mapScriptsPid);
+        const int section = MapScript::sidSection(sid);
+        if (section < 0 || section >= Map::SCRIPT_SECTIONS) {
+            return nullptr;
+        }
+        for (const auto& script : map.getMapFile().map_scripts[section]) {
+            if (script.pid == sid) {
+                return &script;
+            }
+        }
+        return nullptr;
+    }
+
     // Ordered so the emitted objects keep the field order below (nlohmann's default json sorts keys).
     using ordered_json = nlohmann::ordered_json;
+
+    // Forward-declared so crittersToJson (above scriptsToJson) can attach a script's local variables.
+    ordered_json localVarsToJson(const MapScript& script, const std::vector<int32_t>& lvars);
 
     // List everything and keep the .map files, case-insensitively — more robust than a glob
     // against the raw VFS keys (whose case and leading "/" depend on the DAT/mount).
@@ -599,15 +634,77 @@ namespace {
                 }
                 const uint32_t pid = object->pro_pid;
                 const uint32_t packet = object->ai_packet != 0 ? object->ai_packet : names.critterAiPacket(pid);
-                // The attached script as {programIndex, name} (feed programIndex to describe_script) or null.
+                // The attached script as {programIndex, name, localVars} (feed programIndex to
+                // describe_script) or null. localVars is the script's slice of the map's LVAR pool.
                 ordered_json scriptJson = nullptr;
                 if (const auto ref = resolveObjectScript(map, object->map_scripts_pid, scriptsLst); ref.has_value()) {
-                    scriptJson = ordered_json{ { "programIndex", ref->first }, { "name", ref->second } };
+                    ordered_json localVars = ordered_json::array();
+                    if (const MapScript* script = findObjectScript(map, object->map_scripts_pid); script != nullptr) {
+                        localVars = localVarsToJson(*script, map.getMapFile().map_local_vars);
+                    }
+                    scriptJson = ordered_json{ { "programIndex", ref->first }, { "name", ref->second },
+                        { "localVars", std::move(localVars) } };
                 }
                 array.push_back({ { "pid", pidHex(pid) }, { "number", pid & 0xFFFFFFu },
                     { "name", names.protoName(pid) }, { "hex", object->position }, { "elevation", elevation },
                     { "team", object->group_id }, { "aiPacket", packet },
                     { "ai", critterAiToJson(ai.byPacketNum(static_cast<int>(packet))) }, { "script", scriptJson } });
+            }
+        }
+        return array;
+    }
+
+    // The script's local-variable slice of the map's flat LVAR pool: lvars[local_var_offset ..
+    // local_var_offset + local_var_count). Empty array when the script has no locals (offset is the
+    // NONE sentinel or count is 0). Every index is bounds-checked and the slice stops at the pool's
+    // end, so a stale count (e.g. a hand-edited map) can never read past the vector.
+    ordered_json localVarsToJson(const MapScript& script, const std::vector<int32_t>& lvars) {
+        auto array = ordered_json::array();
+        if (script.local_var_offset == MapScript::NONE || script.local_var_count == 0) {
+            return array;
+        }
+        for (uint32_t i = 0; i < script.local_var_count; ++i) {
+            const std::size_t index = static_cast<std::size_t>(script.local_var_offset) + i;
+            if (index >= lvars.size()) {
+                break;
+            }
+            array.push_back(lvars[index]);
+        }
+        return array;
+    }
+
+    // Per-map script list across every section, mirroring the editor's Scripts panel: each entry is
+    // { section, programIndex, name, filename, ownerObject, [spatialRadius|timerMs], localVars }. The
+    // section name comes from the section index (== MapScript::ScriptType); programIndex is the
+    // 0-based scripts.lst index (script_id), resolved to a friendly scrname.msg name and its .lst
+    // filename. ownerObject is the script's owning object id (null for the -1 sentinel / 0 = none).
+    // spatialRadius is included only for Spatial scripts, timerMs only for Timer scripts. localVars
+    // is the script's slice of the map's LVAR pool.
+    ordered_json scriptsToJson(Map& map, const Lst* scriptsLst, resource::GameResources& resources) {
+        auto array = ordered_json::array();
+        const auto& mapFile = map.getMapFile();
+        for (int section = 0; section < Map::SCRIPT_SECTIONS; ++section) {
+            for (const MapScript& script : mapFile.map_scripts[section]) {
+                std::string filename;
+                if (scriptsLst != nullptr && script.script_id < scriptsLst->list().size()) {
+                    filename = scriptsLst->at(script.script_id);
+                }
+                ordered_json entry;
+                entry["section"] = std::string(MapScript::toString(static_cast<MapScript::ScriptType>(section)));
+                entry["programIndex"] = static_cast<int>(script.script_id);
+                entry["name"] = resource::scriptDisplayName(resources, static_cast<int>(script.script_id));
+                entry["filename"] = filename;
+                entry["ownerObject"] = (script.script_oid == MapScript::NONE || script.script_oid == 0)
+                    ? ordered_json(nullptr)
+                    : ordered_json(script.script_oid);
+                if (section == static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+                    entry["spatialRadius"] = script.spatial_radius;
+                }
+                if (section == static_cast<int>(MapScript::ScriptType::TIMER)) {
+                    entry["timerMs"] = script.timer;
+                }
+                entry["localVars"] = localVarsToJson(script, mapFile.map_local_vars);
+                array.push_back(std::move(entry));
             }
         }
         return array;
@@ -731,12 +828,13 @@ namespace {
         entry["clusters"] = clustersToJson(collectClusters(map), ctx.names);
         entry["critters"] = crittersToJson(map, ctx.names, ctx.ai, ctx.scriptsLst);
         entry["header"] = headerToJson(map, loadMapGam(ctx.resources, mapPath), ctx.scriptsLst, ctx.resources);
+        entry["scripts"] = scriptsToJson(map, ctx.scriptsLst, ctx.resources);
         entry["exits"] = exitsToJson(map, ctx.mapNames);
         return entry;
     }
 
     // Machine-readable analyze, for an MCP client: per map { name, path, floor[], objects[],
-    // adjacency[], clusters[], critters[], header{}, exits[] } and an aggregate { analysed, floor[],
+    // adjacency[], clusters[], critters[], header{}, scripts[], exits[] } and an aggregate { analysed, floor[],
     // objects[], adjacency[] }. `flat` is the structural-vs-decoration hint; `adjacency` lists
     // floor-tile borders (transitions); `clusters` groups nearby objects (structures) with a
     // centre/bbox an agent feeds to extract_pattern. Built with nlohmann ordered_json.

--- a/src/cli/MapReachability.cpp
+++ b/src/cli/MapReachability.cpp
@@ -251,7 +251,7 @@ namespace {
         entry["orphanedObjects"] = orphanedObjectsJson(resources, objects, blocked, component, entryFlags, orphanTotal);
         entry["orphanedObjectCount"] = static_cast<int>(orphanTotal);
         if (orphanTotal > kMaxReported) {
-            spdlog::info("reachability {} elev {}: reporting {} of {} orphaned objects", mapName, elevation, kMaxReported, orphanTotal);
+            spdlog::debug("reachability {} elev {}: reporting {} of {} orphaned objects", mapName, elevation, kMaxReported, orphanTotal);
         }
         return entry;
     }

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -403,8 +403,11 @@ namespace {
             "pass it to scope. Each object carries a 'flat' flag (structural blocker vs. decoration) "
             "for curating a scatter palette. Each map also lists 'critters': who is on it, their team "
             "(group_id), their AI packet resolved via ai.txt (aggression, disposition, flee/best-weapon/"
-            "distance), and the attached 'script' ({programIndex,name}) — pass that programIndex to "
-            "describe_script for the script's source and dialog.",
+            "distance), and the attached 'script' ({programIndex,name,localVars}) — pass that "
+            "programIndex to describe_script for the script's source and dialog. Each map also lists "
+            "'scripts': every section's scripts (mirroring the editor's Scripts panel) as "
+            "{section,programIndex,name,filename,ownerObject,localVars}, with spatialRadius on Spatial "
+            "scripts and timerMs on Timer scripts.",
             json({ { "type", "object" }, { "properties", { { "maps", { { "type", "array" }, { "items", { { "type", "string" } } } } } } } }),
             [](resource::GameResources& r, const json& a) { return toolAnalyze(r, a); } });
         t.push_back({ "palette",

--- a/src/reader/frm/FrmReader.cpp
+++ b/src/reader/frm/FrmReader.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<geck::Frm> geck::FrmReader::read() {
                 // Number of pixels for this frame (should equal width * height)
                 uint32_t pixel_count = utils.readBE32();
                 if (pixel_count != static_cast<uint32_t>(width) * static_cast<uint32_t>(height)) {
-                    spdlog::warn("FRM frame {}: pixel count mismatch - header says {}, expected {}",
+                    spdlog::debug("FRM frame {}: pixel count mismatch - header says {}, expected {}",
                         i, pixel_count, width * height);
                 }
 

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -247,7 +247,17 @@ std::unique_ptr<Map> MapReader::read() {
                     case MapScript::ScriptType::CRITTER:
                         break;
                     default:
-                        spdlog::error("Unknown script PID = {}", (pid & 0xFF000000) >> 24);
+                        // Padding slots (j >= script_section_count) hold leftover garbage the original
+                        // mapper never zeroed; an unrecognised type byte there is expected and the slot is
+                        // discarded below, so log it quietly. Only a *real* script (j < count) with an
+                        // unknown type is worth a warning.
+                        if (j < script_section_count) {
+                            spdlog::warn("Unknown script PID type {} for a real script in section {}",
+                                (pid & 0xFF000000) >> 24, script_section);
+                        } else {
+                            spdlog::debug("Skipping padding script slot (garbage PID type {}) in section {}",
+                                (pid & 0xFF000000) >> 24, script_section);
+                        }
                         break;
                 }
 

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<Map> MapReader::read() {
         elevations++;
     if (elevation_high)
         elevations++;
-    spdlog::debug("Map has " + std::to_string(elevations) + " elevation(s)");
+    spdlog::debug("Map has {} elevation(s)", elevations);
 
     map_file->header.darkness = read_be_u32();
 
@@ -291,7 +291,7 @@ std::unique_ptr<Map> MapReader::read() {
     // The engine (object.cc objectLoadAll / objectSaveAll) always frames this
     // section as exactly ELEVATION_COUNT per-elevation count blocks, regardless
     // of which elevations are enabled. Read all three unconditionally.
-    uint32_t total_objects = read_be_u32();
+    read_be_u32(); // total object count across elevations — consumed; per-elevation counts follow
 
     for (int elev = 0; elev < Map::ELEVATION_COUNT; ++elev) {
         auto objectsOnElevation = read_be_u32();

--- a/src/reader/map/MapReader.cpp
+++ b/src/reader/map/MapReader.cpp
@@ -148,8 +148,6 @@ std::unique_ptr<Map> MapReader::read() {
     std::string filename = read_str(16);
     map_file->header.filename = filename;
 
-    spdlog::info("Loading map {} from {}", filename, _path.string());
-
     map_file->header.player_default_position = read_be_u32();
     map_file->header.player_default_elevation = read_be_u32();
     map_file->header.player_default_orientation = read_be_u32();
@@ -172,7 +170,7 @@ std::unique_ptr<Map> MapReader::read() {
         elevations++;
     if (elevation_high)
         elevations++;
-    spdlog::info("Map has " + std::to_string(elevations) + " elevation(s)");
+    spdlog::debug("Map has " + std::to_string(elevations) + " elevation(s)");
 
     map_file->header.darkness = read_be_u32();
 
@@ -195,7 +193,7 @@ std::unique_ptr<Map> MapReader::read() {
         if (!Map::elevationIsPresent(flags, elevation)) {
             continue;
         }
-        spdlog::info("Loading tiles at elevation {}", elevation);
+        spdlog::debug("Loading tiles at elevation {}", elevation);
 
         map_file->tiles[elevation].reserve(Map::TILES_PER_ELEVATION);
 
@@ -209,12 +207,11 @@ std::unique_ptr<Map> MapReader::read() {
 
     // SCRIPTS SECTION
     // Each section contains 16 slots for scripts
-    spdlog::info("Loading map scripts");
     for (unsigned script_section = 0; script_section < Map::SCRIPT_SECTIONS; script_section++) {
         uint32_t script_section_count = read_be_u32();
         map_file->scripts_in_section[script_section] = script_section_count;
 
-        spdlog::info("... script section {} has {} scripts", MapScript::toString(static_cast<MapScript::ScriptType>(script_section)), script_section_count);
+        spdlog::debug("... script section {} has {} scripts", MapScript::toString(static_cast<MapScript::ScriptType>(script_section)), script_section_count);
 
         if (script_section_count > 0) {
             uint32_t loop = script_section_count;
@@ -296,11 +293,10 @@ std::unique_ptr<Map> MapReader::read() {
     // of which elevations are enabled. Read all three unconditionally.
     uint32_t total_objects = read_be_u32();
 
-    spdlog::info("Loading {} map objects", total_objects);
     for (int elev = 0; elev < Map::ELEVATION_COUNT; ++elev) {
         auto objectsOnElevation = read_be_u32();
 
-        spdlog::info("... loading {} map objects on elevation {}", objectsOnElevation, elev);
+        spdlog::debug("... loading {} map objects on elevation {}", objectsOnElevation, elev);
         for (size_t j = 0; j != objectsOnElevation; ++j) {
 
             std::unique_ptr<MapObject> object = readMapObject();

--- a/src/reader/pal/PalReader.cpp
+++ b/src/reader/pal/PalReader.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<geck::Pal> geck::PalReader::read() {
 
             // Validate conversion table values (should be palette indices 0-255)
             if (conversion > 255) {
-                spdlog::warn("PAL file has unusual conversion table value: {} at offset {}",
+                spdlog::debug("PAL file has unusual conversion table value: {} at offset {}",
                     conversion, offset - 1);
             }
         }

--- a/src/resource/CritterFrmResolver.cpp
+++ b/src/resource/CritterFrmResolver.cpp
@@ -17,7 +17,7 @@ std::string CritterFrmResolver::generateCritterFrmName(const std::string& baseNa
 
     char suffix1, suffix2;
     if (!getSuffixes(id1, id2, suffix1, suffix2)) {
-        spdlog::warn("CritterFrmResolver: Invalid suffix combination for id1={}, id2={}", id1, id2);
+        spdlog::debug("CritterFrmResolver: Invalid suffix combination for id1={}, id2={}", id1, id2);
         return "";
     }
 

--- a/src/resource/DataFileSystem.cpp
+++ b/src/resource/DataFileSystem.cpp
@@ -83,7 +83,6 @@ void DataFileSystem::addDataPathLocked(const std::filesystem::path& path) {
     }
 
     _vfs->AddFileSystem("/", fileSystem);
-    spdlog::info("Location '{}' was added to the data path", mountRoot->string());
 }
 
 std::optional<std::vector<uint8_t>> DataFileSystem::readRawBytes(const std::filesystem::path& path) const {

--- a/src/resource/ResourceInitializer.cpp
+++ b/src/resource/ResourceInitializer.cpp
@@ -61,7 +61,6 @@ void ResourceInitializer::loadEssentialLstFiles(resource::GameResources& resourc
             loadLst(path);
         }
 
-        spdlog::info("ResourceInitializer: Loaded all essential LST files");
     } catch (const std::exception& e) {
         spdlog::error("ResourceInitializer: Failed to load essential LST files: {}", e.what());
         throw;
@@ -92,7 +91,6 @@ void ResourceInitializer::loadEssentialTextures(resource::GameResources& resourc
         resources.textures().preload(ResourcePaths::Frm::WALL_BLOCK_FULL);
         resources.textures().preload(ResourcePaths::Frm::EXIT_GRID);
 
-        spdlog::info("ResourceInitializer: Loaded all essential textures");
     } catch (const std::exception& e) {
         spdlog::error("ResourceInitializer: Failed to load essential textures: {}", e.what());
         throw;

--- a/src/state/GameLauncher.cpp
+++ b/src/state/GameLauncher.cpp
@@ -71,7 +71,7 @@ void GameLauncher::playGame(const Map::MapFile* mapFile, const std::string& mapF
             return;
         }
 
-        spdlog::info("Saved map to game directory: {} ({} bytes)", mapDestination.string(), *bytesWritten);
+        spdlog::debug("Saved map to game directory: {} ({} bytes)", mapDestination.string(), *bytesWritten);
 
         // 2. Modify ddraw.ini
         std::filesystem::path ddrawIniPath = gameDataDir / "ddraw.ini";
@@ -169,7 +169,7 @@ bool GameLauncher::modifyDdrawIni(const std::filesystem::path& ddrawIniPath, con
         outFile << content;
         outFile.close();
 
-        spdlog::info("Modified {}: set StartingMap to {}", ddrawIniPath.string(), mapFilename);
+        spdlog::debug("Modified {}: set StartingMap to {}", ddrawIniPath.string(), mapFilename);
         return true;
 
     } catch (const std::exception& e) {
@@ -179,7 +179,7 @@ bool GameLauncher::modifyDdrawIni(const std::filesystem::path& ddrawIniPath, con
 }
 
 void GameLauncher::launchGame(const std::filesystem::path& executablePath) {
-    spdlog::info("Launching game executable: {}", executablePath.string());
+    spdlog::debug("Launching game executable: {}", executablePath.string());
 
     QProcess* gameProcess = new QProcess(this);
     gameProcess->setWorkingDirectory(QString::fromStdString(executablePath.parent_path().string()));
@@ -189,7 +189,7 @@ void GameLauncher::launchGame(const std::filesystem::path& executablePath) {
             if (exitStatus == QProcess::CrashExit) {
                 spdlog::warn("Game process crashed with exit code: {}", exitCode);
             } else {
-                spdlog::info("Game process finished with exit code: {}", exitCode);
+                spdlog::debug("Game process finished with exit code: {}", exitCode);
             }
             gameProcess->deleteLater();
         });
@@ -228,7 +228,6 @@ void GameLauncher::launchGame(const std::filesystem::path& executablePath) {
     }
 
     _showStatus("Game launched successfully!");
-    spdlog::info("Game launched successfully");
 }
 
 } // namespace geck

--- a/src/state/loader/DataPathLoader.cpp
+++ b/src/state/loader/DataPathLoader.cpp
@@ -24,7 +24,7 @@ void DataPathLoader::init() {
 
 void DataPathLoader::load() {
     if (_dataPaths.empty()) {
-        spdlog::warn("DataPathLoader: No data paths to load");
+        spdlog::debug("DataPathLoader: No data paths to load");
         _percentDone = 100;
         _done = true;
         return;
@@ -38,7 +38,7 @@ void DataPathLoader::load() {
         setProgress("Loading: " + path.filename().string());
 
         try {
-            spdlog::info("DataPathLoader: Loading data path: {}", path.string());
+            spdlog::debug("DataPathLoader: Loading data path: {}", path.string());
             _resources->files().addDataPath(path);
 
             _currentPathIndex++;
@@ -80,7 +80,6 @@ void DataPathLoader::onDone() {
     if (_hasError) {
         spdlog::warn("DataPathLoader completed with errors: {}", _errorMessage);
     } else {
-        spdlog::info("DataPathLoader completed successfully, loaded {} data paths", _dataPaths.size());
     }
 }
 

--- a/src/state/loader/DataPathLoader.cpp
+++ b/src/state/loader/DataPathLoader.cpp
@@ -79,7 +79,6 @@ void DataPathLoader::load() {
 void DataPathLoader::onDone() {
     if (_hasError) {
         spdlog::warn("DataPathLoader completed with errors: {}", _errorMessage);
-    } else {
     }
 }
 

--- a/src/state/loader/MapLoader.cpp
+++ b/src/state/loader/MapLoader.cpp
@@ -51,10 +51,10 @@ void MapLoader::load() {
     // reported error instead.
     try {
         if (_forceFilesystem) {
-            spdlog::info("MapLoader: Force filesystem loading requested");
+            spdlog::debug("MapLoader: Force filesystem loading requested");
             loadFromFilesystem();
         } else {
-            spdlog::info("MapLoader: Attempting VFS loading first");
+            spdlog::debug("MapLoader: Attempting VFS loading first");
             loadFromVFS();
         }
     } catch (const FileReaderException& e) {
@@ -66,7 +66,7 @@ void MapLoader::load() {
 }
 
 void MapLoader::loadFromVFS() {
-    spdlog::info("MapLoader: Loading map from VFS: {}", _mapPath.string());
+    spdlog::debug("MapLoader: Loading map from VFS: {}", _mapPath.string());
 
     try {
         if (!ensureResourceListsReady()) {
@@ -101,7 +101,7 @@ void MapLoader::loadFromVFS() {
         }
 
         _percentDone = 20;
-        spdlog::info("MapLoader: Successfully loaded map from VFS: {}", _mapPath.string());
+        spdlog::debug("MapLoader: Successfully loaded map from VFS: {}", _mapPath.string());
 
         loadMapResources();
 
@@ -119,7 +119,7 @@ void MapLoader::loadFromVFS() {
 }
 
 void MapLoader::loadFromFilesystem() {
-    spdlog::info("MapLoader: Loading map from filesystem: {}", _mapPath.string());
+    spdlog::debug("MapLoader: Loading map from filesystem: {}", _mapPath.string());
     spdlog::stopwatch stopwatch_total;
 
     if (!ensureResourceListsReady()) {
@@ -146,11 +146,9 @@ void MapLoader::loadFromFilesystem() {
     }
 
     _percentDone = 20;
-    spdlog::info("MapLoader: Successfully loaded map from filesystem: {}", _mapPath.string());
+    spdlog::debug("MapLoader: Successfully loaded map from filesystem: {}", _mapPath.string());
 
     loadMapResources();
-
-    spdlog::info("Map loader finished after {:.3} seconds", stopwatch_total);
 
     // Only mark complete if loadMapResources didn't set an error.
     if (!_hasError) {
@@ -180,7 +178,7 @@ void MapLoader::loadMapResources() {
     try {
         if (_elevation == INVALID_ELEVATION) {
             uint32_t default_elevation = _map->getMapFile().header.player_default_elevation;
-            spdlog::info("Using default map elevation {}", default_elevation);
+            spdlog::debug("Using default map elevation {}", default_elevation);
             _elevation = default_elevation;
         }
 
@@ -210,7 +208,6 @@ void MapLoader::loadMapResources() {
             tile_number++;
         }
 
-        spdlog::info("... tile textures loaded in {:.3} seconds", stopwatch_chunk);
         stopwatch_chunk.reset();
 
         size_t objectNumber = 1;
@@ -240,8 +237,6 @@ void MapLoader::loadMapResources() {
         _resources->textures().preload(ResourcePaths::Frm::WALL_BLOCK);
         _resources->textures().preload(ResourcePaths::Frm::WALL_BLOCK_FULL);
         _resources->textures().preload(ResourcePaths::Frm::SCROLL_BLOCKER);
-
-        spdlog::info("... objects and resources loaded in {:.3} seconds", stopwatch_chunk);
 
         _percentDone = 100;
         setProgress("Map loading complete");

--- a/src/ui/ExternalEditorLauncher.cpp
+++ b/src/ui/ExternalEditorLauncher.cpp
@@ -35,7 +35,7 @@ void ExternalEditorLauncher::openFile(const QString& vfsFilePath) {
         auto editorMode = settings.getTextEditorMode();
         QString customEditorPath = settings.getCustomEditorPath();
 
-        spdlog::info("ExternalEditorLauncher: Opening text file with {} editor: {}",
+        spdlog::debug("ExternalEditorLauncher: Opening text file with {} editor: {}",
             (editorMode == Settings::TextEditorMode::CUSTOM) ? "custom" : "system",
             vfsFilePath.toStdString());
 
@@ -61,7 +61,7 @@ void ExternalEditorLauncher::openFile(const QString& vfsFilePath) {
         QFileInfo requestedPathInfo(vfsFilePath);
         if (requestedPathInfo.exists() && requestedPathInfo.isReadable() && requestedPathInfo.isFile()) {
             targetFilePath = requestedPathInfo.absoluteFilePath();
-            spdlog::info("ExternalEditorLauncher: Opening native file directly at {}", targetFilePath.toStdString());
+            spdlog::debug("ExternalEditorLauncher: Opening native file directly at {}", targetFilePath.toStdString());
         } else {
             QTemporaryFile tempFile(tempFilePath);
             tempFile.setAutoRemove(false);
@@ -96,7 +96,7 @@ void ExternalEditorLauncher::openFile(const QString& vfsFilePath) {
             opened = QProcess::startDetached(customEditorPath, arguments);
 
             if (opened) {
-                spdlog::info("ExternalEditorLauncher: Successfully opened file with custom editor: {} -> {}",
+                spdlog::debug("ExternalEditorLauncher: Successfully opened file with custom editor: {} -> {}",
                     customEditorPath.toStdString(), targetFilePath.toStdString());
             } else {
                 spdlog::warn("ExternalEditorLauncher: Failed to start custom editor: {}", customEditorPath.toStdString());
@@ -118,7 +118,7 @@ void ExternalEditorLauncher::openFile(const QString& vfsFilePath) {
                     QFile::remove(targetFilePath);
                 }
             } else {
-                spdlog::info("ExternalEditorLauncher: Successfully opened file with system default editor: {}", targetFilePath.toStdString());
+                spdlog::debug("ExternalEditorLauncher: Successfully opened file with system default editor: {}", targetFilePath.toStdString());
             }
         }
 

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -57,7 +57,7 @@ void Settings::load() {
     spdlog::debug("Loading settings from configuration path: {}", filePath.toStdString());
 
     if (!QFile::exists(filePath)) {
-        spdlog::info("Settings file not found in {}, using defaults", filePath.toStdString());
+        spdlog::debug("Settings file not found in {}, using defaults", filePath.toStdString());
         return;
     }
 
@@ -77,7 +77,7 @@ void Settings::load() {
     }
 
     fromJson(doc.object());
-    spdlog::info("Settings loaded from: {}", filePath.toStdString());
+    spdlog::debug("Settings loaded from: {}", filePath.toStdString());
 }
 
 void Settings::save() {
@@ -92,7 +92,7 @@ void Settings::save() {
     QJsonDocument doc(toJson());
     file.write(doc.toJson());
 
-    spdlog::info("Settings saved to: {}", filePath.toStdString());
+    spdlog::debug("Settings saved to: {}", filePath.toStdString());
 }
 
 QJsonObject Settings::toJson() const {
@@ -277,7 +277,7 @@ void Settings::addDataPath(const std::filesystem::path& path) {
     }
 
     _dataPaths.push_back(normalizedPath);
-    spdlog::info("Added data path: {}", normalizedPath.string());
+    spdlog::debug("Added data path: {}", normalizedPath.string());
 }
 
 void Settings::removeDataPath(const std::filesystem::path& path) {
@@ -289,7 +289,7 @@ void Settings::removeDataPath(const std::filesystem::path& path) {
 
     if (it != _dataPaths.end()) {
         _dataPaths.erase(it, _dataPaths.end());
-        spdlog::info("Removed data path: {}", normalizedPath.string());
+        spdlog::debug("Removed data path: {}", normalizedPath.string());
     }
 }
 
@@ -422,7 +422,7 @@ std::vector<std::filesystem::path> Settings::detectFallout2Installations() {
         const std::filesystem::path gamePath(gogPath.toStdString());
         if (const auto normalized = util::resolveGameDataRoot(gamePath)) {
             appendUnique(installations, *normalized);
-            spdlog::info("Found GOG Fallout 2 installation: {}", normalized->string());
+            spdlog::debug("Found GOG Fallout 2 installation: {}", normalized->string());
         }
     }
 
@@ -433,7 +433,7 @@ std::vector<std::filesystem::path> Settings::detectFallout2Installations() {
         const std::filesystem::path steamFo2Path = std::filesystem::path(steamPath.toStdString()) / "steamapps" / "common" / "Fallout 2";
         if (const auto normalized = util::resolveGameDataRoot(steamFo2Path)) {
             appendUnique(installations, *normalized);
-            spdlog::info("Found Steam Fallout 2 installation: {}", normalized->string());
+            spdlog::debug("Found Steam Fallout 2 installation: {}", normalized->string());
         }
     }
 
@@ -448,7 +448,7 @@ std::vector<std::filesystem::path> Settings::detectFallout2Installations() {
     for (const auto& path : macPaths) {
         if (const auto normalized = util::resolveGameDataRoot(path)) {
             appendUnique(installations, *normalized);
-            spdlog::info("Found macOS Fallout 2 installation: {}", normalized->string());
+            spdlog::debug("Found macOS Fallout 2 installation: {}", normalized->string());
         }
     }
 
@@ -463,7 +463,7 @@ std::vector<std::filesystem::path> Settings::detectFallout2Installations() {
     for (const auto& path : linuxPaths) {
         if (const auto normalized = util::resolveGameDataRoot(path)) {
             appendUnique(installations, *normalized);
-            spdlog::info("Found Linux Fallout 2 installation: {}", normalized->string());
+            spdlog::debug("Found Linux Fallout 2 installation: {}", normalized->string());
         }
     }
 #endif
@@ -484,7 +484,7 @@ std::vector<Settings::DetectedInstallation> Settings::detectFallout2Installation
         std::filesystem::path gogGamePath = std::filesystem::path(gogPath.toStdString());
         if (util::hasFallout2DataLayout(gogGamePath)) {
             installations.push_back({ gogGamePath, "GOG Installation" });
-            spdlog::info("Found GOG Fallout 2 installation: {}", gogGamePath.string());
+            spdlog::debug("Found GOG Fallout 2 installation: {}", gogGamePath.string());
         }
     }
 
@@ -495,7 +495,7 @@ std::vector<Settings::DetectedInstallation> Settings::detectFallout2Installation
         std::filesystem::path steamGamePath = std::filesystem::path(steamPath.toStdString()) / "steamapps" / "common" / "Fallout 2";
         if (util::hasFallout2DataLayout(steamGamePath)) {
             installations.push_back({ steamGamePath, "Steam Installation" });
-            spdlog::info("Found Steam Fallout 2 installation: {}", steamGamePath.string());
+            spdlog::debug("Found Steam Fallout 2 installation: {}", steamGamePath.string());
         }
     }
 
@@ -509,7 +509,7 @@ std::vector<Settings::DetectedInstallation> Settings::detectFallout2Installation
     for (const auto& [path, description] : macPaths) {
         if (util::resolveGameDataRoot(path).has_value()) {
             installations.push_back({ path, description });
-            spdlog::info("Found macOS Fallout 2 installation: {}", path.string());
+            spdlog::debug("Found macOS Fallout 2 installation: {}", path.string());
         }
     }
 
@@ -517,7 +517,7 @@ std::vector<Settings::DetectedInstallation> Settings::detectFallout2Installation
     std::filesystem::path steamMacPath = std::filesystem::path(QDir::homePath().toStdString()) / "Library/Application Support/Steam/steamapps/common/Fallout 2";
     if (util::hasFallout2DataLayout(steamMacPath)) {
         installations.push_back({ steamMacPath, "Steam Installation (macOS)" });
-        spdlog::info("Found Steam Fallout 2 installation on macOS: {}", steamMacPath.string());
+        spdlog::debug("Found Steam Fallout 2 installation on macOS: {}", steamMacPath.string());
     }
 
 #else
@@ -531,7 +531,7 @@ std::vector<Settings::DetectedInstallation> Settings::detectFallout2Installation
     for (const auto& [path, description] : linuxPaths) {
         if (util::hasFallout2DataLayout(path)) {
             installations.push_back({ path, description });
-            spdlog::info("Found Linux Fallout 2 installation: {}", path.string());
+            spdlog::debug("Found Linux Fallout 2 installation: {}", path.string());
         }
     }
 #endif
@@ -555,7 +555,7 @@ std::filesystem::path Settings::getExecutableGameLocation() const {
 
 void Settings::setExecutableGameLocation(const std::filesystem::path& location) {
     _executableGameLocation = location;
-    spdlog::info("Executable game location set to: {}", location.string());
+    spdlog::debug("Executable game location set to: {}", location.string());
 }
 
 std::filesystem::path Settings::getGameDataDirectory() const {
@@ -564,7 +564,7 @@ std::filesystem::path Settings::getGameDataDirectory() const {
 
 void Settings::setGameDataDirectory(const std::filesystem::path& location) {
     _gameDataDirectory = location;
-    spdlog::info("Game data directory set to: {}", location.string());
+    spdlog::debug("Game data directory set to: {}", location.string());
 }
 
 bool Settings::isGameLocationValid() const {
@@ -595,7 +595,7 @@ void Settings::autoDetectGameLocation() {
         const std::filesystem::path& gameDir = installations[0];
         _executableGameLocation = gameDir;
         _gameDataDirectory = gameDir;
-        spdlog::info("Auto-detected game location: {}", gameDir.string());
+        spdlog::debug("Auto-detected game location: {}", gameDir.string());
     } else {
         spdlog::warn("No Fallout 2 installations detected");
     }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -512,19 +512,19 @@ void EditorWidget::openMap() {
     QString mapPathQString = QtDialogs::openMapFile(this, "Choose Fallout 2 map to load");
 
     if (mapPathQString.isEmpty()) {
-        spdlog::info("No map file selected");
+        spdlog::debug("No map file selected");
         return;
     }
 
     std::string mapPath = mapPathQString.toStdString();
-    spdlog::info("User requested to open new map: {}", mapPath);
+    spdlog::debug("User requested to open new map: {}", mapPath);
 
     // MainWindow handles the actual loading
     Q_EMIT mapLoadRequested(mapPath);
 }
 
 void EditorWidget::createNewMap() {
-    spdlog::info("Creating new empty map");
+    spdlog::debug("Creating new empty map");
 
     _session.resetToEmptyMap();
     _controller.visualizer().clearHexPositions();
@@ -550,7 +550,7 @@ void EditorWidget::createNewMap() {
         _mainWindow->updateMapInfo(_session.map());
     }
 
-    spdlog::info("Created new empty map with {} tiles per elevation", Map::TILES_PER_ELEVATION);
+    spdlog::debug("Created new empty map with {} tiles per elevation", Map::TILES_PER_ELEVATION);
 }
 
 std::vector<int> EditorWidget::calculateRectangleBorderHexes(sf::FloatRect rectangle) {
@@ -631,7 +631,7 @@ void EditorWidget::loadSprites() {
 
     _session.selectionManager()->initializeSpatialIndex();
 
-    spdlog::info("Map sprites loaded in {:.3} seconds", sw);
+    spdlog::debug("Map sprites loaded in {:.3} seconds", sw);
 }
 
 bool EditorWidget::isObjectSelectable(const std::shared_ptr<Object>& object) const {
@@ -811,7 +811,7 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
         if (_mainWindow && _mainWindow->getTilePalettePanel()) {
             _mainWindow->getTilePalettePanel()->deselectTile();
         }
-        spdlog::info("Tile placement mode cancelled");
+        spdlog::debug("Tile placement mode cancelled");
     };
 
     callbacks.onExitGridPlacement = [this](sf::Vector2f worldPos) {
@@ -914,7 +914,7 @@ void EditorWidget::createScrollBlockersFromHexes(const std::vector<int>& borderH
         }
     }
 
-    spdlog::info("Scroll blocker rectangle: {} scroll blockers created on border", scrollBlockersCreated);
+    spdlog::debug("Scroll blocker rectangle: {} scroll blockers created on border", scrollBlockersCreated);
 }
 
 void EditorWidget::update([[maybe_unused]] const float dt) {
@@ -996,7 +996,7 @@ bool EditorWidget::selectAtPosition(sf::Vector2f worldPos, SelectionModifier mod
     if (result.success && result.selectionChanged) {
         const auto& selection = _session.selectionManager()->getCurrentSelection();
         if (selection.count() > 1) {
-            spdlog::info("Multi-selection: {} items selected", selection.count());
+            spdlog::debug("Multi-selection: {} items selected", selection.count());
         }
     }
 
@@ -1014,7 +1014,7 @@ void EditorWidget::cycleSelectionMode() {
 
     // Changing the selection type keeps the current selection; subsequent clicks/drags then add to
     // or subtract from it under the new type (the add/deselect paths are already mode-aware).
-    spdlog::info("Selection mode changed to: {}", selectionModeToString(_currentSelectionMode));
+    spdlog::debug("Selection mode changed to: {}", selectionModeToString(_currentSelectionMode));
 }
 
 void EditorWidget::setSelectionMode(SelectionMode mode) {
@@ -1029,7 +1029,7 @@ void EditorWidget::setSelectionMode(SelectionMode mode) {
     }
 
     // Keep the current selection across a type change (see cycleSelectionMode).
-    spdlog::info("Selection mode set to: {}", selectionModeToString(_currentSelectionMode));
+    spdlog::debug("Selection mode set to: {}", selectionModeToString(_currentSelectionMode));
 }
 
 void EditorWidget::setActiveSelectionLayers(SelectionLayers layers) {
@@ -1043,7 +1043,7 @@ void EditorWidget::setActiveSelectionLayers(SelectionLayers layers) {
         return; // created lazily with the map; a menu sync can run first (first New Map)
     }
     _session.selectionManager()->setActiveLayers(layers);
-    spdlog::info("Selection layers set to: floor={} roof={} objects={}",
+    spdlog::debug("Selection layers set to: floor={} roof={} objects={}",
         layers.floorTiles, layers.roofTiles, layers.objects);
 }
 
@@ -1057,15 +1057,15 @@ SelectionLayers EditorWidget::getActiveSelectionLayers() const {
 void EditorWidget::toggleScrollBlockerRectangleMode() {
     if (_currentSelectionMode == SelectionMode::SCROLL_BLOCKER_RECTANGLE) {
         _currentSelectionMode = SelectionMode::ALL;
-        spdlog::info("Scroll blocker rectangle mode disabled, switched to ALL mode");
+        spdlog::debug("Scroll blocker rectangle mode disabled, switched to ALL mode");
     } else {
         _currentSelectionMode = SelectionMode::SCROLL_BLOCKER_RECTANGLE;
         // Auto-enable scroll blocker visibility so the user can see what they are placing
         if (!_session.visibility().showScrollBlockers) {
             _session.visibility().showScrollBlockers = true;
-            spdlog::info("Automatically enabled scroll blocker visibility");
+            spdlog::debug("Automatically enabled scroll blocker visibility");
         }
-        spdlog::info("Scroll blocker rectangle mode enabled");
+        spdlog::debug("Scroll blocker rectangle mode enabled");
     }
 
     if (_inputHandler) {
@@ -1097,7 +1097,7 @@ void EditorWidget::rotateSelectedObject() {
             spdlog::debug("Rotated object to direction {}", object->getMapObject().direction);
         }
         registerObjectRotation(validObjects, beforeDirs, afterDirs);
-        spdlog::info("Rotated {} selected object(s)", objects.size());
+        spdlog::debug("Rotated {} selected object(s)", objects.size());
     } else {
         spdlog::debug("No objects selected for rotation");
     }
@@ -1431,7 +1431,7 @@ selection::SelectionResult EditorWidget::handleRangeSelection(sf::Vector2f world
 
     auto result = _session.selectionManager()->selectArea(selectionArea, areaMode, _session.currentElevation());
 
-    spdlog::info("Range selection: area ({:.1f}, {:.1f}, {:.1f}, {:.1f})",
+    spdlog::debug("Range selection: area ({:.1f}, {:.1f}, {:.1f}, {:.1f})",
         selectionArea.position.x, selectionArea.position.y, selectionArea.size.x, selectionArea.size.y);
 
     return result;
@@ -1684,7 +1684,7 @@ void EditorWidget::placeObjectAtPosition(sf::Vector2f worldPos) {
             object->setHexPosition(hex->get());
         }
 
-        spdlog::info("EditorWidget: Successfully placed object at hex {} (pro_pid: {})",
+        spdlog::debug("EditorWidget: Successfully placed object at hex {} (pro_pid: {})",
             hexPosition, mapObject->pro_pid);
 
         registerObjectPlacement(mapObject, object);
@@ -1828,7 +1828,7 @@ void EditorWidget::setShowLightOverlays(bool show) {
         object->setShowLightOverlay(show);
     });
 
-    spdlog::info("Light overlay display set to: {} (found {} light objects)", show, lightObjectCount);
+    spdlog::debug("Light overlay display set to: {} (found {} light objects)", show, lightObjectCount);
 }
 
 void EditorWidget::clearDragSelectionPreview() {
@@ -1858,7 +1858,7 @@ void EditorWidget::onObjectFrmChanged(std::shared_ptr<Object> object, uint32_t n
         }
 
         registerObjectFrmChange(object, oldFrmPid, oldFrmPath, newFrmPid, newFrmPath);
-        spdlog::info("EditorWidget::onObjectFrmChanged - updated object visual to FRM PID {} ({})", newFrmPid, newFrmPath);
+        spdlog::debug("EditorWidget::onObjectFrmChanged - updated object visual to FRM PID {} ({})", newFrmPid, newFrmPath);
     } catch (const std::exception& e) {
         spdlog::error("EditorWidget::onObjectFrmChanged - failed to update object FRM: {}", e.what());
     }
@@ -1880,7 +1880,7 @@ void EditorWidget::onObjectFrmPathChanged(std::shared_ptr<Object> object, const 
         std::string oldFrmPath = _resources.frmResolver().resolve(oldFrmPid);
 
         registerObjectFrmChange(object, oldFrmPid, oldFrmPath, oldFrmPid, newFrmPath);
-        spdlog::info("EditorWidget::onObjectFrmPathChanged - updated object visual to FRM path: {}", newFrmPath);
+        spdlog::debug("EditorWidget::onObjectFrmPathChanged - updated object visual to FRM path: {}", newFrmPath);
 
     } catch (const std::exception& e) {
         spdlog::error("EditorWidget::onObjectFrmPathChanged - failed to update object FRM from path {}: {}",
@@ -1901,7 +1901,7 @@ void EditorWidget::deleteSelectedObjects() {
         return;
     }
 
-    spdlog::info("EditorWidget::deleteSelectedObjects - Deleting {} selected objects", selectedObjects.size());
+    spdlog::debug("EditorWidget::deleteSelectedObjects - Deleting {} selected objects", selectedObjects.size());
 
     std::vector<std::pair<std::shared_ptr<MapObject>, std::shared_ptr<Object>>> removedObjects;
     for (const auto& object : selectedObjects) {
@@ -1928,7 +1928,7 @@ void EditorWidget::deleteSelectedObjects() {
 
     Q_EMIT selectionChanged(_session.selectionManager()->getCurrentSelection(), _session.currentElevation());
 
-    spdlog::info("EditorWidget::deleteSelectedObjects - Successfully deleted {} objects", removedObjects.size());
+    spdlog::debug("EditorWidget::deleteSelectedObjects - Successfully deleted {} objects", removedObjects.size());
 }
 
 } // namespace geck

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -505,7 +505,7 @@ void MainWindow::setupMenuBar() {
                 dock->setFloating(false);
             }
         }
-        spdlog::info("Re-docked all floating panels");
+        spdlog::debug("Re-docked all floating panels");
     });
 
     dockLayoutMenu->addSeparator();
@@ -915,7 +915,7 @@ void MainWindow::setupDockWidgets() {
     spdlog::debug("Dock widget setup completed with flexible sizing and state monitoring");
 
     // Qt already renders dock widgets above the central SFML widget, avoiding redraw issues
-    spdlog::info("Dock widgets configured with proper z-order and panel features");
+    spdlog::debug("Dock widgets configured with proper z-order and panel features");
 }
 
 void MainWindow::connectFileBrowserSignals() {
@@ -925,10 +925,10 @@ void MainWindow::connectFileBrowserSignals() {
 
     connect(_fileBrowserPanel, &FileBrowserPanel::fileDoubleClicked, this, [this](const QString& filePath) {
         if (filePath.endsWith(".map", Qt::CaseInsensitive)) {
-            spdlog::info("MainWindow: Opening map from file browser: {}", filePath.toStdString());
+            spdlog::debug("MainWindow: Opening map from file browser: {}", filePath.toStdString());
             handleMapLoadRequest(filePath.toStdString(), false);
         } else if (ExternalEditorLauncher::isTextFile(filePath)) {
-            spdlog::info("MainWindow: Opening text file from file browser: {}", filePath.toStdString());
+            spdlog::debug("MainWindow: Opening text file from file browser: {}", filePath.toStdString());
             _externalEditorLauncher->openFile(filePath);
         } else {
             spdlog::debug("MainWindow: Unsupported file type double-clicked: {}", filePath.toStdString());
@@ -1064,7 +1064,7 @@ void MainWindow::startGameLoop() {
     if (!_isRunning) {
         _isRunning = true;
         _gameLoopTimer->start(16); // ~60 FPS
-        spdlog::info("Qt6 game loop started");
+        spdlog::debug("Qt6 game loop started");
     }
 }
 
@@ -1072,7 +1072,7 @@ void MainWindow::stopGameLoop() {
     if (_isRunning) {
         _isRunning = false;
         _gameLoopTimer->stop();
-        spdlog::info("Qt6 game loop stopped");
+        spdlog::debug("Qt6 game loop stopped");
     }
 }
 
@@ -1371,7 +1371,7 @@ void MainWindow::connectPanelSignals() {
                 updateElevationMenu(_currentEditorWidget->getMap());
                 if (_currentEditorWidget->getCurrentElevation() == elevation) {
                     _currentEditorWidget->loadTileSprites();
-                    spdlog::info("MainWindow: Reloaded sprites for newly added elevation {}", elevation);
+                    spdlog::debug("MainWindow: Reloaded sprites for newly added elevation {}", elevation);
                 }
             });
         connect(_mapInfoPanel, &MapInfoPanel::elevationRemoved,
@@ -1391,7 +1391,7 @@ void MainWindow::connectPanelSignals() {
                         else if ((flags & 0x8) == 0)
                             elevationChanged(ELEVATION_3);
                     }
-                    spdlog::info("MainWindow: Switched away from removed elevation {}", elevation);
+                    spdlog::debug("MainWindow: Switched away from removed elevation {}", elevation);
                 }
             });
         connect(_mapInfoPanel, &MapInfoPanel::clearElevationRequested,
@@ -1469,7 +1469,7 @@ void MainWindow::connectToEditorWidget() {
 
     applySelectionColorsToEditor();
 
-    spdlog::info("Connected EditorWidget instance signals");
+    spdlog::debug("Connected EditorWidget instance signals");
 }
 
 void MainWindow::applySelectionColorsToEditor() {
@@ -1534,7 +1534,7 @@ void MainWindow::updateMapInfo(Map* map) {
 
             if (tileList) {
                 _tilePalettePanel->loadTiles(tileList);
-                spdlog::info("Loaded tiles.lst into palette: {} tiles", tileList->list().size());
+                spdlog::debug("Loaded tiles.lst into palette: {} tiles", tileList->list().size());
             } else {
                 spdlog::error("Failed to get tiles.lst from the resource repository");
             }
@@ -1547,7 +1547,7 @@ void MainWindow::updateMapInfo(Map* map) {
         try {
             _objectPalettePanel->setMap(map);
             _objectPalettePanel->loadObjects();
-            spdlog::info("Loaded objects into ObjectPalettePanel");
+            spdlog::debug("Loaded objects into ObjectPalettePanel");
         } catch (const std::exception& e) {
             spdlog::error("Failed to load objects for palette: {}", e.what());
         }
@@ -1589,7 +1589,7 @@ void MainWindow::handleMapLoadRequest(const std::string& mapPath, bool forceFile
     if (!maybeSaveChanges()) {
         return; // user cancelled — keep the current map instead of loading over it
     }
-    spdlog::info("MainWindow: Handling request to load map: {} (filesystem: {})", mapPath, forceFilesystem);
+    spdlog::debug("MainWindow: Handling request to load map: {} (filesystem: {})", mapPath, forceFilesystem);
 
     auto loadingWidget = std::make_unique<LoadingWidget>(this);
     loadingWidget->setWindowTitle("Loading Map");
@@ -1611,7 +1611,7 @@ void MainWindow::handleMapLoadRequest(const std::string& mapPath, bool forceFile
 
     loadingWidget->exec();
 
-    spdlog::info("Map loading completed from MainWindow");
+    spdlog::debug("Map loading completed from MainWindow");
 }
 
 void MainWindow::setupPanelsMenu() {
@@ -1891,7 +1891,7 @@ void MainWindow::closeCurrentMap() {
         return;
     }
 
-    spdlog::info("Closing current map due to data path changes");
+    spdlog::debug("Closing current map due to data path changes");
 
     stopGameLoop();
 
@@ -1924,9 +1924,9 @@ void MainWindow::showPreferences() {
     int result = dialog.exec();
 
     if (result == QDialog::Accepted) {
-        spdlog::info("Settings dialog closed with changes");
+        spdlog::debug("Settings dialog closed with changes");
     } else {
-        spdlog::info("Settings dialog cancelled");
+        spdlog::debug("Settings dialog cancelled");
     }
 
     showFileBrowserPanel();

--- a/src/ui/dialogs/InventoryViewerDialog.cpp
+++ b/src/ui/dialogs/InventoryViewerDialog.cpp
@@ -357,7 +357,7 @@ void InventoryViewerDialog::onAddItemClicked() {
         populateInventoryTree();
         updateStatusLabel();
 
-        spdlog::info("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", pid, amount);
+        spdlog::debug("InventoryViewerDialog: Added item PID 0x{:08X} with amount {} to inventory", pid, amount);
 
     } catch (const std::exception& e) {
         QMessageBox::warning(this, "Error", QString("Failed to add item: %1").arg(e.what()));
@@ -404,7 +404,7 @@ void InventoryViewerDialog::onRemoveItemClicked() {
 
         _removeButton->setEnabled(false);
 
-        spdlog::info("InventoryViewerDialog: Removed item PID 0x{:08X} (display amount {}) from inventory", removedPid, displayAmount);
+        spdlog::debug("InventoryViewerDialog: Removed item PID 0x{:08X} (display amount {}) from inventory", removedPid, displayAmount);
 
     } catch (const std::exception& e) {
         QMessageBox::warning(this, "Error", QString("Failed to remove item: %1").arg(e.what()));

--- a/src/ui/dialogs/ProEditorDialog.cpp
+++ b/src/ui/dialogs/ProEditorDialog.cpp
@@ -265,7 +265,7 @@ void ProEditorDialog::onAccept() {
         try {
             std::filesystem::copy_file(savePath, backupPath,
                 std::filesystem::copy_options::overwrite_existing);
-            spdlog::info("Created backup: {}", backupPath.string());
+            spdlog::debug("Created backup: {}", backupPath.string());
         } catch (const std::exception& e) {
             spdlog::warn("Failed to create backup: {}", e.what());
         }

--- a/src/ui/dialogs/SettingsDialog.cpp
+++ b/src/ui/dialogs/SettingsDialog.cpp
@@ -248,7 +248,7 @@ void SettingsDialog::saveSettings() {
     _hasChanges = false;
 
     setMainStatus("Settings saved successfully", "success");
-    spdlog::info("Settings saved from preferences dialog");
+    spdlog::debug("Settings saved from preferences dialog");
 
     Q_EMIT settingsSaved(pathsHaveChanged);
 }

--- a/src/ui/input/InputHandler.cpp
+++ b/src/ui/input/InputHandler.cpp
@@ -107,22 +107,22 @@ void InputHandler::handleMousePressed(const sf::Event::MouseButtonPressed& event
             if (_callbacks.onTilePlacementCancel) {
                 _callbacks.onTilePlacementCancel();
             }
-            spdlog::info("Tile placement mode cancelled with right-click");
+            spdlog::debug("Tile placement mode cancelled with right-click");
         } else if (_mode == EditorMode::PlaceExitGrid) {
             _mode = EditorMode::Select;
-            spdlog::info("Exit grid placement mode cancelled with right-click");
+            spdlog::debug("Exit grid placement mode cancelled with right-click");
         } else if (_mode == EditorMode::MarkExits) {
             _mode = EditorMode::Select;
             if (_callbacks.onMarkExitsModeCancelled) {
                 _callbacks.onMarkExitsModeCancelled();
             }
-            spdlog::info("Mark exits mode cancelled with right-click");
+            spdlog::debug("Mark exits mode cancelled with right-click");
         } else if (_mode == EditorMode::StampPattern) {
             _mode = EditorMode::Select;
             if (_callbacks.onStampPatternCancel) {
                 _callbacks.onStampPatternCancel();
             }
-            spdlog::info("Stamp pattern mode cancelled with right-click");
+            spdlog::debug("Stamp pattern mode cancelled with right-click");
         } else {
             _currentAction = EditorAction::PANNING;
             _mouseStartPos = event.position;

--- a/src/ui/panels/FileBrowserPanel.cpp
+++ b/src/ui/panels/FileBrowserPanel.cpp
@@ -96,7 +96,7 @@ FileLoaderWorker::FileLoaderWorker(std::shared_ptr<resource::GameResources> reso
 
 void FileLoaderWorker::loadFiles() {
     try {
-        spdlog::info("FileLoaderWorker: Starting background file loading...");
+        spdlog::debug("FileLoaderWorker: Starting background file loading...");
         Q_EMIT loadingProgress(0, 100, "Initializing file system...");
 
         spdlog::debug("FileLoaderWorker: Listing mounted files...");
@@ -150,7 +150,7 @@ void FileLoaderWorker::loadFiles() {
         spdlog::debug("FileLoaderWorker: Emitting filesLoaded with {} files", allFiles.size());
         Q_EMIT filesLoaded(allFiles);
 
-        spdlog::info("FileLoaderWorker: Loaded {} files with {} file types",
+        spdlog::debug("FileLoaderWorker: Loaded {} files with {} file types",
             allFiles.size(), fileTypes.size());
 
         Q_EMIT loadingComplete();
@@ -438,7 +438,7 @@ void FileBrowserPanel::loadFiles() {
     connect(_loaderWorker, &FileLoaderWorker::loadingComplete, _loaderThread, &QThread::quit, Qt::QueuedConnection);
 
     spdlog::debug("FileBrowserPanel: Worker signals connected");
-    spdlog::info("FileBrowserPanel: Starting background file loading...");
+    spdlog::debug("FileBrowserPanel: Starting background file loading...");
     _loaderThread->start();
 }
 
@@ -637,7 +637,7 @@ void FileBrowserPanel::updateFileCount() {
 }
 
 void FileBrowserPanel::refreshFileList() {
-    spdlog::info("FileBrowserPanel: Refreshing file list");
+    spdlog::debug("FileBrowserPanel: Refreshing file list");
     loadFiles();
 }
 
@@ -717,7 +717,7 @@ void FileBrowserPanel::onTreeItemDoubleClicked(const QModelIndex& index) {
 
     if (treeItem && treeItem->getType() == FileTreeItem::File) {
         QString filePath = treeItem->getFilePath();
-        spdlog::info("FileBrowserPanel: File double-clicked with path: '{}'", filePath.toStdString());
+        spdlog::debug("FileBrowserPanel: File double-clicked with path: '{}'", filePath.toStdString());
 
         if (filePath.endsWith(".pro", Qt::CaseInsensitive)) {
             spdlog::debug("FileBrowserPanel: Opening PRO editor for double-clicked file: {}", filePath.toStdString());
@@ -740,7 +740,7 @@ void FileBrowserPanel::updateFileDisplay() {
 void FileBrowserPanel::onFilesLoaded(const std::vector<std::string>& files) {
     spdlog::debug("FileBrowserPanel::onFilesLoaded called with {} files", files.size());
     _allFiles = files;
-    spdlog::info("FileBrowserPanel: Received {} files from background loader", files.size());
+    spdlog::debug("FileBrowserPanel: Received {} files from background loader", files.size());
 
     buildFileTreeProgressive(files);
 }
@@ -784,7 +784,7 @@ void FileBrowserPanel::buildFileTreeProgressive(const std::vector<std::string>& 
         filteredFiles.push_back(file);
     }
 
-    spdlog::info("FileBrowserPanel: Starting progressive build of {} filtered files", filteredFiles.size());
+    spdlog::debug("FileBrowserPanel: Starting progressive build of {} filtered files", filteredFiles.size());
     startProgressiveTreeBuild(filteredFiles);
 }
 
@@ -818,7 +818,7 @@ void FileBrowserPanel::processNextChunk() {
         resizeNameColumnToContent();
         updateFileCount();
 
-        spdlog::info("FileBrowserPanel: Progressive tree building completed");
+        spdlog::debug("FileBrowserPanel: Progressive tree building completed");
         return;
     }
 
@@ -960,7 +960,7 @@ void FileBrowserPanel::exportFile(const QString& filePath) {
         }
 
         _statusLabel->setText(QString("Exported %1 (%2 bytes)").arg(fileInfo.fileName()).arg(bytesWritten));
-        spdlog::info("FileBrowserPanel: Exported {} to {} ({} bytes)",
+        spdlog::debug("FileBrowserPanel: Exported {} to {} ({} bytes)",
             filePath.toStdString(), saveFilePath.toStdString(), bytesWritten);
 
         Q_EMIT fileExportRequested(filePath);
@@ -983,7 +983,7 @@ void FileBrowserPanel::executeScript(const QString& filePath) {
 
     const QString source = QString::fromUtf8(reinterpret_cast<const char*>(buffer->data()),
         static_cast<qsizetype>(buffer->size()));
-    spdlog::info("FileBrowserPanel: Loading script into the console: {}", filePath.toStdString());
+    spdlog::debug("FileBrowserPanel: Loading script into the console: {}", filePath.toStdString());
     Q_EMIT executeScriptRequested(source);
 }
 

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -837,7 +837,7 @@ void MapInfoPanel::onElevationCheckboxChanged() {
         }
 
         Q_EMIT elevationAdded(elevation);
-        spdlog::info("MapInfoPanel: Added {} to map", elevationName.toStdString());
+        spdlog::debug("MapInfoPanel: Added {} to map", elevationName.toStdString());
 
         updateElevationCheckboxStates();
 
@@ -873,7 +873,7 @@ void MapInfoPanel::onElevationCheckboxChanged() {
             }
 
             Q_EMIT elevationRemoved(elevation);
-            spdlog::info("MapInfoPanel: Removed {} from map", elevationName.toStdString());
+            spdlog::debug("MapInfoPanel: Removed {} from map", elevationName.toStdString());
 
             updateElevationCheckboxStates();
 
@@ -1042,7 +1042,7 @@ void MapInfoPanel::writeNameEdits(const std::filesystem::path& writableRoot, int
         _resources.repository().clear();
         _mapNames = std::make_unique<resource::MapNameResolver>(_resources);
         updateMapNameDisplay();
-        spdlog::info("MapInfoPanel: saved map names to {}", writableRoot.string());
+        spdlog::debug("MapInfoPanel: saved map names to {}", writableRoot.string());
     } catch (const std::exception& e) {
         QMessageBox::warning(this, "Save Map Names", QString("Failed to save map names:\n%1").arg(e.what()));
     }

--- a/src/ui/panels/ObjectPalettePanel.cpp
+++ b/src/ui/panels/ObjectPalettePanel.cpp
@@ -79,7 +79,7 @@ ObjectPalettePanel::ObjectPalettePanel(resource::GameResources& resources, QWidg
     : GridPalettePanel("Objects", parent)
     , _resources(resources) {
     setupUI();
-    spdlog::info("ObjectPalettePanel: Created object palette panel");
+    spdlog::debug("ObjectPalettePanel: Created object palette panel");
 }
 
 ObjectPalettePanel::~ObjectPalettePanel() {
@@ -171,7 +171,7 @@ void ObjectPalettePanel::setupPaginationControls() {
 }
 
 void ObjectPalettePanel::loadObjects() {
-    spdlog::info("ObjectPalettePanel: Loading objects from LST files");
+    spdlog::debug("ObjectPalettePanel: Loading objects from LST files");
 
     loadCategoryObjects(_currentCategory);
     updateObjectGrid();
@@ -242,7 +242,7 @@ void ObjectPalettePanel::loadCategoryObjects(ObjectCategory category) {
             }
         }
 
-        spdlog::info("ObjectPalettePanel: Loaded {} objects for category {} from {}",
+        spdlog::debug("ObjectPalettePanel: Loaded {} objects for category {} from {}",
             loadedCount, getCategoryDisplayName(category).toStdString(), lstPath.toStdString());
 
     } catch (const std::exception& e) {
@@ -339,7 +339,7 @@ void ObjectPalettePanel::updateObjectGrid() {
 
     GridPalettePanel::updatePaginationControls();
 
-    spdlog::info("ObjectPalettePanel: Loaded {} object widgets for category {}",
+    spdlog::debug("ObjectPalettePanel: Loaded {} object widgets for category {}",
         objectsLoaded, getCategoryDisplayName(_currentCategory).toStdString());
 }
 

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -863,7 +863,7 @@ void SelectionPanel::onChangeFrmClicked() {
     const auto objectTypeFilter = FrmSelectorDialog::filterForFid(currentFrmPid);
     dialog.setObjectTypeFilter(objectTypeFilter);
     if (objectTypeFilter.has_value()) {
-        spdlog::info("SelectionPanel: Filtering FRM dialog by object type: {}", static_cast<int>(*objectTypeFilter));
+        spdlog::debug("SelectionPanel: Filtering FRM dialog by object type: {}", static_cast<int>(*objectTypeFilter));
     }
 
     if (dialog.exec() == QDialog::Accepted) {
@@ -900,13 +900,13 @@ void SelectionPanel::onChangeFrmClicked() {
 
                         // Update the visual but keep the original frm_pid for game compatibility:
                         // the editor shows the new FRM while the saved map stays loadable in-game.
-                        spdlog::info("SelectionPanel: Keeping original frm_pid {} for game compatibility, visual uses custom FRM", currentFrmPid);
+                        spdlog::debug("SelectionPanel: Keeping original frm_pid {} for game compatibility, visual uses custom FRM", currentFrmPid);
 
                         Q_EMIT statusMessage(QString("Warning: Custom FRM may not display correctly in game"));
                     } else {
                         // Valid LST-based FID, safe to persist.
                         mapObject.frm_pid = derivedFrmPid;
-                        spdlog::info("SelectionPanel: Updated MapObject frm_pid from {} to {} for persistent save",
+                        spdlog::debug("SelectionPanel: Updated MapObject frm_pid from {} to {} for persistent save",
                             currentFrmPid, derivedFrmPid);
                     }
 
@@ -932,7 +932,7 @@ void SelectionPanel::onChangeFrmClicked() {
                 // compatibility while still showing the new FRM in the editor.
                 if ((currentFrmPid >> 24) == 1) { // FID type field 1 == critter
                     spdlog::warn("SelectionPanel: FRM '{}' not found in critters.lst - change may not persist in game", filename);
-                    spdlog::info("SelectionPanel: Keeping original FRM PID ({}) for game compatibility", currentFrmPid);
+                    spdlog::debug("SelectionPanel: Keeping original FRM PID ({}) for game compatibility", currentFrmPid);
 
                     Q_EMIT statusMessage(QString("Warning: FRM '%1' may not display correctly in game - not found in critters.lst")
                             .arg(QString::fromStdString(filename)));
@@ -945,7 +945,7 @@ void SelectionPanel::onChangeFrmClicked() {
                 updateObjectInfo();
             }
 
-            spdlog::info("SelectionPanel: Changed object FRM visual to path: {}", newFrmPath);
+            spdlog::debug("SelectionPanel: Changed object FRM visual to path: {}", newFrmPath);
 
             // Keep the object highlighted after the FRM change. Delay via a single-shot
             // timer so the texture update is fully processed before re-highlighting.

--- a/src/ui/panels/TilePalettePanel.cpp
+++ b/src/ui/panels/TilePalettePanel.cpp
@@ -174,7 +174,7 @@ void TilePalettePanel::loadTiles(const Lst* tileList) {
 
     _tileList = tileList;
 
-    spdlog::info("TilePalettePanel: Loading {} tiles", tileList->list().size());
+    spdlog::debug("TilePalettePanel: Loading {} tiles", tileList->list().size());
 
     int maxTiles = static_cast<int>(tileList->list().size()) - 1;
     _startTileSpinBox->setMaximum(maxTiles);
@@ -320,7 +320,7 @@ void TilePalettePanel::updateTileGrid() {
 
     GridPalettePanel::updatePaginationControls();
 
-    spdlog::info("TilePalettePanel: Loaded {} tile widgets", tilesLoaded);
+    spdlog::debug("TilePalettePanel: Loaded {} tile widgets", tilesLoaded);
 }
 
 void TilePalettePanel::filterTiles() {

--- a/src/ui/widgets/GameLocationWidget.cpp
+++ b/src/ui/widgets/GameLocationWidget.cpp
@@ -177,7 +177,7 @@ void GameLocationWidget::onBrowseExecutable() {
         if (_dataDirectoryEdit->text().trimmed().isEmpty()) {
             if (const auto dataDirectory = util::resolveGameDataRoot(std::filesystem::path(selectedFile.toStdString()))) {
                 _dataDirectoryEdit->setText(QString::fromStdString(dataDirectory->string()));
-                spdlog::info("Auto-set data directory to: {}", dataDirectory->string());
+                spdlog::debug("Auto-set data directory to: {}", dataDirectory->string());
             }
         }
 
@@ -207,7 +207,7 @@ void GameLocationWidget::onBrowseExecutable() {
             QFileInfo fileInfo(selectedFile);
             QString parentDir = fileInfo.dir().absolutePath();
             _dataDirectoryEdit->setText(parentDir);
-            spdlog::info("Auto-set data directory to: {}", parentDir.toStdString());
+            spdlog::debug("Auto-set data directory to: {}", parentDir.toStdString());
         }
 
         validateGameLocation(selectedFile);

--- a/src/ui/widgets/LoadingWidget.cpp
+++ b/src/ui/widgets/LoadingWidget.cpp
@@ -94,7 +94,7 @@ void LoadingWidget::start() {
     // 30 FPS for smooth progress updates
     _updateTimer->start(UI::TIMER_INTERVAL_MS);
 
-    spdlog::info("LoadingWidget started with {} loaders", _loaders.size());
+    spdlog::debug("LoadingWidget started with {} loaders", _loaders.size());
 }
 
 void LoadingWidget::updateProgress() {
@@ -150,7 +150,7 @@ void LoadingWidget::updateProgress() {
         _isLoading = false;
         _progressBar->setValue(100);
         _statusLabel->setText("Complete");
-        spdlog::info("LoadingWidget completed all loaders");
+        spdlog::debug("LoadingWidget completed all loaders");
 
         // Delay so the completed (100%) state is briefly visible before closing
         QTimer::singleShot(200, this, [this]() {

--- a/src/writer/map/MapWriter.cpp
+++ b/src/writer/map/MapWriter.cpp
@@ -169,7 +169,7 @@ bool MapWriter::write(const Map::MapFile& map) {
         // utils.writeBE32(0);
 
         utils.flush();
-        spdlog::info("Successfully wrote map file: {} ({} bytes)", getPath().filename().string(), getBytesWritten());
+        spdlog::debug("Successfully wrote map file: {} ({} bytes)", getPath().filename().string(), getBytesWritten());
         return true;
 
     } catch (const FileWriterException& e) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 # Pattern stamp (de)serialization round-trip — needs gecko_cli (cli::serializePattern/loadPattern),
 # no scripting or game data.
 if(TARGET gecko_cli)
-    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp)
+    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp general/test_map_analyzer_scripts.cpp)
     target_link_libraries(general_tests PRIVATE gecko_cli)
 endif()
 

--- a/tests/general/test_map_analyzer_scripts.cpp
+++ b/tests/general/test_map_analyzer_scripts.cpp
@@ -34,6 +34,28 @@ const json* findScript(const json& scripts, const std::string& section) {
     return nullptr;
 }
 
+// Write `mapFile` to a temp .map and return analyze's parsed JSON. No game data is mounted, so analyze
+// reads the file back via cli::loadMap's disk fallback. Shared by the cases below.
+json analyzeWrittenMap(Map::MapFile mapFile, const char* mapName, const char* tempPrefix, StubProvider& provider) {
+    Map map{ mapName };
+    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
+
+    TempFile out{ tempPrefix, ".map" };
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(out.path());
+        REQUIRE(writer.write(map.getMapFile()));
+    } // flush + close before analyze reads it back
+
+    resource::GameResources resources;
+    cli::AnalyzeOptions options;
+    options.json = true;
+    options.maps = { out.path().string() };
+    std::ostringstream jsonOut;
+    REQUIRE(cli::analyzeMaps(resources, options, jsonOut) == 0);
+    return json::parse(jsonOut.str());
+}
+
 } // namespace
 
 // analyze emits a per-map `scripts` list (mirroring the editor's Scripts panel) covering every
@@ -89,26 +111,7 @@ TEST_CASE("analyze surfaces per-section scripts with their local variables", "[c
     critter->map_scripts_pid = static_cast<int32_t>(critterSid);
     mapFile.map_objects[0].push_back(critter);
 
-    Map map{ "synthetic.map" };
-    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
-
-    TempFile out{ "geck_analyze_scripts", ".map" };
-    const auto path = out.path();
-    {
-        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
-        writer.openFile(path);
-        REQUIRE(writer.write(map.getMapFile()));
-    } // flush + close before analyze reads it back
-
-    // analyze reads the .map straight off disk (the cli::loadMap fallback), so no data need be mounted.
-    resource::GameResources resources;
-    cli::AnalyzeOptions options;
-    options.json = true;
-    options.maps = { path.string() };
-    std::ostringstream jsonOut;
-    REQUIRE(cli::analyzeMaps(resources, options, jsonOut) == 0);
-
-    const json root = json::parse(jsonOut.str());
+    const json root = analyzeWrittenMap(std::move(mapFile), "synthetic.map", "geck_analyze_scripts", provider);
     REQUIRE(root["maps"].is_array());
     REQUIRE(root["maps"].size() == 1);
     const json& entry = root["maps"][0];
@@ -174,25 +177,7 @@ TEST_CASE("analyze clamps a script's local-var slice to the pool", "[cli][analyz
     system.local_var_count = 5; // stale: only one value (index 1) actually exists
     mapFile.map_scripts[static_cast<int>(MapScript::ScriptType::SYSTEM)].push_back(system);
 
-    Map map{ "synthetic_clamp.map" };
-    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
-
-    TempFile out{ "geck_analyze_scripts_clamp", ".map" };
-    const auto path = out.path();
-    {
-        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
-        writer.openFile(path);
-        REQUIRE(writer.write(map.getMapFile()));
-    }
-
-    resource::GameResources resources;
-    cli::AnalyzeOptions options;
-    options.json = true;
-    options.maps = { path.string() };
-    std::ostringstream jsonOut;
-    REQUIRE(cli::analyzeMaps(resources, options, jsonOut) == 0);
-
-    const json root = json::parse(jsonOut.str());
+    const json root = analyzeWrittenMap(std::move(mapFile), "synthetic_clamp.map", "geck_analyze_scripts_clamp", provider);
     const json& scripts = root["maps"][0]["scripts"];
     REQUIRE(scripts.size() == 1);
     CHECK(scripts[0]["localVars"] == json::array({ 2 })); // only the in-range value, not five

--- a/tests/general/test_map_analyzer_scripts.cpp
+++ b/tests/general/test_map_analyzer_scripts.cpp
@@ -1,0 +1,199 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "cli/MapAnalyzer.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+#include "writer/map/MapWriter.h"
+
+#include "support/ProStubProvider.h"
+#include "support/TempFile.h"
+
+using nlohmann::json;
+using namespace geck;
+using namespace geck::test;
+
+namespace {
+
+// Find the first scripts[] entry whose section matches `section`.
+const json* findScript(const json& scripts, const std::string& section) {
+    for (const auto& entry : scripts) {
+        if (entry.at("section") == section) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// analyze emits a per-map `scripts` list (mirroring the editor's Scripts panel) covering every
+// section, each script's resolved program index, owner object, section-specific radius/timer, and
+// its slice of the map's local-variable pool — and a critter's attached `script` carries the same
+// localVars. Built on a synthetic .map written headlessly (no game data mounted): scrname.msg names
+// don't resolve, so this asserts the structural fields, not the friendly names.
+TEST_CASE("analyze surfaces per-section scripts with their local variables", "[cli][analyze][scripts]") {
+    StubProvider provider;
+    const uint32_t critterPid = pidOf(Pro::OBJECT_TYPE::CRITTER, 50);
+
+    auto mapFile = Map::createEmptyMapFile();
+
+    // A flat LVAR pool shared by every script; each script owns a [offset, offset+count) slice.
+    mapFile.map_local_vars = { 11, 22, 33, 44, 55, 66, 77 };
+    mapFile.header.num_local_vars = static_cast<uint32_t>(mapFile.map_local_vars.size());
+
+    // System script (section 0): program index 7, locals {11,22,33}. No owner object.
+    MapScript system{};
+    system.pid = MapScript::makeSid(MapScript::ScriptType::SYSTEM, 0);
+    system.script_id = 7;
+    system.script_oid = MapScript::NONE; // -> ownerObject null
+    system.local_var_offset = 0;
+    system.local_var_count = 3;
+    mapFile.map_scripts[static_cast<int>(MapScript::ScriptType::SYSTEM)].push_back(system);
+
+    // Spatial script (section 1): program index 9, radius 4, locals {44,55}.
+    MapScript spatial{};
+    spatial.pid = MapScript::makeSid(MapScript::ScriptType::SPATIAL, 0);
+    spatial.script_id = 9;
+    spatial.script_oid = 0; // 0 == none -> ownerObject null
+    spatial.spatial_radius = 4;
+    spatial.local_var_offset = 3;
+    spatial.local_var_count = 2;
+    mapFile.map_scripts[static_cast<int>(MapScript::ScriptType::SPATIAL)].push_back(spatial);
+
+    // Critter script (section 4): program index 12, owner object 1234, locals {66,77}. A critter
+    // object points at it through its map_scripts_pid (== this script's SID/pid).
+    const uint32_t critterSid = MapScript::makeSid(MapScript::ScriptType::CRITTER, 0);
+    MapScript critterScript{};
+    critterScript.pid = critterSid;
+    critterScript.script_id = 12;
+    critterScript.script_oid = 1234;
+    critterScript.local_var_offset = 5;
+    critterScript.local_var_count = 2;
+    mapFile.map_scripts[static_cast<int>(MapScript::ScriptType::CRITTER)].push_back(critterScript);
+
+    // The critter instance carrying that script.
+    auto critter = std::make_shared<MapObject>();
+    critter->pro_pid = critterPid;
+    critter->elevation = 0;
+    critter->position = 100 * 200 + 100;
+    critter->map_scripts_pid = static_cast<int32_t>(critterSid);
+    mapFile.map_objects[0].push_back(critter);
+
+    Map map{ "synthetic.map" };
+    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
+
+    TempFile out{ "geck_analyze_scripts", ".map" };
+    const auto path = out.path();
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(path);
+        REQUIRE(writer.write(map.getMapFile()));
+    } // flush + close before analyze reads it back
+
+    // analyze reads the .map straight off disk (the cli::loadMap fallback), so no data need be mounted.
+    resource::GameResources resources;
+    cli::AnalyzeOptions options;
+    options.json = true;
+    options.maps = { path.string() };
+    std::ostringstream jsonOut;
+    REQUIRE(cli::analyzeMaps(resources, options, jsonOut) == 0);
+
+    const json root = json::parse(jsonOut.str());
+    REQUIRE(root["maps"].is_array());
+    REQUIRE(root["maps"].size() == 1);
+    const json& entry = root["maps"][0];
+
+    REQUIRE(entry.contains("scripts"));
+    const json& scripts = entry["scripts"];
+    REQUIRE(scripts.is_array());
+    REQUIRE(scripts.size() == 3);
+
+    SECTION("the System script reports its program index and local vars, no owner") {
+        const json* s = findScript(scripts, "System");
+        REQUIRE(s != nullptr);
+        CHECK((*s)["programIndex"] == 7);
+        CHECK((*s)["ownerObject"].is_null());
+        CHECK_FALSE(s->contains("spatialRadius")); // only on Spatial
+        CHECK_FALSE(s->contains("timerMs"));       // only on Timer
+        CHECK((*s)["localVars"] == json::array({ 11, 22, 33 }));
+    }
+
+    SECTION("the Spatial script carries spatialRadius and its own slice") {
+        const json* s = findScript(scripts, "Spatial");
+        REQUIRE(s != nullptr);
+        CHECK((*s)["programIndex"] == 9);
+        CHECK((*s)["ownerObject"].is_null()); // script_oid 0 == none
+        CHECK(s->contains("spatialRadius"));
+        CHECK((*s)["spatialRadius"] == 4);
+        CHECK_FALSE(s->contains("timerMs"));
+        CHECK((*s)["localVars"] == json::array({ 44, 55 }));
+    }
+
+    SECTION("the Critter script reports its owner object and slice") {
+        const json* s = findScript(scripts, "Critter");
+        REQUIRE(s != nullptr);
+        CHECK((*s)["programIndex"] == 12);
+        CHECK((*s)["ownerObject"] == 1234);
+        CHECK((*s)["localVars"] == json::array({ 66, 77 }));
+    }
+
+    SECTION("the critter's attached script includes the same local vars") {
+        REQUIRE(entry["critters"].is_array());
+        REQUIRE(entry["critters"].size() == 1);
+        const json& attached = entry["critters"][0]["script"];
+        REQUIRE(attached.is_object());
+        CHECK(attached["programIndex"] == 12);
+        CHECK(attached["localVars"] == json::array({ 66, 77 }));
+    }
+}
+
+// A stale local_var_count (more than the pool holds) must never read past the LVAR vector: the
+// emitted slice stops at the pool's end rather than over-reading.
+TEST_CASE("analyze clamps a script's local-var slice to the pool", "[cli][analyze][scripts]") {
+    StubProvider provider;
+
+    auto mapFile = Map::createEmptyMapFile();
+    mapFile.map_local_vars = { 1, 2 };
+    mapFile.header.num_local_vars = static_cast<uint32_t>(mapFile.map_local_vars.size());
+
+    MapScript system{};
+    system.pid = MapScript::makeSid(MapScript::ScriptType::SYSTEM, 0);
+    system.script_id = 3;
+    system.script_oid = MapScript::NONE;
+    system.local_var_offset = 1;
+    system.local_var_count = 5; // stale: only one value (index 1) actually exists
+    mapFile.map_scripts[static_cast<int>(MapScript::ScriptType::SYSTEM)].push_back(system);
+
+    Map map{ "synthetic_clamp.map" };
+    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
+
+    TempFile out{ "geck_analyze_scripts_clamp", ".map" };
+    const auto path = out.path();
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(path);
+        REQUIRE(writer.write(map.getMapFile()));
+    }
+
+    resource::GameResources resources;
+    cli::AnalyzeOptions options;
+    options.json = true;
+    options.maps = { path.string() };
+    std::ostringstream jsonOut;
+    REQUIRE(cli::analyzeMaps(resources, options, jsonOut) == 0);
+
+    const json root = json::parse(jsonOut.str());
+    const json& scripts = root["maps"][0]["scripts"];
+    REQUIRE(scripts.size() == 1);
+    CHECK(scripts[0]["localVars"] == json::array({ 2 })); // only the in-range value, not five
+}


### PR DESCRIPTION
Three related commits — map-script tooling parity for the MCP, and a logging-noise cleanup that started from the `Unknown script PID = 204` report. Off `master` (independent of the #86 editor stack).

## 1. fix: stop erroring on garbage in script-padding slots
Script sections are padded to a multiple of 16 slots; the original mapper left non-zeroed garbage in the unused ones. The reader parses every slot (to advance) but keeps only the real scripts. A padding slot's garbage type byte (e.g. `204 = 0xCC`) hit `default:` and logged `spdlog::error` for a discarded slot — noise on many vanilla maps (newr1.map etc.). Now logged at debug; only a *real* script with an unknown type warns. (What closed PR #81 would have done.)

## 2. feat: expose a map's full script list + local variables in analyze
Brings the MCP/CLI `analyze` JSON to parity with the editor's Scripts panel. Each map gains a `scripts` array — every section's scripts with `{section, programIndex, name, filename, ownerObject, localVars}` (+ `spatialRadius` on Spatial, `timerMs` on Timer). Each critter's `script` also gains `localVars`. `localVars` is the script's slice of the map's LVAR pool, bounds-checked so a stale count can't over-read. Also made the analyzer's tiles.lst load tolerant so a bare/just-generated map analyzes instead of throwing. MCP tool description updated; `[cli][analyze][scripts]` tests added.

## 3. chore: quiet routine logging
Audited every info/warn/error spdlog call (multi-agent sweep, 87 left as genuine). **Removed 13** useless progress/confirmation lines; **downgraded 118** noisy-but-useful lines to debug/trace — routine flow (per map load, file open, selection/mode change, panel build) and per object/tile/frame, plus a few per-iteration data-validation warns (PAL/FRM/critter-FRM) that aren't failures. Genuine errors and one-time startup lines unchanged.

274 tests pass; full build green across all targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2