### PR TITLE
Exit grids: pick the destination map by name

### DIFF
--- a/src/resource/MapNameResolver.cpp
+++ b/src/resource/MapNameResolver.cpp
@@ -6,6 +6,9 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <cctype>
+
 namespace geck::resource {
 
 namespace {
@@ -48,6 +51,30 @@ std::string MapNameResolver::displayName(int mapIndex, int elevation) const {
 int MapNameResolver::indexOf(const std::string& mapFileName) const {
     const auto info = _doc.findByName(mapFileName); // findByName lowercases + normalizes internally
     return info.has_value() ? info->index : -1;
+}
+
+namespace {
+
+    bool lessByFileNameCi(const MapName& lhs, const MapName& rhs) {
+        const auto toLower = [](unsigned char c) { return std::tolower(c); };
+        return std::lexicographical_compare(
+            lhs.fileName.begin(), lhs.fileName.end(),
+            rhs.fileName.begin(), rhs.fileName.end(),
+            [&](unsigned char a, unsigned char b) { return toLower(a) < toLower(b); });
+    }
+
+} // namespace
+
+std::vector<MapName> MapNameResolver::allMaps() const {
+    std::vector<MapName> maps;
+    for (const auto& section : _doc.sections) {
+        if (section.index < 0) {
+            continue; // skip non-Map sections and any negative sentinels
+        }
+        maps.push_back({ section.index, fileNameOf(section.index), displayName(section.index, 0) });
+    }
+    std::sort(maps.begin(), maps.end(), lessByFileNameCi);
+    return maps;
 }
 
 std::string MapNameResolver::fileNameOfLookup(const std::string& lookupName) const {

--- a/src/resource/MapNameResolver.h
+++ b/src/resource/MapNameResolver.h
@@ -3,10 +3,19 @@
 #include "format/maps/MapsTxt.h"
 
 #include <string>
+#include <vector>
 
 namespace geck::resource {
 
 class GameResources;
+
+/// One map entry for the by-name destination picker: its maps.txt index plus the resolved .map
+/// filename and the primary (elevation 0) map.msg display name.
+struct MapName {
+    int index = -1;
+    std::string fileName;
+    std::string displayName;
+};
 
 /// Resolves Fallout 2 map identifiers to names, from the mounted game data:
 ///  - the **.map filename** for a map index, via the `data/maps.txt` document;
@@ -29,6 +38,12 @@ public:
 
     /// The maps.txt index for a .map filename (basename, any case), or -1 if absent.
     int indexOf(const std::string& mapFileName) const;
+
+    /// Every `[Map N]` section with a non-negative index, as `{ index, fileNameOf(index),
+    /// displayName(index, 0) }`, sorted by filename (case-insensitive). The single source for the
+    /// editor's by-name destination-map picker, so the index↔name rules stay here. Empty when no
+    /// maps.txt is mounted.
+    std::vector<MapName> allMaps() const;
 
     /// The .map filename for a maps.txt lookup_name (city.txt's entrance map key, e.g. "Arroyo
     /// Bridge"), case-insensitive, or "" if no map has that lookup_name. The join from the worldmap

--- a/src/ui/dialogs/ExitGridPropertiesDialog.cpp
+++ b/src/ui/dialogs/ExitGridPropertiesDialog.cpp
@@ -7,9 +7,12 @@
 #include "resource/MapNameResolver.h"
 
 #include <QApplication>
+#include <QCompleter>
 #include <QStyle>
 #include <QMessageBox>
 #include <spdlog/spdlog.h>
+
+#include <vector>
 
 namespace geck {
 
@@ -20,11 +23,10 @@ ExitGridPropertiesDialog::ExitGridPropertiesDialog(QWidget* parent, const resour
     , _mainLayout(nullptr)
     , _formLayout(nullptr)
     , _buttonBox(nullptr)
-    , _mapIdSpinBox(nullptr)
+    , _mapComboBox(nullptr)
     , _positionSpinBox(nullptr)
     , _elevationComboBox(nullptr)
     , _orientationComboBox(nullptr)
-    , _mapNameLabel(nullptr)
     , _statusLabel(nullptr)
     , _names(names) {
 
@@ -67,28 +69,27 @@ void ExitGridPropertiesDialog::setupFormLayout() {
 
     // World map exit checkbox (-2)
     _exitToWorldmapCheckBox = new QCheckBox("Exit to world map", this);
+    _exitToWorldmapCheckBox->setObjectName("exitToWorldmap");
     _exitToWorldmapCheckBox->setToolTip("Exit leads to world map (map ID -2)");
     connect(_exitToWorldmapCheckBox, &QCheckBox::toggled, this, &ExitGridPropertiesDialog::onExitToWorldmapToggled);
     _formLayout->addRow(_exitToWorldmapCheckBox);
 
     // Town map exit checkbox (-1) - mutually exclusive with world map
     _townMapCheckBox = new QCheckBox("Exit to town map", this);
+    _townMapCheckBox->setObjectName("exitToTownmap");
     _townMapCheckBox->setToolTip("Exit leads to town map (map ID -1)");
     connect(_townMapCheckBox, &QCheckBox::toggled, this, &ExitGridPropertiesDialog::onTownMapToggled);
     _formLayout->addRow(_townMapCheckBox);
 
-    // Map ID input
-    _mapIdSpinBox = new QSpinBox(this);
-    _mapIdSpinBox->setRange(-2, 999999); // Allow -2 for worldmap exits
-    _mapIdSpinBox->setToolTip("Destination map ID (-2 = worldmap, 0-999999 = specific map)");
-    _formLayout->addRow("Destination Map ID:", _mapIdSpinBox);
-
-    // Resolved destination-map name (filename · friendly map.msg name), shown under the map ID when a
-    // MapNameResolver is supplied; stays hidden otherwise (e.g. no game data mounted).
-    _mapNameLabel = new QLabel(this);
-    _mapNameLabel->setStyleSheet(ui::theme::styles::mutedText());
-    _mapNameLabel->hide();
-    _formLayout->addRow("", _mapNameLabel);
+    // Destination map picker: a searchable by-name list of the mounted maps. The combo's edit field
+    // is for filtering only (NoInsert); the user picks an existing item.
+    _mapComboBox = new QComboBox(this);
+    _mapComboBox->setObjectName("destinationMap");
+    _mapComboBox->setEditable(true);
+    _mapComboBox->setInsertPolicy(QComboBox::NoInsert);
+    _mapComboBox->setToolTip("Destination map (type to search by filename or name)");
+    populateMapComboBox();
+    _formLayout->addRow("Destination Map:", _mapComboBox);
 
     // Position input (hex coordinate)
     _positionSpinBox = new QSpinBox(this);
@@ -119,18 +120,49 @@ void ExitGridPropertiesDialog::setupFormLayout() {
     _formLayout->addRow("Player Orientation:", _orientationComboBox);
 
     // Connect validation
-    connect(_mapIdSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+    connect(_mapComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
         this, &ExitGridPropertiesDialog::validateInput);
     connect(_elevationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
         this, &ExitGridPropertiesDialog::validateInput);
     connect(_orientationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
         this, &ExitGridPropertiesDialog::validateInput);
+}
 
-    // Keep the resolved destination-map name in sync with the map ID and elevation
-    connect(_mapIdSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
-        this, &ExitGridPropertiesDialog::updateMapName);
-    connect(_elevationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
-        this, &ExitGridPropertiesDialog::updateMapName);
+void ExitGridPropertiesDialog::populateMapComboBox() {
+    if (_names == nullptr) {
+        return; // no resolver (e.g. no game data mounted) -> the combo starts empty
+    }
+
+    const std::vector<resource::MapName> maps = _names->allMaps();
+    for (const auto& map : maps) {
+        QString text = QString::fromStdString(map.fileName);
+        if (!map.displayName.empty()) {
+            text += QString::fromUtf8(" \xC2\xB7 ") + QString::fromStdString(map.displayName); // " · "
+        }
+        _mapComboBox->addItem(text, QVariant(map.index));
+    }
+
+    // Filter the list as the user types: match anywhere, case-insensitively.
+    auto* completer = new QCompleter(_mapComboBox->model(), _mapComboBox);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    completer->setFilterMode(Qt::MatchContains);
+    completer->setCompletionMode(QCompleter::PopupCompletion);
+    _mapComboBox->setCompleter(completer);
+}
+
+// Select the combo item whose data == mapId. When no item matches (an unknown/unlisted destination,
+// or no resolver was supplied) insert a "Map <id>" entry carrying that id, so the value is preserved
+// and round-trips through getProperties() unchanged.
+void ExitGridPropertiesDialog::selectMap(uint32_t mapId) {
+    const int id = static_cast<int>(mapId);
+    for (int i = 0; i < _mapComboBox->count(); ++i) {
+        if (_mapComboBox->itemData(i).toInt() == id) {
+            _mapComboBox->setCurrentIndex(i);
+            return;
+        }
+    }
+    _mapComboBox->addItem(QString("Map %1").arg(id), QVariant(id));
+    _mapComboBox->setCurrentIndex(_mapComboBox->count() - 1);
 }
 
 void ExitGridPropertiesDialog::setupButtonBox() {
@@ -158,7 +190,10 @@ void ExitGridPropertiesDialog::updateUI() {
     _exitToWorldmapCheckBox->blockSignals(false);
     _townMapCheckBox->blockSignals(false);
 
-    _mapIdSpinBox->setValue(isTownMap ? -1 : (isWorldMap ? -2 : static_cast<int>(_properties.exitMap)));
+    // For specific-map exits, select the destination by id (inserting a "Map <id>" entry if it isn't
+    // listed). For world/town exits the combo is disabled below; still point it at a real map so the
+    // dialog has a sensible value if the user unchecks the box.
+    selectMap((isTownMap || isWorldMap) ? 0u : _properties.exitMap);
     _positionSpinBox->setValue(static_cast<int>(_properties.exitPosition));
 
     for (int i = 0; i < _elevationComboBox->count(); ++i) {
@@ -176,7 +211,6 @@ void ExitGridPropertiesDialog::updateUI() {
     }
 
     updateMapControlsEnabled();
-    updateMapName();
 
     // Run validation to enable/disable the OK button
     validateInput();
@@ -184,7 +218,14 @@ void ExitGridPropertiesDialog::updateUI() {
 
 ExitGridPropertiesDialog::ExitGridProperties ExitGridPropertiesDialog::getProperties() const {
     ExitGridProperties props;
-    props.exitMap = static_cast<uint32_t>(_mapIdSpinBox->value());
+    if (_exitToWorldmapCheckBox->isChecked()) {
+        props.exitMap = ExitGrid::WORLD_MAP_EXIT;
+    } else if (_townMapCheckBox->isChecked()) {
+        props.exitMap = ExitGrid::TOWN_MAP_EXIT;
+    } else {
+        // The selected map's index (the unknown-id fallback guarantees a current item with data).
+        props.exitMap = static_cast<uint32_t>(_mapComboBox->currentData().toInt());
+    }
     props.exitPosition = static_cast<uint32_t>(_positionSpinBox->value());
     props.exitElevation = _elevationComboBox->currentData().toUInt();
     props.exitOrientation = _orientationComboBox->currentData().toUInt();
@@ -209,34 +250,6 @@ void ExitGridPropertiesDialog::onPositionChanged() {
     validateInput();
 }
 
-void ExitGridPropertiesDialog::updateMapName() {
-    if (_names == nullptr) {
-        return; // no resolver (e.g. no game data mounted) -> leave the label hidden
-    }
-
-    const int mapId = _mapIdSpinBox->value();
-    QString text;
-    if (mapId == -2) { // ExitGrid::WORLD_MAP_EXIT, as the spin box represents it
-        text = "→ world map";
-    } else if (mapId == -1) { // ExitGrid::TOWN_MAP_EXIT
-        text = "→ town map";
-    } else {
-        const int elevation = _elevationComboBox->currentData().toInt();
-        const std::string file = _names->fileNameOf(mapId);
-        const std::string display = _names->displayName(mapId, elevation);
-        if (file.empty() && display.empty()) {
-            text = QString("→ map %1 (not in maps.txt)").arg(mapId);
-        } else {
-            text = "→ " + QString::fromStdString(file.empty() ? ("map " + std::to_string(mapId)) : file);
-            if (!display.empty()) {
-                text += " · " + QString::fromStdString(display);
-            }
-        }
-    }
-    _mapNameLabel->setText(text);
-    _mapNameLabel->show();
-}
-
 void ExitGridPropertiesDialog::validateInput() {
     bool valid = isValidInput();
     _buttonBox->button(QDialogButtonBox::Ok)->setEnabled(valid);
@@ -250,6 +263,13 @@ void ExitGridPropertiesDialog::validateInput() {
 }
 
 bool ExitGridPropertiesDialog::isValidInput() const {
+    // A world/town map exit is always a valid destination; otherwise the combo must carry a map index
+    // (the unknown-id fallback guarantees one whenever a specific-map exit is selected).
+    const bool isSpecialExit = _exitToWorldmapCheckBox->isChecked() || _townMapCheckBox->isChecked();
+    if (!isSpecialExit && !_mapComboBox->currentData().isValid()) {
+        return false;
+    }
+
     int position = _positionSpinBox->value();
     if (position < 0 || position >= HexagonGrid::POSITION_COUNT) { // hex position 0-39999
         return false;
@@ -275,16 +295,10 @@ void ExitGridPropertiesDialog::onExitToWorldmapToggled(bool checked) {
         _townMapCheckBox->setChecked(false);
         _townMapCheckBox->blockSignals(false);
 
-        // World map exit (map ID -2)
-        _mapIdSpinBox->setValue(-2);
+        // World map exit: a fixed spawn/orientation; getProperties() reports WORLD_MAP_EXIT.
         _positionSpinBox->setValue(0);
         _elevationComboBox->setCurrentIndex(0);   // Ground level
         _orientationComboBox->setCurrentIndex(0); // North
-    } else {
-        // Reset to specific map exit if it was a world/town map value
-        if (_mapIdSpinBox->value() < 0) {
-            _mapIdSpinBox->setValue(0);
-        }
     }
 
     updateMapControlsEnabled();
@@ -298,16 +312,10 @@ void ExitGridPropertiesDialog::onTownMapToggled(bool checked) {
         _exitToWorldmapCheckBox->setChecked(false);
         _exitToWorldmapCheckBox->blockSignals(false);
 
-        // Town map exit (map ID -1)
-        _mapIdSpinBox->setValue(-1);
+        // Town map exit: a fixed spawn/orientation; getProperties() reports TOWN_MAP_EXIT.
         _positionSpinBox->setValue(0);
         _elevationComboBox->setCurrentIndex(0);   // Ground level
         _orientationComboBox->setCurrentIndex(0); // North
-    } else {
-        // Reset to specific map exit if it was a world/town map value
-        if (_mapIdSpinBox->value() < 0) {
-            _mapIdSpinBox->setValue(0);
-        }
     }
 
     updateMapControlsEnabled();
@@ -317,7 +325,7 @@ void ExitGridPropertiesDialog::onTownMapToggled(bool checked) {
 void ExitGridPropertiesDialog::updateMapControlsEnabled() {
     // Disable map-specific controls when either world map or town map is checked
     bool isSpecificMapExit = !_exitToWorldmapCheckBox->isChecked() && !_townMapCheckBox->isChecked();
-    _mapIdSpinBox->setEnabled(isSpecificMapExit);
+    _mapComboBox->setEnabled(isSpecificMapExit);
     _positionSpinBox->setEnabled(isSpecificMapExit);
     _elevationComboBox->setEnabled(isSpecificMapExit);
     _orientationComboBox->setEnabled(isSpecificMapExit);

--- a/src/ui/dialogs/ExitGridPropertiesDialog.h
+++ b/src/ui/dialogs/ExitGridPropertiesDialog.h
@@ -22,14 +22,15 @@ namespace resource {
  * @brief Properties dialog for exit grid configuration
  *
  * Provides UI for setting the 4 essential exit grid properties:
- * - Destination map ID
+ * - Destination map (chosen by name)
  * - Player spawn position (hex coordinate)
  * - Destination elevation level
  * - Player orientation/direction
  *
- * When a MapNameResolver is supplied, the destination map ID is annotated with the resolved .map
- * filename and friendly map.msg name (from maps.txt / map.msg), so the editor shows "arcaves.map ·
- * Temple: Foyer" instead of a bare number.
+ * When a MapNameResolver is supplied, the destination map is chosen from a searchable list of the
+ * mounted maps by their .map filename and friendly map.msg name (from maps.txt / map.msg), so the
+ * editor shows "arcaves.map · Temple: Foyer" instead of a bare number. An exit pointing at a map ID
+ * that isn't listed (or any ID when no game data is mounted) is preserved as a "Map <id>" entry.
  */
 class ExitGridPropertiesDialog : public QDialog {
     Q_OBJECT
@@ -56,7 +57,6 @@ public slots:
 private slots:
     void onPositionChanged();
     void validateInput();
-    void updateMapName();
     void onExitToWorldmapToggled(bool checked);
     void onTownMapToggled(bool checked);
 
@@ -64,6 +64,8 @@ private:
     void setupUI();
     void setupFormLayout();
     void setupButtonBox();
+    void populateMapComboBox();
+    void selectMap(uint32_t mapId);
     void updateUI();
     void updateMapControlsEnabled();
     bool isValidInput() const;
@@ -76,13 +78,10 @@ private:
     // Input fields
     QCheckBox* _exitToWorldmapCheckBox;
     QCheckBox* _townMapCheckBox;
-    QSpinBox* _mapIdSpinBox;
+    QComboBox* _mapComboBox; // searchable by-name destination-map picker; item data = maps.txt index
     QSpinBox* _positionSpinBox;
     QComboBox* _elevationComboBox;
     QComboBox* _orientationComboBox;
-
-    // Resolved destination-map name shown under the map ID (filename · friendly name)
-    QLabel* _mapNameLabel;
 
     // Status
     QLabel* _statusLabel;

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -32,6 +32,7 @@
 #include "ui/core/EditorWidget.h"
 #include "ui/core/MainWindow.h"
 #include "ui/dialogs/CritterPropertiesDialog.h"
+#include "ui/dialogs/ExitGridPropertiesDialog.h"
 #include "ui/dialogs/InventoryViewerDialog.h"
 #include "ui/dialogs/ItemSelectorDialog.h"
 #include "ui/dialogs/ScriptSelectorDialog.h"
@@ -45,6 +46,8 @@
 #include "ui/widgets/pro/ProSceneryWidget.h"
 #include "ui/widgets/pro/ProWeaponWidget.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
+#include "util/Constants.h"
 #include "util/FalloutEngineEnums.h"
 #include "util/FileIo.h"
 #include "ui/Settings.h"
@@ -968,6 +971,112 @@ TEST_CASE("MapInfoPanel hints to add a writable Data Path when none is configure
     // anywhere hidden.
     CHECK_FALSE(hint->isHidden());
     CHECK(hint->text().contains("writable folder"));
+}
+
+// The exit-grid dialog's by-name destination-map picker. The fixture mounts a tiny maps.txt with two
+// maps (out of alphabetical order, to verify sorting) plus a negative-index section (to verify it is
+// skipped), and a matching map.msg so each map resolves a primary (elevation 0) display name.
+namespace {
+
+struct ExitGridFixture {
+    ResourceDataScope data;
+    std::unique_ptr<geck::resource::MapNameResolver> names;
+
+    ExitGridFixture() {
+        // Map 0 -> klamall.map, Map 1 -> arcaves.map; sorted by filename, arcaves precedes klamall.
+        data.writeGameMessageFile("data/maps.txt",
+            "[Map 0]\nlookup_name=Klamath\nmap_name=klamall\n"
+            "[Map 1]\nlookup_name=Caves\nmap_name=arcaves\n"
+            "[Map -1]\nlookup_name=Sentinel\nmap_name=ignored\n");
+        // displayName(index, 0) reads map.msg[index*3 + 200]: Map 0 -> 200, Map 1 -> 203.
+        data.writeGameMessageFile("text/english/game/map.msg",
+            messageLine(200, QStringLiteral("Klamath")) + messageLine(203, QStringLiteral("Arroyo Caves")));
+        data.mount();
+        names = std::make_unique<geck::resource::MapNameResolver>(data.resources());
+    }
+};
+
+} // namespace
+
+TEST_CASE("ExitGridPropertiesDialog lists mounted maps by name, sorted, with maps.txt index as data", "[qt][exitgrid]") {
+    ExitGridFixture fixture;
+    geck::ExitGridPropertiesDialog dialog(nullptr, fixture.names.get());
+
+    auto* combo = dialog.findChild<QComboBox*>("destinationMap");
+    REQUIRE(combo != nullptr);
+
+    // Sorted case-insensitively by filename: arcaves before klamall. The negative section is skipped.
+    // maps.txt's map_name normalizes to a loadable "<name>.map" filename.
+    REQUIRE(combo->count() == 2);
+    CHECK(combo->itemText(0) == QStringLiteral("arcaves.map · Arroyo Caves"));
+    CHECK(combo->itemData(0).toInt() == 1);
+    CHECK(combo->itemText(1) == QStringLiteral("klamall.map · Klamath"));
+    CHECK(combo->itemData(1).toInt() == 0);
+}
+
+TEST_CASE("ExitGridPropertiesDialog returns the selected map's index", "[qt][exitgrid]") {
+    ExitGridFixture fixture;
+    geck::ExitGridPropertiesDialog dialog(nullptr, fixture.names.get());
+
+    auto* combo = dialog.findChild<QComboBox*>("destinationMap");
+    REQUIRE(combo != nullptr);
+
+    combo->setCurrentIndex(combo->findData(0)); // klamall.map (maps.txt index 0)
+    CHECK(dialog.getProperties().exitMap == 0u);
+
+    combo->setCurrentIndex(combo->findData(1)); // arcaves.map (maps.txt index 1)
+    CHECK(dialog.getProperties().exitMap == 1u);
+}
+
+TEST_CASE("ExitGridPropertiesDialog world/town toggles disable the picker and report the sentinel", "[qt][exitgrid]") {
+    ExitGridFixture fixture;
+    geck::ExitGridPropertiesDialog dialog(nullptr, fixture.names.get());
+
+    auto* combo = dialog.findChild<QComboBox*>("destinationMap");
+    REQUIRE(combo != nullptr);
+
+    geck::ExitGridPropertiesDialog::ExitGridProperties world;
+    world.exitMap = geck::ExitGrid::WORLD_MAP_EXIT;
+    dialog.setProperties(world);
+    CHECK_FALSE(combo->isEnabled());
+    CHECK(dialog.getProperties().exitMap == geck::ExitGrid::WORLD_MAP_EXIT);
+
+    geck::ExitGridPropertiesDialog::ExitGridProperties town;
+    town.exitMap = geck::ExitGrid::TOWN_MAP_EXIT;
+    dialog.setProperties(town);
+    CHECK_FALSE(combo->isEnabled());
+    CHECK(dialog.getProperties().exitMap == geck::ExitGrid::TOWN_MAP_EXIT);
+}
+
+TEST_CASE("ExitGridPropertiesDialog preserves a destination not listed in maps.txt", "[qt][exitgrid]") {
+    ExitGridFixture fixture;
+    geck::ExitGridPropertiesDialog dialog(nullptr, fixture.names.get());
+
+    auto* combo = dialog.findChild<QComboBox*>("destinationMap");
+    REQUIRE(combo != nullptr);
+
+    geck::ExitGridPropertiesDialog::ExitGridProperties props;
+    props.exitMap = 4242; // a map id that isn't in the mounted maps.txt
+    dialog.setProperties(props);
+
+    // An unknown id is preserved as a selected "Map <id>" entry and round-trips unchanged.
+    CHECK(combo->currentText() == QStringLiteral("Map 4242"));
+    CHECK(combo->currentData().toInt() == 4242);
+    CHECK(dialog.getProperties().exitMap == 4242u);
+}
+
+TEST_CASE("ExitGridPropertiesDialog operates with no resolver and preserves the destination id", "[qt][exitgrid]") {
+    // No game data mounted (null resolver): the combo has no map entries but the dialog still works.
+    geck::ExitGridPropertiesDialog dialog(nullptr, nullptr);
+
+    auto* combo = dialog.findChild<QComboBox*>("destinationMap");
+    REQUIRE(combo != nullptr);
+
+    geck::ExitGridPropertiesDialog::ExitGridProperties props;
+    props.exitMap = 7;
+    dialog.setProperties(props);
+    CHECK(combo->currentData().toInt() == 7);
+    CHECK(dialog.getProperties().exitMap == 7u);
 }
 
 TEST_CASE("ScriptsPanel lists the map's scripts with resolved filename and name", "[qt][scripts]") {


### PR DESCRIPTION
The exit-grid properties dialog's **Destination Map ID** was a raw number spinbox (annotated with the resolved name). This replaces it with a **searchable by-name picker** — the same selection style as the script / AI-packet pickers.

## What changed
- **`MapNameResolver::allMaps()`** — enumerates every `maps.txt` entry as `{index, filename, map.msg name (elevation 0)}`, sorted case-insensitively by filename, negative-index sections skipped. Keeps the index↔name rules in one place.
- **`ExitGridPropertiesDialog`** — the map-ID spinbox becomes a `QComboBox` listing `klamall.map · Klamath`-style entries, editable + a `MatchContains`/case-insensitive `QCompleter` so typing filters the list. `getProperties()`/`setProperties()` read/write the selected map index.
- **Edges preserved:** the worldmap (`-2`) / town-map (`-1`) toggles still set the sentinel and disable the combo; a destination pointing at a map not in `maps.txt` (or when no game data is mounted) is kept as a selected `"Map <id>"` item so the value round-trips unchanged.

## Tests
`[qt][exitgrid]` cases: list-by-name + sort + negative-index skip, selection → index, the worldmap/town sentinels (checkbox + disabled combo + round-trip), and the unknown-id round-trip with and without a resolver. **274 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne97WnbUfeLRcTQeeHwEe2