### PR TITLE
Add area fill driven by Luau scripts

### DIFF
--- a/scripts/fills/badlands.luau
+++ b/scripts/fills/badlands.luau
@@ -1,0 +1,113 @@
+-- name: Rocky Badlands
+--
+-- Procedural ROCKY BADLANDS fill: the universal edg5000 sand ground strewn with boulder piles and
+-- sparse dead brush — barren and harsh (a "wasteland" feel) but built from correct walkable surface
+-- tiles, not the cave-floor tiles. Selection-scoped (api:areaFloorTiles() + api:areaHexes()) and
+-- seeded, like the other biome fills.
+--
+-- Ids were read from the shipped maps with `gecko-cli map dump-grid`, then every scenery NUMBER was
+-- resolved to its FRM with `resolve_fid` and eyeballed with `render_frm` so only complete, free-standing
+-- art is scattered: boulder piles 90/91/92/93 (rock07-rock10) + desert rocks 428/435 (drock1/drock8),
+-- with sparse dead weed 125/126. (The "Mountain" protos 691-696 are art/scenery/mount*.frm — tileable
+-- cliff *construction* pieces that are incomplete on their own — so they are deliberately NOT used.)
+-- The floor WEIGHTS mirror the real edg5000-series gradient.
+--
+--   gecko-cli map generate --script scripts/fills/badlands.luau --out out.map --data <master.dat>
+--
+-- --arg density   debris chance per clumped hex (default 0.012)
+-- --arg coverage  0..1 share of the area that grows debris (default 0.5)
+
+local DENSITY = tonumber(args.density) or 0.012
+local COVERAGE = tonumber(args.coverage) or 0.5
+
+-- Graded sand floor (the universal surface ground), weights ≈ real edg5000-series counts. {id,weight}.
+local GROUND = {
+    { 191, 24 }, { 194, 12 }, { 193, 9 }, { 192, 8 }, { 195, 8 }, { 196, 6 }, { 197, 5 }, { 198, 4 },
+}
+
+-- Badlands scenery by scenery-proto NUMBER, weighted: mostly boulder piles, a little dead weed. Every
+-- entry resolves to complete, free-standing rock art. {number, weight}.
+local SCENERY = {
+    { 90, 8 }, { 91, 7 }, { 92, 6 }, { 93, 5 }, -- rock07/rock08/rock09/rock10 boulder piles
+    { 428, 4 }, { 435, 3 }, -- drock1/drock8 desert rocks
+    { 125, 2 }, { 126, 2 }, -- dead weed (weed24/weed25)
+}
+
+local GROUND_SCALE = 0.05 -- dune-region size
+local CLUMP_SCALE = 0.08 -- rock-field clump size
+local TILE_W, TILE_H = 100, 100
+local HEX_W, HEX_H = 200, 200
+
+-- Targets: the selection when one is bound (Fill Selection), else the whole elevation (generate).
+local function targetFloorTiles()
+    if api:hasArea() then
+        return api:areaFloorTiles()
+    end
+    local all = {}
+    for i = 0, TILE_W * TILE_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+local function targetHexes()
+    if api:hasArea() then
+        return api:areaHexes()
+    end
+    local all = {}
+    for i = 0, HEX_W * HEX_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+-- Cumulative-weight picker: maps f in [0,1) to a value by weight.
+local function weightedPicker(entries)
+    local total = 0
+    for _, e in ipairs(entries) do
+        total = total + e[2]
+    end
+    return function(f)
+        local x = f * total
+        local acc = 0
+        for _, e in ipairs(entries) do
+            acc = acc + e[2]
+            if x < acc then
+                return e[1]
+            end
+        end
+        return entries[#entries][1]
+    end
+end
+
+local groundFor = weightedPicker(GROUND)
+local sceneryFor = weightedPicker(SCENERY)
+
+print("Seed " .. args.seed .. " — re-run with --arg seed=" .. args.seed .. " to reproduce.")
+
+-- 1. sand floor over the target tiles.
+local ox, oy = api:rng() * 1000.0, api:rng() * 1000.0
+local painted = 0
+for _, t in ipairs(targetFloorTiles()) do
+    local f = api:noise2d(api:tileCol(t) * GROUND_SCALE + ox, api:tileRow(t) * GROUND_SCALE + oy)
+    if api:paintFloor(t, groundFor(f)) then
+        painted = painted + 1
+    end
+end
+
+-- 2. sparse, clumped rock debris over the target hexes.
+local sx, sy = api:rng() * 1000.0, api:rng() * 1000.0
+local threshold = 1.0 - COVERAGE
+local placed = 0
+for _, h in ipairs(targetHexes()) do
+    local col, row = api:hexCol(h), api:hexRow(h)
+    local clump = api:noise2d(col * CLUMP_SCALE + sx, row * CLUMP_SCALE + sy)
+    if clump > threshold and api:rng() < DENSITY then
+        local pid = api:proto("scenery", sceneryFor(api:rng()))
+        if api:placeProtoXY(pid, col, row, 0) then
+            placed = placed + 1
+        end
+    end
+end
+
+print(string.format("Rocky Badlands: %d floor tiles, %d debris.", painted, placed))

--- a/scripts/fills/desert.luau
+++ b/scripts/fills/desert.luau
@@ -1,0 +1,115 @@
+-- name: Desert
+--
+-- Procedural DESERT fill for the current selection: a noise-blended sand floor with sparse, clumped
+-- scrub, weeds and the odd cactus — matched to how the shipped Fallout 2 desert encounter maps
+-- actually look. Selection-scoped (api:areaFloorTiles() + api:areaHexes()), so it works as a "Fill
+-- Selection" script in the editor and, over a whole elevation, as a gecko-cli generator. Seeded:
+-- the same seed reproduces the layout.
+--
+-- Every id below was read from the shipped maps with `gecko-cli map dump-grid maps/desert{3,5,6}.map`
+-- / `map analyze`: the floor WEIGHTS mirror the real edg5000-series proportions (edg5000 ~24%, the
+-- rest a graded gradient), the scenery NUMBERS are the api:proto values (scrub 102-105, weed 125-127,
+-- cactus 64-65, rocks 93), and DENSITY matches the real ~1-3% scenery-per-tile (not a carpet).
+--
+--   gecko-cli map generate --script scripts/fills/desert.luau --out out.map --data <master.dat>
+--
+-- --arg density   scenery placement chance per clumped hex (default 0.01 ≈ real desert)
+-- --arg coverage  0..1 share of the area that grows scenery (default 0.55)
+
+local DENSITY = tonumber(args.density) or 0.01
+local COVERAGE = tonumber(args.coverage) or 0.55
+
+-- Graded sand floor, weights ≈ real desert-map tile counts (edg5000 dominant, then a smooth fall-off
+-- through edg5001..5007). Ordered so the noise bands below read as dunes, not hard patches. {id,weight}.
+local GROUND = {
+    { 191, 24 }, { 194, 12 }, { 193, 9 }, { 192, 8 }, { 195, 8 }, { 196, 6 }, { 197, 5 }, { 198, 4 },
+}
+
+-- Desert scenery by scenery-proto NUMBER (the value api:proto wants), weighted by real frequency:
+-- scrub is most common, then weeds, a few cacti, the rare rock. {number, weight}.
+local SCENERY = {
+    { 102, 10 }, { 103, 10 }, { 104, 8 }, { 105, 8 }, -- scrub
+    { 125, 5 }, { 126, 5 }, { 127, 4 }, -- weeds
+    { 64, 3 }, { 65, 2 }, -- cacti
+    { 93, 1 }, -- rocks
+}
+
+local GROUND_SCALE = 0.05 -- smaller = larger, smoother dune regions
+local CLUMP_SCALE = 0.08 -- scenery clump size
+local TILE_W, TILE_H = 100, 100
+local HEX_W, HEX_H = 200, 200
+
+-- Targets: the selection when one is bound (Fill Selection in the editor), else the whole elevation
+-- (gecko-cli generate, which binds no area). One script, both uses.
+local function targetFloorTiles()
+    if api:hasArea() then
+        return api:areaFloorTiles()
+    end
+    local all = {}
+    for i = 0, TILE_W * TILE_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+local function targetHexes()
+    if api:hasArea() then
+        return api:areaHexes()
+    end
+    local all = {}
+    for i = 0, HEX_W * HEX_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+-- Build a cumulative-weight picker: returns a function mapping f in [0,1) to a value by weight.
+local function weightedPicker(entries)
+    local total = 0
+    for _, e in ipairs(entries) do
+        total = total + e[2]
+    end
+    return function(f)
+        local x = f * total
+        local acc = 0
+        for _, e in ipairs(entries) do
+            acc = acc + e[2]
+            if x < acc then
+                return e[1]
+            end
+        end
+        return entries[#entries][1]
+    end
+end
+
+local groundFor = weightedPicker(GROUND)
+local sceneryFor = weightedPicker(SCENERY)
+
+print("Seed " .. args.seed .. " — re-run with --arg seed=" .. args.seed .. " to reproduce.")
+
+-- 1. noise-blended sand floor over the target tiles.
+local ox, oy = api:rng() * 1000.0, api:rng() * 1000.0
+local painted = 0
+for _, t in ipairs(targetFloorTiles()) do
+    local f = api:noise2d(api:tileCol(t) * GROUND_SCALE + ox, api:tileRow(t) * GROUND_SCALE + oy)
+    if api:paintFloor(t, groundFor(f)) then
+        painted = painted + 1
+    end
+end
+
+-- 2. sparse, clumped scenery over the target hexes.
+local sx, sy = api:rng() * 1000.0, api:rng() * 1000.0
+local threshold = 1.0 - COVERAGE
+local placed = 0
+for _, h in ipairs(targetHexes()) do
+    local col, row = api:hexCol(h), api:hexRow(h)
+    local clump = api:noise2d(col * CLUMP_SCALE + sx, row * CLUMP_SCALE + sy)
+    if clump > threshold and api:rng() < DENSITY then
+        local pid = api:proto("scenery", sceneryFor(api:rng()))
+        if api:placeProtoXY(pid, col, row, 0) then
+            placed = placed + 1
+        end
+    end
+end
+
+print(string.format("Desert: %d floor tiles, %d scenery.", painted, placed))

--- a/scripts/fills/overgrown.luau
+++ b/scripts/fills/overgrown.luau
@@ -1,0 +1,111 @@
+-- name: Overgrown
+--
+-- Procedural OVERGROWN / WILD fill: the universal edg5000 sand ground overrun with low plants, weeds
+-- and scrub — a reclaimed-by-nature look, denser low greenery than desert but without trees.
+-- Selection-scoped (api:areaFloorTiles() + api:areaHexes()) and seeded, like the other biome fills.
+--
+-- Ids were read from the shipped maps with `gecko-cli map dump-grid`, then every scenery NUMBER was
+-- resolved to its FRM with `resolve_fid` and eyeballed with `render_frm` so only complete, free-standing
+-- art is scattered: dense scrub 102/103/104/105 (weed01-weed04) + weed 125/126/127 (weed24-weed26), a
+-- thick low ground cover. (The generic "Plant" protos 366/367/369/963-965 are garden crops — cabbages,
+-- corn, marijuana — so they are deliberately NOT used.) The floor WEIGHTS mirror the real edg5000-series
+-- gradient.
+--
+--   gecko-cli map generate --script scripts/fills/overgrown.luau --out out.map --data <master.dat>
+--
+-- --arg density   growth chance per clumped hex (default 0.05)
+-- --arg coverage  0..1 share of the area that grows (default 0.6)
+
+local DENSITY = tonumber(args.density) or 0.05
+local COVERAGE = tonumber(args.coverage) or 0.6
+
+-- Graded sand floor (the universal surface ground), weights ≈ real edg5000-series counts. {id,weight}.
+local GROUND = {
+    { 191, 24 }, { 194, 12 }, { 193, 9 }, { 192, 8 }, { 195, 8 }, { 196, 6 }, { 197, 5 }, { 198, 4 },
+}
+
+-- Overgrowth scenery by scenery-proto NUMBER, weighted: dense scrub bushes dominate, then weeds. Every
+-- entry resolves to complete, free-standing bush/weed art — a thick low ground cover. {number, weight}.
+local SCENERY = {
+    { 102, 6 }, { 103, 6 }, { 104, 5 }, { 105, 5 }, -- scrub (weed01-weed04)
+    { 125, 4 }, { 126, 4 }, { 127, 3 }, -- weeds (weed24-weed26)
+}
+
+local GROUND_SCALE = 0.05 -- dune-region size
+local CLUMP_SCALE = 0.07 -- growth-patch size
+local TILE_W, TILE_H = 100, 100
+local HEX_W, HEX_H = 200, 200
+
+-- Targets: the selection when one is bound (Fill Selection), else the whole elevation (generate).
+local function targetFloorTiles()
+    if api:hasArea() then
+        return api:areaFloorTiles()
+    end
+    local all = {}
+    for i = 0, TILE_W * TILE_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+local function targetHexes()
+    if api:hasArea() then
+        return api:areaHexes()
+    end
+    local all = {}
+    for i = 0, HEX_W * HEX_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+-- Cumulative-weight picker: maps f in [0,1) to a value by weight.
+local function weightedPicker(entries)
+    local total = 0
+    for _, e in ipairs(entries) do
+        total = total + e[2]
+    end
+    return function(f)
+        local x = f * total
+        local acc = 0
+        for _, e in ipairs(entries) do
+            acc = acc + e[2]
+            if x < acc then
+                return e[1]
+            end
+        end
+        return entries[#entries][1]
+    end
+end
+
+local groundFor = weightedPicker(GROUND)
+local sceneryFor = weightedPicker(SCENERY)
+
+print("Seed " .. args.seed .. " — re-run with --arg seed=" .. args.seed .. " to reproduce.")
+
+-- 1. sand floor over the target tiles.
+local ox, oy = api:rng() * 1000.0, api:rng() * 1000.0
+local painted = 0
+for _, t in ipairs(targetFloorTiles()) do
+    local f = api:noise2d(api:tileCol(t) * GROUND_SCALE + ox, api:tileRow(t) * GROUND_SCALE + oy)
+    if api:paintFloor(t, groundFor(f)) then
+        painted = painted + 1
+    end
+end
+
+-- 2. dense low growth over the target hexes.
+local sx, sy = api:rng() * 1000.0, api:rng() * 1000.0
+local threshold = 1.0 - COVERAGE
+local placed = 0
+for _, h in ipairs(targetHexes()) do
+    local col, row = api:hexCol(h), api:hexRow(h)
+    local clump = api:noise2d(col * CLUMP_SCALE + sx, row * CLUMP_SCALE + sy)
+    if clump > threshold and api:rng() < DENSITY then
+        local pid = api:proto("scenery", sceneryFor(api:rng()))
+        if api:placeProtoXY(pid, col, row, 0) then
+            placed = placed + 1
+        end
+    end
+end
+
+print(string.format("Overgrown: %d floor tiles, %d growth.", painted, placed))

--- a/scripts/fills/woods.luau
+++ b/scripts/fills/woods.luau
@@ -1,0 +1,113 @@
+-- name: Woods
+--
+-- Procedural WOODS / OASIS fill: the universal edg5000 sand ground (what every Fallout 2 surface map
+-- uses) thickly planted with tree groves, plants and scrub — a green, wooded patch, the most distinct
+-- look from open desert while still using correct walkable surface tiles. Selection-scoped
+-- (api:areaFloorTiles() + api:areaHexes()) and seeded, like the other biome fills.
+--
+-- Ids were read from the shipped maps with `gecko-cli map dump-grid`, then every scenery NUMBER was
+-- resolved to its FRM with `resolve_fid` and eyeballed with `render_frm` so only complete, free-standing
+-- art is scattered: trees 66/316/319/320/321 (tre1000, tree1, tree4-6) + 945/946/947 (tree7-9), with a
+-- little scrub 102/103 (weed01/02) at the edges. (The generic "Plant" protos 366/367/369/944 are garden
+-- crops — cabbages, corn, marijuana — so they are deliberately NOT used.) The floor WEIGHTS mirror the
+-- real edg5000-series gradient. Trees are placed in tight groves.
+--
+--   gecko-cli map generate --script scripts/fills/woods.luau --out out.map --data <master.dat>
+--
+-- --arg density   scenery chance per hex inside a grove (default 0.07)
+-- --arg coverage  0..1 share of the area that grows groves (default 0.4)
+
+local DENSITY = tonumber(args.density) or 0.07
+local COVERAGE = tonumber(args.coverage) or 0.4
+
+-- Graded sand floor (the universal surface ground), weights ≈ real edg5000-series counts. {id,weight}.
+local GROUND = {
+    { 191, 24 }, { 194, 12 }, { 193, 9 }, { 192, 8 }, { 195, 8 }, { 196, 6 }, { 197, 5 }, { 198, 4 },
+}
+
+-- Woodland scenery by scenery-proto NUMBER, weighted: trees dominate (the groves), then a little scrub
+-- at the edges. Every entry resolves to complete, free-standing tree/bush art. {number, weight}.
+local SCENERY = {
+    { 946, 8 }, { 945, 7 }, { 947, 7 }, -- tree8/tree7/tree9 (leafy)
+    { 66, 5 }, { 316, 4 }, { 319, 4 }, { 320, 3 }, { 321, 3 }, -- tre1000/tree1/tree4/tree5/tree6
+    { 102, 2 }, { 103, 2 }, -- scrub (weed01/weed02)
+}
+
+local GROUND_SCALE = 0.05 -- dune-region size
+local CLUMP_SCALE = 0.10 -- grove size (larger value = smaller, tighter groves)
+local TILE_W, TILE_H = 100, 100
+local HEX_W, HEX_H = 200, 200
+
+-- Targets: the selection when one is bound (Fill Selection), else the whole elevation (generate).
+local function targetFloorTiles()
+    if api:hasArea() then
+        return api:areaFloorTiles()
+    end
+    local all = {}
+    for i = 0, TILE_W * TILE_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+local function targetHexes()
+    if api:hasArea() then
+        return api:areaHexes()
+    end
+    local all = {}
+    for i = 0, HEX_W * HEX_H - 1 do
+        all[#all + 1] = i
+    end
+    return all
+end
+
+-- Cumulative-weight picker: maps f in [0,1) to a value by weight.
+local function weightedPicker(entries)
+    local total = 0
+    for _, e in ipairs(entries) do
+        total = total + e[2]
+    end
+    return function(f)
+        local x = f * total
+        local acc = 0
+        for _, e in ipairs(entries) do
+            acc = acc + e[2]
+            if x < acc then
+                return e[1]
+            end
+        end
+        return entries[#entries][1]
+    end
+end
+
+local groundFor = weightedPicker(GROUND)
+local sceneryFor = weightedPicker(SCENERY)
+
+print("Seed " .. args.seed .. " — re-run with --arg seed=" .. args.seed .. " to reproduce.")
+
+-- 1. sand floor over the target tiles.
+local ox, oy = api:rng() * 1000.0, api:rng() * 1000.0
+local painted = 0
+for _, t in ipairs(targetFloorTiles()) do
+    local f = api:noise2d(api:tileCol(t) * GROUND_SCALE + ox, api:tileRow(t) * GROUND_SCALE + oy)
+    if api:paintFloor(t, groundFor(f)) then
+        painted = painted + 1
+    end
+end
+
+-- 2. tree groves over the target hexes — dense inside a clump, open between.
+local sx, sy = api:rng() * 1000.0, api:rng() * 1000.0
+local threshold = 1.0 - COVERAGE
+local placed = 0
+for _, h in ipairs(targetHexes()) do
+    local col, row = api:hexCol(h), api:hexRow(h)
+    local clump = api:noise2d(col * CLUMP_SCALE + sx, row * CLUMP_SCALE + sy)
+    if clump > threshold and api:rng() < DENSITY * clump then
+        local pid = api:proto("scenery", sceneryFor(api:rng()))
+        if api:placeProtoXY(pid, col, row, 0) then
+            placed = placed + 1
+        end
+    end
+end
+
+print(string.format("Woods: %d floor tiles, %d trees/plants.", painted, placed))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,9 @@ set(GECK_APP_SOURCES
     pattern/ThumbnailComposer.cpp
     pattern/PatternThumbnail.h
     pattern/PatternThumbnail.cpp
+    # Area-fill editor side: the fill-script library locator (a peer of the pattern equivalents above).
+    pattern/FillLibrary.h
+    pattern/FillLibrary.cpp
 
     ui/ExternalEditorLauncher.h
     ui/ExternalEditorLauncher.cpp
@@ -110,6 +113,8 @@ set(GECK_APP_SOURCES
     ui/dialogs/AboutDialog.cpp
     ui/dialogs/PatternBrowserDialog.h
     ui/dialogs/PatternBrowserDialog.cpp
+    ui/dialogs/FillDialog.h
+    ui/dialogs/FillDialog.cpp
     ui/dialogs/MapBrowserDialog.h
     ui/dialogs/MapBrowserDialog.cpp
 
@@ -533,6 +538,11 @@ add_library(gecko_editing STATIC
     pattern/PatternBuilder.cpp
     pattern/PatternStamper.h
     pattern/PatternStamper.cpp
+    # Built-but-uncommitted edit (FillPlan) + its single-undo-entry apply path (PlacementBatch),
+    # shared by the prefab stamper and the area-fill plan-sink.
+    pattern/FillPlan.h
+    pattern/PlacementBatch.h
+    pattern/PlacementBatch.cpp
     rendering/MapSpriteLoader.h
     rendering/MapSpriteLoader.cpp
     # SFML map renderer (Qt-free): drives the same drawing for the Qt editor and headless

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -900,6 +900,74 @@ std::vector<std::string> listMapPaths(const resource::DataFileSystem& files) {
     return mapPaths;
 }
 
+int dumpMapGrid(resource::GameResources& resources, const DumpGridOptions& options, std::ostream& out) {
+    if (options.map.empty()) {
+        out << "error: dump-grid requires --map <path>\n";
+        return 2;
+    }
+    const std::unique_ptr<Map> map = loadMap(resources, options.map);
+    if (!map) {
+        out << "skip (unreadable or parse failed): " << options.map << "\n";
+        return 1;
+    }
+    NameResolver names(resources);
+
+    ordered_json root;
+    root["map"] = baseName(options.map);
+    root["path"] = options.map;
+    root["tileCols"] = Map::COLS;
+    root["tileRows"] = Map::ROWS;
+    root["hexCols"] = HexagonGrid::GRID_WIDTH;
+    root["hexRows"] = HexagonGrid::GRID_HEIGHT;
+    root["emptyTile"] = Map::EMPTY_TILE; // floor/roof ids equal to this mark an empty cell
+
+    const auto& mapFile = map->getMapFile();
+    auto elevations = ordered_json::array();
+    for (const auto& [elevation, tiles] : mapFile.tiles) {
+        if (options.elevation >= 0 && elevation != options.elevation) {
+            continue;
+        }
+        ordered_json entry;
+        entry["elevation"] = elevation;
+        if (options.floor) {
+            auto floor = ordered_json::array();
+            for (const auto& tile : tiles) {
+                floor.push_back(tile.getFloor());
+            }
+            entry["floor"] = std::move(floor); // row-major, COLS wide (index = row*COLS + col)
+        }
+        if (options.roof) {
+            auto roof = ordered_json::array();
+            for (const auto& tile : tiles) {
+                roof.push_back(tile.getRoof());
+            }
+            entry["roof"] = std::move(roof);
+        }
+        if (options.objects) {
+            auto objects = ordered_json::array();
+            if (const auto it = mapFile.map_objects.find(elevation); it != mapFile.map_objects.end()) {
+                for (const auto& object : it->second) {
+                    if (!object) {
+                        continue;
+                    }
+                    const uint32_t pid = object->pro_pid;
+                    objects.push_back({ { "pid", pidHex(pid) }, { "number", pid & 0xFFFFFFu },
+                        { "type", typeLabel(pid) }, { "name", names.protoName(pid) },
+                        { "fid", pidHex(object->frm_pid) }, // the art FID — feed to resolve_fid to SEE what it is
+                        { "hex", object->position }, { "col", hexgrid::columnOf(object->position) },
+                        { "row", hexgrid::rowOf(object->position) }, { "dir", object->direction },
+                        { "flat", names.isFlat(pid) } });
+                }
+            }
+            entry["objects"] = std::move(objects);
+        }
+        elevations.push_back(std::move(entry));
+    }
+    root["elevations"] = std::move(elevations);
+    out << root.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
+    return 0;
+}
+
 int analyzeMaps(resource::GameResources& resources, const AnalyzeOptions& options, std::ostream& out) {
     const std::vector<std::string> mapPaths = collectMapPaths(resources.files(), options, out);
     if (mapPaths.empty()) {

--- a/src/cli/MapAnalyzer.cpp
+++ b/src/cli/MapAnalyzer.cpp
@@ -867,6 +867,37 @@ namespace {
         out << root.dump(-1, ' ', false, ordered_json::error_handler_t::replace) << "\n";
     }
 
+    // One elevation's floor or roof layer as a flat row-major id array (index = row*COLS + col).
+    ordered_json tileGridArray(const std::vector<Tile>& tiles, bool roof) {
+        auto arr = ordered_json::array();
+        for (const auto& tile : tiles) {
+            arr.push_back(roof ? tile.getRoof() : tile.getFloor());
+        }
+        return arr;
+    }
+
+    // One elevation's objects as an array (pid/number/type/name/fid/hex/col/row/dir/flat per object).
+    ordered_json objectGridArray(const Map::MapFile& mapFile, int elevation, NameResolver& names) {
+        auto objects = ordered_json::array();
+        const auto it = mapFile.map_objects.find(elevation);
+        if (it == mapFile.map_objects.end()) {
+            return objects;
+        }
+        for (const auto& object : it->second) {
+            if (!object) {
+                continue;
+            }
+            const uint32_t pid = object->pro_pid;
+            objects.push_back({ { "pid", pidHex(pid) }, { "number", pid & 0xFFFFFFu },
+                { "type", typeLabel(pid) }, { "name", names.protoName(pid) },
+                { "fid", pidHex(object->frm_pid) }, // the art FID — feed to resolve_fid to SEE what it is
+                { "hex", object->position }, { "col", hexgrid::columnOf(object->position) },
+                { "row", hexgrid::rowOf(object->position) }, { "dir", object->direction },
+                { "flat", names.isFlat(pid) } });
+        }
+        return objects;
+    }
+
 } // namespace
 
 std::vector<MapExit> collectMapExits(Map& map) {
@@ -930,36 +961,13 @@ int dumpMapGrid(resource::GameResources& resources, const DumpGridOptions& optio
         ordered_json entry;
         entry["elevation"] = elevation;
         if (options.floor) {
-            auto floor = ordered_json::array();
-            for (const auto& tile : tiles) {
-                floor.push_back(tile.getFloor());
-            }
-            entry["floor"] = std::move(floor); // row-major, COLS wide (index = row*COLS + col)
+            entry["floor"] = tileGridArray(tiles, /*roof=*/false); // row-major, COLS wide
         }
         if (options.roof) {
-            auto roof = ordered_json::array();
-            for (const auto& tile : tiles) {
-                roof.push_back(tile.getRoof());
-            }
-            entry["roof"] = std::move(roof);
+            entry["roof"] = tileGridArray(tiles, /*roof=*/true);
         }
         if (options.objects) {
-            auto objects = ordered_json::array();
-            if (const auto it = mapFile.map_objects.find(elevation); it != mapFile.map_objects.end()) {
-                for (const auto& object : it->second) {
-                    if (!object) {
-                        continue;
-                    }
-                    const uint32_t pid = object->pro_pid;
-                    objects.push_back({ { "pid", pidHex(pid) }, { "number", pid & 0xFFFFFFu },
-                        { "type", typeLabel(pid) }, { "name", names.protoName(pid) },
-                        { "fid", pidHex(object->frm_pid) }, // the art FID — feed to resolve_fid to SEE what it is
-                        { "hex", object->position }, { "col", hexgrid::columnOf(object->position) },
-                        { "row", hexgrid::rowOf(object->position) }, { "dir", object->direction },
-                        { "flat", names.isFlat(pid) } });
-                }
-            }
-            entry["objects"] = std::move(objects);
+            entry["objects"] = objectGridArray(mapFile, elevation, names);
         }
         elevations.push_back(std::move(entry));
     }

--- a/src/cli/MapAnalyzer.h
+++ b/src/cli/MapAnalyzer.h
@@ -60,7 +60,7 @@ struct DumpGridOptions {
     int elevation = -1;
     bool floor = true;   // emit the floor-tile id grid
     bool roof = false;   // emit the roof-tile id grid
-    bool objects = true; // emit per-object {pid,number,type,name,hex,col,row,dir,flat}
+    bool objects = true; // emit one record per object: pid, number, type, name, hex, col, row, dir, flat
 };
 
 // Dump the RAW spatial layout of one map as JSON: per elevation, the floor (and optionally roof)

--- a/src/cli/MapAnalyzer.h
+++ b/src/cli/MapAnalyzer.h
@@ -53,4 +53,22 @@ struct AnalyzeOptions {
 // TextureManager. Shared by the gecko-cli frontend (and, later, the MCP server).
 int analyzeMaps(resource::GameResources& resources, const AnalyzeOptions& options, std::ostream& out);
 
+struct DumpGridOptions {
+    // The single map to dump (VFS path, e.g. "maps/desert6.map"), required.
+    std::string map;
+    // Which elevation to dump; -1 = every present elevation.
+    int elevation = -1;
+    bool floor = true;   // emit the floor-tile id grid
+    bool roof = false;   // emit the roof-tile id grid
+    bool objects = true; // emit per-object {pid,number,type,name,hex,col,row,dir,flat}
+};
+
+// Dump the RAW spatial layout of one map as JSON: per elevation, the floor (and optionally roof)
+// tile-id grid (row-major, COLS wide; `emptyTile` marks empty) and every object's pid/number/type/
+// name and hex position (with col/row + facing). Where `analyze` gives digested adjacency and
+// object clusters, this is the underlying per-cell data — for learning exact tile placement,
+// transition masks and scatter density/positions from real maps. Returns 0 on success, non-zero if
+// the map can't be read. Headless, like analyzeMaps.
+int dumpMapGrid(resource::GameResources& resources, const DumpGridOptions& options, std::ostream& out);
+
 } // namespace geck::cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -39,9 +39,11 @@ struct CliArgs {
     bool quests = false;
     bool endings = false;
     bool findGvar = false;
+    bool dumpGrid = false;
     std::string findGvarName;
     std::vector<std::string> dataPaths;
     geck::cli::AnalyzeOptions analyze;
+    geck::cli::DumpGridOptions dumpOpts;
     geck::cli::GenerateOptions gen;
     geck::cli::RenderOptions ren;
     geck::cli::ExtractOptions ext;
@@ -93,6 +95,12 @@ void printUsage(const char* program) {
               << "  " << program << " map describe-map --map <path> --data <dir-or-.dat> [--data <...>]\n"
               << "      One digest composing analyze + reachability for a map (header, biome, structures,\n"
               << "      critter roster with AI + scripts, exits, reachability), as JSON.\n"
+              << "  " << program << " map dump-grid --map <path> [--elevation 0|1|2] [--roof]\n"
+              << "      [--no-floor] [--no-objects] --data <dir-or-.dat> [--data <...>]\n"
+              << "      Dumps the RAW spatial layout as JSON: per elevation the floor (and --roof) tile-id\n"
+              << "      grid (row-major, 100 wide; emptyTile marks empty) and every object's\n"
+              << "      {pid,number,type,name,hex,col,row,dir,flat}. The per-cell data behind analyze's\n"
+              << "      adjacency/clusters — for learning exact tile placement + scatter density.\n"
               << "  " << program << " map graph [map ...] --data <dir-or-.dat> [--data <...>]\n"
               << "      The exit-grid connectivity graph: how maps link via exit grids WITHIN a location\n"
               << "      (+ worldmap hand-off edges), named via maps.txt/map.msg. Not inter-city travel\n"
@@ -131,7 +139,8 @@ bool isKnownSubcommand(const std::vector<std::string>& args) {
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
             || args[1] == "describe-script" || args[1] == "reachability" || args[1] == "describe-map"
             || args[1] == "graph" || args[1] == "world" || args[1] == "encounters"
-            || args[1] == "gvars" || args[1] == "quests" || args[1] == "endings" || args[1] == "find-gvar");
+            || args[1] == "gvars" || args[1] == "quests" || args[1] == "endings" || args[1] == "find-gvar"
+            || args[1] == "dump-grid");
 }
 
 bool generateMissingRequired(const CliArgs& cli) {
@@ -173,7 +182,8 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         || (out.extract && (arg == "--map" || arg == "--out" || arg == "--name" || arg == "--elevation" || arg == "--pids" || arg == "--anchor" || arg == "--radius"))
         || (out.describeScript && (arg == "--index" || arg == "--locale"))
         || (out.reachability && arg == "--map")
-        || (out.describeMap && arg == "--map");
+        || (out.describeMap && arg == "--map")
+        || (out.dumpGrid && (arg == "--map" || arg == "--elevation"));
 
     if (valueFlag && i + 1 >= args.size()) {
         std::cerr << "error: " << arg << " needs a value\n";
@@ -347,6 +357,31 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         printUsage(program);
         return 0;
     }
+    if (out.dumpGrid && arg == "--map") {
+        out.dumpOpts.map = args[i + 1];
+        return 2;
+    }
+    if (out.dumpGrid && arg == "--elevation") {
+        out.dumpOpts.elevation = std::stoi(args[i + 1]);
+        return 2;
+    }
+    if (out.dumpGrid && arg == "--roof") {
+        out.dumpOpts.roof = true;
+        return 1;
+    }
+    if (out.dumpGrid && arg == "--no-floor") {
+        out.dumpOpts.floor = false;
+        return 1;
+    }
+    if (out.dumpGrid && arg == "--no-objects") {
+        out.dumpOpts.objects = false;
+        return 1;
+    }
+    if (out.dumpGrid) {
+        std::cerr << "error: unexpected argument: " << arg << "\n";
+        printUsage(program);
+        return 0;
+    }
     if (out.graph) { // trailing positional args are the maps to include (empty = all)
         out.graphOpts.maps.push_back(arg);
         return 1;
@@ -406,6 +441,7 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     out.quests = args[1] == "quests";
     out.endings = args[1] == "endings";
     out.findGvar = args[1] == "find-gvar";
+    out.dumpGrid = args[1] == "dump-grid";
 
     for (std::size_t i = 2; i < args.size();) {
         const int consumed = consumeArg(args, i, out, program);
@@ -442,6 +478,11 @@ std::optional<int> parseArgs(const std::vector<std::string>& args, const char* p
     }
     if (out.reachability && out.reach.mapPath.empty()) {
         std::cerr << "error: reachability requires --map <path>\n";
+        printUsage(program);
+        return 2;
+    }
+    if (out.dumpGrid && out.dumpOpts.map.empty()) {
+        std::cerr << "error: dump-grid requires --map <path>\n";
         printUsage(program);
         return 2;
     }
@@ -640,6 +681,9 @@ int main(int argc, char** argv) {
             return 2;
         }
         return geck::cli::findGvarRefs(resources, cli.findGvarName, std::cout);
+    }
+    if (cli.dumpGrid) {
+        return geck::cli::dumpMapGrid(resources, cli.dumpOpts, std::cout);
     }
     return geck::cli::analyzeMaps(resources, cli.analyze, std::cout);
 }

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -239,7 +239,7 @@ namespace {
         int rc = 0;
         try {
             rc = cli::dumpMapGrid(resources, opts, oss);
-        } catch (const std::exception& e) {
+        } catch (const std::exception& e) { // NOSONAR: tool boundary — any failure is returned to the caller as an error result
             return toolText(std::string("dump_grid failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
         }
         return toolText(oss.str(), rc != 0);
@@ -528,7 +528,7 @@ namespace {
             "Args: map.",
             json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
             [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
-        t.push_back({ "dump_grid",
+        t.push_back({ "dump_grid", // NOSONAR: braced-init of the tool descriptor; emplace_back would need C++20 paren-aggregate-init
             "The RAW spatial layout of one map, the per-cell data behind analyze's digested "
             "adjacency/clusters. Per elevation: the floor (and, with roof=true, roof) tile-id grid as a "
             "flat row-major array, 'tileCols' (100) wide so cell (col,row) is grid[row*100+col], with "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -220,6 +220,31 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    json toolDumpGrid(resource::GameResources& resources, const json& args) {
+        cli::DumpGridOptions opts;
+        opts.map = requireString(args, "map");
+        if (args.contains("elevation") && args.at("elevation").is_number_integer()) {
+            opts.elevation = args.at("elevation").get<int>();
+        }
+        if (args.contains("roof") && args.at("roof").is_boolean()) {
+            opts.roof = args.at("roof").get<bool>();
+        }
+        if (args.contains("floor") && args.at("floor").is_boolean()) {
+            opts.floor = args.at("floor").get<bool>();
+        }
+        if (args.contains("objects") && args.at("objects").is_boolean()) {
+            opts.objects = args.at("objects").get<bool>();
+        }
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::dumpMapGrid(resources, opts, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("dump_grid failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     json toolMapGraph(resource::GameResources& resources, const json& args) {
         cli::MapGraphOptions opts;
         opts.maps = optMaps(args);
@@ -503,6 +528,17 @@ namespace {
             "Args: map.",
             json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
             [](resource::GameResources& r, const json& a) { return toolDescribeMap(r, a); } });
+        t.push_back({ "dump_grid",
+            "The RAW spatial layout of one map, the per-cell data behind analyze's digested "
+            "adjacency/clusters. Per elevation: the floor (and, with roof=true, roof) tile-id grid as a "
+            "flat row-major array, 'tileCols' (100) wide so cell (col,row) is grid[row*100+col], with "
+            "'emptyTile' (1) marking empty; and 'objects' [{pid,number,type,name,hex,col,row,dir,flat}] "
+            "for every object (filter flat=true / type to separate scenery from structural exit grids "
+            "and blockers). Use it to learn exact tile placement, transition masks and real scatter "
+            "density/positions from shipped maps before generating terrain. Args: map (required), "
+            "optional elevation (-1/all), roof, floor, objects (booleans).",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "roof", { { "type", "boolean" } } }, { "floor", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } } } }, { "required", json::array({ "map" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolDumpGrid(r, a); } });
         t.push_back({ "map_graph",
             "The EXIT-GRID connectivity graph — how maps link via exit grids: within a location "
             "(intramap self-edges for elevation changes, and intermap edges between a town's maps, e.g. "

--- a/src/pattern/FillLibrary.cpp
+++ b/src/pattern/FillLibrary.cpp
@@ -1,0 +1,23 @@
+#include "pattern/FillLibrary.h"
+
+#include <QDir>
+#include <QStandardPaths>
+
+#include "Application.h"
+
+namespace geck::pattern {
+
+QString FillLibrary::rootDir() {
+    // Mirror Settings/PatternLibrary: <ConfigLocation>/gecko/<...>.
+    const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    const QString fillsPath = QDir(configPath).filePath(QStringLiteral("gecko/fills"));
+    QDir().mkpath(fillsPath);
+    return fillsPath;
+}
+
+QString FillLibrary::bundledDir() {
+    // The same place the script console finds bundled stamps: <resources>/scripts/<...>.
+    return QString::fromStdString((Application::getResourcesPath() / "scripts" / "fills").string());
+}
+
+} // namespace geck::pattern

--- a/src/pattern/FillLibrary.h
+++ b/src/pattern/FillLibrary.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+
+namespace geck::pattern {
+
+/// Locates the area-fill recipe library. Mirrors PatternLibrary: user fills live under
+/// <ConfigLocation>/gecko/fills (where "save fill" writes), and a read-only set of bundled examples
+/// ships with the editor under <resources>/scripts/fills. The Fill dialog shows both (a user fill of
+/// the same file name wins), exactly as the script console merges bundled + library stamps.
+class FillLibrary {
+public:
+    /// The user fill library root, created on first use. Absolute path.
+    static QString rootDir();
+    /// The bundled (read-only) example-fills directory shipped with the editor. Absolute path; may
+    /// not exist in a dev tree without the resources folder populated.
+    static QString bundledDir();
+};
+
+} // namespace geck::pattern

--- a/src/pattern/FillPlan.h
+++ b/src/pattern/FillPlan.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "editor/TileChange.h"
+
+namespace geck {
+class Object;
+struct MapObject;
+} // namespace geck
+
+namespace geck::pattern {
+
+/// A fully-resolved, fully-built edit that has NOT been committed to the map: every object is
+/// already a constructed MapObject (and, when sprites are built, its visual Object), and every
+/// tile is a ready TileChange with its before/after captured at plan time. Producing a FillPlan
+/// mutates nothing — PlacementBatch::replay() applies it as a single undo entry.
+///
+/// This separation is what lets a preview be byte-identical to the apply (record once into a plan,
+/// replay to commit — no second run, so a seeded/noise-based fill cannot drift between the two) and
+/// what collapses a whole stamp/fill into one Ctrl-Z under the UndoStack command cap.
+struct FillPlan {
+    /// One placed object: its map data plus, when buildSprites is true, the visual Object. The
+    /// Object is null in headless/data-only mode (replay then records the MapObject as data) and
+    /// also when GUI art could not be resolved (replay then counts the entry as failed).
+    struct Entry {
+        std::shared_ptr<MapObject> mapObject;
+        std::shared_ptr<Object> object; ///< null when sprites are not built or art failed to load
+    };
+
+    std::vector<Entry> objects;
+    std::vector<TileChange> tiles;
+    int dropped = 0; ///< objects/tiles whose target fell off the grid (later: clipped/capped too)
+};
+
+} // namespace geck::pattern

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -8,13 +8,12 @@
 #include "editor/HexGeometry.h"
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
-#include "format/frm/Frm.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
-#include "format/map/Tile.h"
+#include "pattern/FillPlan.h"
 #include "pattern/PatternSprite.h"
+#include "pattern/PlacementBatch.h"
 #include "resource/GameResources.h"
-#include "editor/TileChange.h"
 #include "editing/commands/ObjectCommandController.h"
 
 namespace geck::pattern {
@@ -112,57 +111,54 @@ std::shared_ptr<MapObject> PatternStamper::makeMapObject(const ObjectPlacement& 
     return mapObject;
 }
 
-int PatternStamper::applyTiles(const std::vector<TilePlacement>& tiles, int elevation, const std::string& description) {
+void PatternStamper::appendTiles(FillPlan& out, const std::vector<TilePlacement>& tiles, int elevation) const {
     if (tiles.empty()) {
-        return 0;
+        return;
     }
-    std::vector<TileChange> changes;
-    changes.reserve(tiles.size());
     const auto& tilesByElevation = _map.getMapFile().tiles;
     const auto it = tilesByElevation.find(elevation);
+    out.tiles.reserve(out.tiles.size() + tiles.size());
     for (const TilePlacement& tp : tiles) {
         uint16_t before = static_cast<uint16_t>(Map::EMPTY_TILE);
         if (it != tilesByElevation.end() && tp.tileIndex >= 0 && tp.tileIndex < static_cast<int>(it->second.size())) {
             before = tp.isRoof ? it->second[tp.tileIndex].getRoof() : it->second[tp.tileIndex].getFloor();
         }
-        changes.push_back({ elevation, tp.tileIndex, tp.isRoof, before, tp.tileId });
+        out.tiles.push_back({ elevation, tp.tileIndex, tp.isRoof, before, tp.tileId });
     }
-    _controller.applyTileChanges(changes, true);
-    _controller.registerTileEdit(description + " (tiles)", changes);
-    return static_cast<int>(changes.size());
 }
 
-bool PatternStamper::registerStampObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid) {
-    // Headless (data-only): record the MapObject without a sprite — the .map stores just these ids,
-    // so a stamp's objects land even with no art or GL. GUI: build the sprite so it draws, which (as
-    // for placeObject) needs resolvable art.
-    if (!_buildSprites) {
-        return _controller.registerObjectData(mapObject);
+void PatternStamper::planInto(FillPlan& out, const PatternVariant& variant, int targetHex, int elevation) const {
+    const Plan p = plan(variant, targetHex);
+    out.dropped += p.objectsDropped + p.tilesDropped;
+
+    out.objects.reserve(out.objects.size() + p.objects.size());
+    for (const ObjectPlacement& op : p.objects) {
+        auto mapObject = makeMapObject(op, elevation);
+        // GUI: build the visual so the object draws (needs resolvable art; a null one is left in
+        // the entry and PlacementBatch counts it failed). Headless: no sprite — replay records the
+        // MapObject as data, so a stamp's objects land even with no art or GL.
+        std::shared_ptr<Object> object = _buildSprites ? buildObject(mapObject, op.frmPid) : nullptr;
+        out.objects.push_back({ std::move(mapObject), std::move(object) });
     }
-    const auto object = buildObject(mapObject, frmPid);
-    return object != nullptr && _controller.registerObjectPlacement(mapObject, object);
+
+    appendTiles(out, p.tiles, elevation);
 }
 
 PatternStamper::Result PatternStamper::stamp(const PatternVariant& variant, int targetHex, int elevation) {
-    const Plan p = plan(variant, targetHex);
+    FillPlan fp;
+    planInto(fp, variant, targetHex, elevation);
+
     Result r;
-    r.dropped = p.objectsDropped + p.tilesDropped;
-    if (p.objects.empty() && p.tiles.empty()) {
+    r.dropped = fp.dropped;
+    if (fp.objects.empty() && fp.tiles.empty()) {
         return r;
     }
 
     const std::string desc = variant.label.empty() ? "Stamp pattern" : ("Stamp pattern: " + variant.label);
-    ScopedUndoBatch batch(_controller, desc);
-
-    for (const ObjectPlacement& op : p.objects) {
-        if (registerStampObject(makeMapObject(op, elevation), op.frmPid)) {
-            ++r.objectsPlaced;
-        } else {
-            ++r.objectsFailed;
-        }
-    }
-    r.tilesPainted = applyTiles(p.tiles, elevation, desc);
-
+    const PlacementBatch::Result br = PlacementBatch::replay(_controller, fp, _buildSprites, desc);
+    r.objectsPlaced = br.objectsPlaced;
+    r.objectsFailed = br.objectsFailed;
+    r.tilesPainted = br.tilesPainted;
     r.success = true;
     return r;
 }

--- a/src/pattern/PatternStamper.cpp
+++ b/src/pattern/PatternStamper.cpp
@@ -138,7 +138,7 @@ void PatternStamper::planInto(FillPlan& out, const PatternVariant& variant, int 
         // the entry and PlacementBatch counts it failed). Headless: no sprite — replay records the
         // MapObject as data, so a stamp's objects land even with no art or GL.
         std::shared_ptr<Object> object = _buildSprites ? buildObject(mapObject, op.frmPid) : nullptr;
-        out.objects.push_back({ std::move(mapObject), std::move(object) });
+        out.objects.push_back({ std::move(mapObject), std::move(object) }); // NOSONAR: braced-init of an aggregate; emplace_back would need C++20 paren-aggregate-init
     }
 
     appendTiles(out, p.tiles, elevation);

--- a/src/pattern/PatternStamper.h
+++ b/src/pattern/PatternStamper.h
@@ -19,11 +19,14 @@ namespace resource {
 
 namespace geck::pattern {
 
+struct FillPlan;
+
 /// Places a pattern variant onto the map. Resolution (where each entry lands when the
 /// variant's anchor is dropped on a target hex) is a pure, dependency-free static step;
-/// application builds the objects/tiles and routes them through ObjectCommandController
-/// as a single undo entry. Entries are placed verbatim (no rotation) — orientation is
-/// chosen by selecting a variant, since Fallout 2 object art is direction-specific.
+/// building the objects/tiles (planInto) is non-mutating; committing (stamp) routes the
+/// built plan through ObjectCommandController as a single undo entry via PlacementBatch.
+/// Entries are placed verbatim (no rotation) — orientation is chosen by selecting a
+/// variant, since Fallout 2 object art is direction-specific.
 class PatternStamper {
 public:
     struct ObjectPlacement {
@@ -75,14 +78,21 @@ public:
     /// snapped to the anchor's parity (see plan()), so placement is tile-granular.
     Result stamp(const PatternVariant& variant, int targetHex, int elevation);
 
+    /// Resolve and BUILD `variant` near `targetHex` on `elevation` into `out` without committing:
+    /// each resolved object becomes a MapObject (and, when buildSprites is true, its visual Object)
+    /// and each tile a TileChange (before captured from the current map), appended to the plan.
+    /// Mutates nothing — PlacementBatch::replay(out) commits it. This is the capture path the
+    /// fill plan-sink uses so a stamp placed inside a fill is previewed, not applied. Appends, so a
+    /// caller can build one plan from several stamps; counts off-grid drops into `out.dropped`.
+    void planInto(FillPlan& out, const PatternVariant& variant, int targetHex, int elevation) const;
+
 private:
     std::shared_ptr<Object> buildObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid) const;
     // Build the MapObject for a resolved placement (position/flags/ids verbatim) on `elevation`.
     std::shared_ptr<MapObject> makeMapObject(const ObjectPlacement& placement, int elevation) const;
-    // Register one stamped object: as map data (buildSprites=false) or with a built sprite (true).
-    bool registerStampObject(const std::shared_ptr<MapObject>& mapObject, uint32_t frmPid);
-    // Apply the plan's tiles as one labelled tile edit; returns how many were painted.
-    int applyTiles(const std::vector<TilePlacement>& tiles, int elevation, const std::string& description);
+    // Resolve the plan's tiles into TileChanges (before-value read from the current map) and append
+    // them to `out`; builds nothing on the map (PlacementBatch applies them later).
+    void appendTiles(FillPlan& out, const std::vector<TilePlacement>& tiles, int elevation) const;
 
     resource::GameResources& _resources;
     const HexagonGrid& _hexgrid;

--- a/src/pattern/PlacementBatch.cpp
+++ b/src/pattern/PlacementBatch.cpp
@@ -1,0 +1,44 @@
+#include "pattern/PlacementBatch.h"
+
+#include "pattern/FillPlan.h"
+#include "editing/commands/ObjectCommandController.h"
+
+namespace geck::pattern {
+
+PlacementBatch::Result PlacementBatch::replay(ObjectCommandController& controller, const FillPlan& plan,
+    bool buildSprites, const std::string& description) {
+    Result r;
+    if (plan.objects.empty() && plan.tiles.empty()) {
+        return r;
+    }
+
+    // One batch for the whole plan: register*() buffer their commands and endBatch() collapses
+    // them into a single UndoStack entry, so a thousand-tile fill is one Ctrl-Z, not one per edit.
+    ScopedUndoBatch batch(controller, description);
+
+    for (const FillPlan::Entry& entry : plan.objects) {
+        // GUI: the object draws, so it needs a built visual; a null one (art that wouldn't load)
+        // is counted as failed and dropped, like the prefab stamper always did. Headless: record
+        // the MapObject as data — the .map stores only these ids, so no sprite or GL is needed.
+        const bool ok = buildSprites
+            ? (entry.object != nullptr && controller.registerObjectPlacement(entry.mapObject, entry.object))
+            : controller.registerObjectData(entry.mapObject);
+        if (ok) {
+            ++r.objectsPlaced;
+        } else {
+            ++r.objectsFailed;
+        }
+    }
+
+    if (!plan.tiles.empty()) {
+        // before/after were captured when the plan was built; apply the after-state now and record
+        // the same changes for undo (the controller applies, then registerTileEdit records).
+        controller.applyTileChanges(plan.tiles, true);
+        controller.registerTileEdit(description + " (tiles)", plan.tiles);
+        r.tilesPainted = static_cast<int>(plan.tiles.size());
+    }
+
+    return r;
+}
+
+} // namespace geck::pattern

--- a/src/pattern/PlacementBatch.h
+++ b/src/pattern/PlacementBatch.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+
+namespace geck {
+class ObjectCommandController;
+} // namespace geck
+
+namespace geck::pattern {
+
+struct FillPlan;
+
+/// Commits a FillPlan to the map as a SINGLE undo entry. This is the shared apply path for both
+/// prefab stamps (PatternStamper) and area fills (MapScriptApi's plan-sink): the objects and tiles
+/// are already built/resolved in the plan, so replay only registers them — nothing is rebuilt, so
+/// the committed result matches whatever produced the plan (a preview, a seeded run) byte for byte.
+struct PlacementBatch {
+    struct Result {
+        int objectsPlaced = 0;
+        int objectsFailed = 0; ///< an entry the controller refused (e.g. a null visual when sprites are required)
+        int tilesPainted = 0;
+    };
+
+    /// Replay `plan` into one ScopedUndoBatch labelled `description`. `buildSprites` mirrors the
+    /// producer: when true each entry is registered with its visual Object (registerObjectPlacement);
+    /// when false the entry's MapObject is recorded as data only (registerObjectData), so a plan
+    /// built headlessly lands without a GL context. An empty plan registers nothing.
+    static Result replay(ObjectCommandController& controller, const FillPlan& plan,
+        bool buildSprites, const std::string& description);
+};
+
+} // namespace geck::pattern

--- a/src/scripting/EditArea.h
+++ b/src/scripting/EditArea.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+
+namespace geck {
+
+/// The target of an area fill: the hexes and floor/roof tiles a user selection covers, projected to
+/// plain index lists the host builds from SelectionManager / SelectionState. A fill reads these via
+/// MapScriptApi's area-queries and writes only inside them.
+///
+/// Each list MUST be sorted ascending: areaContains*() binary-searches them, and a seeded fill
+/// iterates them in this canonical order, so the same selection + seed reproduces the same result.
+/// Hex indices are 0..39999 (200x200); tile indices are 0..9999 (100x100) — the two grids are
+/// distinct (see CLAUDE.md), so never cross-validate one against the other's range.
+struct EditArea {
+    std::vector<int> hexes;
+    std::vector<int> floorTiles;
+    std::vector<int> roofTiles;
+};
+
+} // namespace geck

--- a/src/scripting/LuaScriptRuntime.cpp
+++ b/src/scripting/LuaScriptRuntime.cpp
@@ -1,6 +1,7 @@
 #include "scripting/LuaScriptRuntime.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
@@ -22,6 +23,48 @@
 namespace geck {
 
 namespace {
+    // Time-budget watchdog. A pointer to one of these lives in lua_callbacks(L)->userdata (the
+    // documented per-state scratch slot, untouched by Luau and unused by LuaBridge), so the
+    // safepoint interrupt below can read the deadline straight off the lua_State.
+    struct TimeBudget {
+        std::chrono::steady_clock::time_point deadline;
+    };
+
+    // Called by Luau at safepoints (loop back-edges, call/ret, gc). `gc >= 0` marks a GC step:
+    // we must not longjmp out of the collector, so we only abort on the non-GC safepoints. Past
+    // the deadline, luaL_error raises a runtime error that unwinds the pcall — the standard Luau
+    // timeout pattern. Clearing the callback first stops it re-firing during the unwind.
+    void timeBudgetInterrupt(lua_State* L, int gc) {
+        if (gc >= 0) {
+            return;
+        }
+        const auto* budget = static_cast<const TimeBudget*>(lua_callbacks(L)->userdata);
+        if (budget == nullptr) {
+            return;
+        }
+        if (std::chrono::steady_clock::now() >= budget->deadline) {
+            lua_callbacks(L)->interrupt = nullptr;
+            luaL_error(L, "script exceeded its time budget (possible infinite loop)");
+        }
+    }
+
+    // RAII teardown for the run's lua_State: on EVERY exit path (normal return, early compile-error
+    // return, or a C++ exception unwinding out of the run) it disarms the watchdog FIRST — so the
+    // interrupt can't fire (and luaL_error/longjmp) during lua_close's GC, or read the by-then-dead
+    // TimeBudget — then closes the state so it never leaks. Disarming is two pointer writes and
+    // lua_close runs no Lua callbacks once disarmed, so the destructor never throws.
+    struct LuaStateGuard {
+        lua_State* L;
+        ~LuaStateGuard() {
+            if (L == nullptr) {
+                return;
+            }
+            lua_callbacks(L)->interrupt = nullptr;
+            lua_callbacks(L)->userdata = nullptr;
+            lua_close(L);
+        }
+    };
+
     // print(...) capture: append each argument (tab-separated) plus a newline to the std::string
     // carried as a lightuserdata upvalue, so console scripts can report progress.
     int capturePrint(lua_State* L) {
@@ -45,13 +88,17 @@ namespace {
 }
 
 ScriptResult LuaScriptRuntime::run(const std::string& source, MapScriptApi& api,
-    ObjectCommandController& controller, const std::string& description, const ScriptArgs& args) {
+    ObjectCommandController& controller, const std::string& description, const ScriptArgs& args,
+    unsigned timeBudgetMs) {
     ScriptResult result;
 
     lua_State* L = luaL_newstate();
     if (L == nullptr) {
         return { false, "failed to create Luau state", "" };
     }
+    // From here, the state (and the watchdog disarm) is owned by RAII: every return below, and any
+    // exception unwinding through this function, tears it down correctly.
+    LuaStateGuard stateGuard{ L };
     luaL_openlibs(L); // Luau's stdlib is already safe: no `io`, `os` trimmed, no bytecode loaders
 
     // Replace print() with one that captures into result.output (a stable stack local for this run).
@@ -130,13 +177,25 @@ ScriptResult LuaScriptRuntime::run(const std::string& source, MapScriptApi& api,
     if (loadResult != 0) {
         result.ok = false;
         result.error = std::string("compile error: ") + lua_tostring(L, -1);
-        lua_close(L);
-        return result;
+        return result; // stateGuard closes L
+    }
+
+    // Arm the time-budget watchdog (GUI live previews pass a budget; trusted CLI/batch runs pass 0).
+    // The TimeBudget lives on this stack frame, which outlives the pcall below; its address goes in
+    // the per-state userdata slot the interrupt reads. The deadline is taken here so it covers only
+    // execution, not the compile above.
+    TimeBudget budget;
+    if (timeBudgetMs > 0) {
+        budget.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeBudgetMs);
+        lua_callbacks(L)->userdata = &budget;
+        lua_callbacks(L)->interrupt = &timeBudgetInterrupt;
     }
 
     {
-        // The whole run is one undo entry: every api mutator buffers into this batch, and
-        // endBatch() (on scope exit) collapses them — even if the script errors part-way.
+        // The whole run is one undo entry: a committing run's api mutators buffer into this batch and
+        // endBatch() (on scope exit) collapses them — even if the script errors part-way. When the
+        // caller has installed a plan sink (a fill preview), the mutators record into the sink and
+        // commit nothing, so this batch stays empty and endBatch() pushes nothing — a harmless no-op.
         ScopedUndoBatch batch(controller, description);
         if (lua_pcall(L, 0, 0, 0) != 0) {
             result.ok = false;
@@ -146,7 +205,7 @@ ScriptResult LuaScriptRuntime::run(const std::string& source, MapScriptApi& api,
         }
     }
 
-    lua_close(L);
+    // stateGuard disarms the watchdog and closes the state on return (and on any exception above).
     return result;
 }
 

--- a/src/scripting/LuaScriptRuntime.h
+++ b/src/scripting/LuaScriptRuntime.h
@@ -31,11 +31,17 @@ public:
     /// Bind `api`, sandbox, compile + run `source`. Returns ok=false with a message on a
     /// compile or runtime error; partial edits made before the error are still flushed as
     /// the one undo entry, so the user can Ctrl-Z a failed run.
+    ///
+    /// `timeBudgetMs` guards against a runaway script (e.g. an infinite loop in a live GUI
+    /// preview): when > 0, a safepoint interrupt aborts the run once that wall-clock budget
+    /// elapses, returning ok=false with a "time budget" message. 0 (the default) means no
+    /// limit — batch/CLI generation runs are trusted and may take as long as they need.
     ScriptResult run(const std::string& source,
         MapScriptApi& api,
         ObjectCommandController& controller,
         const std::string& description = "Run script",
-        const ScriptArgs& args = {});
+        const ScriptArgs& args = {},
+        unsigned timeBudgetMs = 0);
 };
 
 } // namespace geck

--- a/src/scripting/MapScriptApi.cpp
+++ b/src/scripting/MapScriptApi.cpp
@@ -329,7 +329,7 @@ bool MapScriptApi::registerObject(const std::shared_ptr<MapObject>& mapObject, i
             }
             object->setMapObject(mapObject);
         }
-        _planSink->objects.push_back({ mapObject, std::move(object) });
+        _planSink->objects.push_back({ mapObject, std::move(object) }); // NOSONAR: braced-init of an aggregate; emplace_back would need C++20 paren-aggregate-init
         ++_placedObjects;
         return true;
     }

--- a/src/scripting/MapScriptApi.cpp
+++ b/src/scripting/MapScriptApi.cpp
@@ -14,6 +14,7 @@
 #include "editor/Hex.h"
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
+#include "scripting/EditArea.h"
 #include "format/lst/Lst.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
@@ -21,6 +22,7 @@
 #include "format/msg/Msg.h"
 #include "format/pro/Pro.h"
 #include "editor/TileChange.h"
+#include "pattern/FillPlan.h"
 #include "pattern/PatternSprite.h"
 #include "pattern/PatternStamper.h"
 #include "reader/map/MapReader.h"
@@ -223,6 +225,15 @@ namespace {
         h ^= h >> 16;
         return (h & 0xFFFFFFu) / static_cast<double>(0x1000000);
     }
+
+    // 3D form of latticeValue: a stable [0,1) hash of a (xi, yi, zi) lattice corner.
+    double latticeValue3(int xi, int yi, int zi) {
+        uint32_t h = static_cast<uint32_t>(xi) * 374761393u + static_cast<uint32_t>(yi) * 668265263u
+            + static_cast<uint32_t>(zi) * 2246822519u;
+        h = (h ^ (h >> 13)) * 1274126177u;
+        h ^= h >> 16;
+        return (h & 0xFFFFFFu) / static_cast<double>(0x1000000);
+    }
 } // namespace
 
 double MapScriptApi::noise2d(double x, double y) const {
@@ -239,6 +250,25 @@ double MapScriptApi::noise2d(double x, double y) const {
     const double v11 = latticeValue(xi + 1, yi + 1);
 
     return std::lerp(std::lerp(v00, v10, tx), std::lerp(v01, v11, tx), ty); // bilinear -> [0,1)
+}
+
+double MapScriptApi::noise3d(double x, double y, double z) const {
+    const double xf = std::floor(x);
+    const double yf = std::floor(y);
+    const double zf = std::floor(z);
+    const int xi = static_cast<int>(xf);
+    const int yi = static_cast<int>(yf);
+    const int zi = static_cast<int>(zf);
+    const double tx = fade(x - xf);
+    const double ty = fade(y - yf);
+    const double tz = fade(z - zf);
+
+    // Trilinear blend of the 8 cube-corner lattice values -> [0,1).
+    const double x00 = std::lerp(latticeValue3(xi, yi, zi), latticeValue3(xi + 1, yi, zi), tx);
+    const double x10 = std::lerp(latticeValue3(xi, yi + 1, zi), latticeValue3(xi + 1, yi + 1, zi), tx);
+    const double x01 = std::lerp(latticeValue3(xi, yi, zi + 1), latticeValue3(xi + 1, yi, zi + 1), tx);
+    const double x11 = std::lerp(latticeValue3(xi, yi + 1, zi + 1), latticeValue3(xi + 1, yi + 1, zi + 1), tx);
+    return std::lerp(std::lerp(x00, x10, ty), std::lerp(x01, x11, ty), tz);
 }
 
 uint32_t MapScriptApi::proto(const std::string& typeName, int number) const {
@@ -286,6 +316,24 @@ void MapScriptApi::endBatch() {
 }
 
 bool MapScriptApi::registerObject(const std::shared_ptr<MapObject>& mapObject, int hex, uint32_t frmPid, uint32_t direction) {
+    // Plan-sink active (preview / area fill): build the object exactly as the commit paths do
+    // (GUI needs a resolvable sprite — a fid that won't load is "not placed", same as below;
+    // headless records data with a null visual) but RECORD it into the plan instead of committing.
+    // PlacementBatch::replay applies the plan later, so the result matches a direct run.
+    if (_planSink != nullptr) {
+        std::shared_ptr<Object> object;
+        if (_buildSprites) {
+            object = pattern::buildSpriteObject(_resources, _hexgrid, frmPid, hex, direction);
+            if (!object) {
+                return false;
+            }
+            object->setMapObject(mapObject);
+        }
+        _planSink->objects.push_back({ mapObject, std::move(object) });
+        ++_placedObjects;
+        return true;
+    }
+
     // Headless: record the MapObject as data only. The .map stores just these ids; the engine
     // and editor resolve the art (frmPid) when the map is loaded, so no sprite or GL is needed
     // and placement does not require the FRM to be present in the mounted data.
@@ -363,6 +411,13 @@ bool MapScriptApi::paintTile(int tileIndex, uint16_t tileId, bool isRoof) {
         return false;
     }
     const uint16_t before = isRoof ? getRoof(tileIndex) : getFloor(tileIndex);
+    // Plan-sink active: record the tile change (before captured from the committed map) instead of
+    // applying it; PlacementBatch::replay applies it later as part of the one-entry batch.
+    if (_planSink != nullptr) {
+        _planSink->tiles.push_back({ _elevation, tileIndex, isRoof, before, tileId });
+        ++_paintedTiles;
+        return true;
+    }
     std::vector<TileChange> changes{ { _elevation, tileIndex, isRoof, before, tileId } };
     _controller.applyTileChanges(changes, true);
     _controller.registerTileEdit(isRoof ? "Script: paint roof" : "Script: paint floor", changes);
@@ -409,6 +464,62 @@ uint16_t MapScriptApi::getRoofXY(int col, int row) const {
     return getRoof(tileIndex(col, row));
 }
 
+// --- Selection area ----------------------------------------------------------
+bool MapScriptApi::hasArea() const {
+    return _area != nullptr;
+}
+
+std::vector<int> MapScriptApi::areaHexes() const {
+    return _area != nullptr ? _area->hexes : std::vector<int>{};
+}
+
+std::vector<int> MapScriptApi::areaFloorTiles() const {
+    return _area != nullptr ? _area->floorTiles : std::vector<int>{};
+}
+
+std::vector<int> MapScriptApi::areaRoofTiles() const {
+    return _area != nullptr ? _area->roofTiles : std::vector<int>{};
+}
+
+bool MapScriptApi::areaContainsHex(int hex) const {
+    // The area lists are sorted ascending by contract (see EditArea), so membership is a binary search.
+    return _area != nullptr && std::ranges::binary_search(_area->hexes, hex);
+}
+
+bool MapScriptApi::areaContainsTile(int tileIndex) const {
+    return _area != nullptr && std::ranges::binary_search(_area->floorTiles, tileIndex);
+}
+
+// --- Deterministic helpers ---------------------------------------------------
+uint32_t MapScriptApi::objectAt(int hex) const {
+    const auto& byElevation = _map.getMapFile().map_objects;
+    const auto it = byElevation.find(_elevation);
+    if (it == byElevation.end()) {
+        return 0;
+    }
+    for (const auto& object : it->second) {
+        if (object && static_cast<int>(object->position) == hex) {
+            return object->pro_pid;
+        }
+    }
+    return 0;
+}
+
+double MapScriptApi::rng() {
+    // Top 24 bits of the mt19937 word mapped to [0,1). mt19937's sequence is standardised and the
+    // shift/divide are integer-exact, so the same seed gives the same draws on every platform —
+    // unlike std::uniform_real_distribution, whose output is implementation-defined.
+    return (static_cast<uint32_t>(_rng()) >> 8) * (1.0 / 16777216.0);
+}
+
+int MapScriptApi::rngInt(int lo, int hi) {
+    if (hi < lo) {
+        std::swap(lo, hi);
+    }
+    const uint32_t range = static_cast<uint32_t>(hi - lo) + 1u;
+    return lo + static_cast<int>(static_cast<uint32_t>(_rng()) % range);
+}
+
 bool MapScriptApi::placeObjectXY(uint32_t proPid, uint32_t frmPid, int col, int row, uint32_t direction) {
     return placeObject(proPid, frmPid, hexIndex(col, row), direction);
 }
@@ -441,6 +552,18 @@ int MapScriptApi::placeStamp(const std::string& name, int anchorHex, int variant
         throw ScriptError("placeStamp: variant " + std::to_string(variant) + " out of range for stamp '" + name + "'");
     }
     pattern::PatternStamper stamper(_resources, _hexgrid, _controller, _map, _buildSprites);
+    // Plan-sink active: capture the stamp's built objects/tiles into the plan (committing nothing),
+    // so a stamp scattered by a fill is previewed and lands in the fill's single undo entry. Without
+    // this, placeStamp would open its own ScopedUndoBatch and mutate the live map during preview.
+    if (_planSink != nullptr) {
+        const std::size_t objBefore = _planSink->objects.size();
+        const std::size_t tileBefore = _planSink->tiles.size();
+        stamper.planInto(*_planSink, pattern.variants[variant], anchorHex, _elevation);
+        const int placed = static_cast<int>(_planSink->objects.size() - objBefore);
+        _placedObjects += placed;
+        _paintedTiles += static_cast<int>(_planSink->tiles.size() - tileBefore);
+        return placed;
+    }
     const pattern::PatternStamper::Result result = stamper.stamp(pattern.variants[variant], anchorHex, _elevation);
     _placedObjects += result.objectsPlaced;
     _paintedTiles += result.tilesPainted;
@@ -448,11 +571,21 @@ int MapScriptApi::placeStamp(const std::string& name, int anchorHex, int variant
 }
 
 void MapScriptApi::newMap() {
+    // These whole-map/header mutators can't be expressed as a deferred FillPlan (replay only
+    // applies object/tile changes), so they must never run while a sink is recording a fill
+    // preview — doing so would mutate the live map directly and break preview==apply. Reject with
+    // a clear error instead; a fill script paints/scatters, it does not reset the map.
+    if (_planSink != nullptr) {
+        throw ScriptError("newMap() is not allowed in a fill — it would reset the live map");
+    }
     _controller.newEmptyMap();
     _mutatedDirectly = true;
 }
 
 void MapScriptApi::setPlayerStart(int hex, int orientation, int elevation) {
+    if (_planSink != nullptr) {
+        throw ScriptError("setPlayerStart() is not allowed in a fill — header edits aren't part of a fill plan");
+    }
     if (!isValidHex(hex)) {
         throw ScriptError("setPlayerStart: hex " + std::to_string(hex) + " is off the 200x200 hex grid");
     }

--- a/src/scripting/MapScriptApi.cpp
+++ b/src/scripting/MapScriptApi.cpp
@@ -256,9 +256,9 @@ double MapScriptApi::noise3d(double x, double y, double z) const {
     const double xf = std::floor(x);
     const double yf = std::floor(y);
     const double zf = std::floor(z);
-    const int xi = static_cast<int>(xf);
-    const int yi = static_cast<int>(yf);
-    const int zi = static_cast<int>(zf);
+    const auto xi = static_cast<int>(xf);
+    const auto yi = static_cast<int>(yf);
+    const auto zi = static_cast<int>(zf);
     const double tx = fade(x - xf);
     const double ty = fade(y - yf);
     const double tz = fade(z - zf);
@@ -559,7 +559,7 @@ int MapScriptApi::placeStamp(const std::string& name, int anchorHex, int variant
         const std::size_t objBefore = _planSink->objects.size();
         const std::size_t tileBefore = _planSink->tiles.size();
         stamper.planInto(*_planSink, pattern.variants[variant], anchorHex, _elevation);
-        const int placed = static_cast<int>(_planSink->objects.size() - objBefore);
+        const auto placed = static_cast<int>(_planSink->objects.size() - objBefore);
         _placedObjects += placed;
         _paintedTiles += static_cast<int>(_planSink->tiles.size() - tileBefore);
         return placed;

--- a/src/scripting/MapScriptApi.h
+++ b/src/scripting/MapScriptApi.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -15,7 +16,11 @@ namespace geck {
 class HexagonGrid;
 class Map;
 struct MapObject;
+struct EditArea;
 class ObjectCommandController;
+namespace pattern {
+    struct FillPlan;
+}
 namespace resource {
     class GameResources;
 }
@@ -120,9 +125,49 @@ public:
     uint16_t getFloorXY(int col, int row) const;
     uint16_t getRoofXY(int col, int row) const;
 
+    // --- Selection area (host-set per run; the queries below read it) -------------
+    /// True if a selection area is bound to this run (see setArea).
+    bool hasArea() const;
+    /// The selection's hex / floor-tile / roof-tile indices, ascending (empty if no area is bound).
+    std::vector<int> areaHexes() const;
+    std::vector<int> areaFloorTiles() const;
+    std::vector<int> areaRoofTiles() const;
+    /// Is `hex` inside the selection? (binary search — the area lists are sorted.)
+    bool areaContainsHex(int hex) const;
+    /// Is `tileIndex` inside the selection's floor tiles?
+    bool areaContainsTile(int tileIndex) const;
+
+    // --- Deterministic helpers (seeded; for reproducible scatter) -----------------
+    /// PID of an object occupying `hex` in the COMMITTED map (0 if none). It does NOT see placements
+    /// already recorded in the current plan sink, so intra-fill occupancy is the caller's to track.
+    uint32_t objectAt(int hex) const;
+    /// Coherent 3D value noise in [0,1]; the z axis varies the field per seed/octave (cf. noise2d).
+    double noise3d(double x, double y, double z) const;
+    /// Next draw from this api's seeded stream (see setSeed): rng() in [0,1), rngInt(lo,hi) an int in
+    /// [lo,hi]. Deterministic and cross-platform (mt19937 + integer reduction), so a seed reproduces.
+    double rng();
+    int rngInt(int lo, int hi);
+
     // --- Undo batching -----------------------------------------------------------
     void beginBatch(const std::string& description);
     void endBatch();
+
+    // --- Plan sink (host-only; not script-bound) ---------------------------------
+    /// Redirect the mutators: while a sink is installed, placeObject/placeProto/paint*/placeStamp/
+    /// placeExitGrid* RECORD their fully-built objects and tiles into `sink` and commit NOTHING to
+    /// the map (no undo entry, no live mutation). The host then applies the captured plan as one
+    /// undo entry via pattern::PlacementBatch::replay — so a preview is byte-identical to the apply
+    /// even for seeded/noise runs, and a whole fill collapses to one Ctrl-Z. Pass nullptr to restore
+    /// direct (committing) behaviour. Queries (getFloor, objectAt, …) always read the COMMITTED map,
+    /// so they do not see edits already recorded in the current plan.
+    void setPlanSink(pattern::FillPlan* sink) { _planSink = sink; }
+
+    /// Bind the selection area the area-queries report (borrowed, must outlive the run; nullptr
+    /// clears it). Host-only — a script can't fabricate its own area. See EditArea.
+    void setArea(const EditArea* area) { _area = area; }
+    /// Seed this api's deterministic stream (rng/rngInt) so a fill reproduces. Host-only; the GUI/CLI
+    /// set it from the run's seed, exactly as LuaScriptRuntime seeds Lua's math.random.
+    void setSeed(uint32_t seed) { _rng.seed(seed); }
 
     // --- Mutators (undoable; batch to collapse into one history entry) -----------
     /// Build and place an object at `hex`. Returns false if `hex` is off-grid or the
@@ -220,6 +265,12 @@ private:
     // so mutated() reports them even though the placed/painted counters stay at 0.
     bool _mutatedDirectly = false;
     std::unordered_map<std::string, pattern::Pattern> _stamps;
+    // When non-null, mutators record into this plan instead of committing (see setPlanSink). Borrowed.
+    pattern::FillPlan* _planSink = nullptr;
+    // The selection area the area-queries report (see setArea). Borrowed; null when none is bound.
+    const EditArea* _area = nullptr;
+    // Deterministic stream for rng()/rngInt(); reseed per run via setSeed for reproducible scatter.
+    std::mt19937 _rng;
 };
 
 } // namespace geck

--- a/src/scripting/MapScriptApi.h
+++ b/src/scripting/MapScriptApi.h
@@ -270,7 +270,7 @@ private:
     // The selection area the area-queries report (see setArea). Borrowed; null when none is bound.
     const EditArea* _area = nullptr;
     // Deterministic stream for rng()/rngInt(); reseed per run via setSeed for reproducible scatter.
-    std::mt19937 _rng;
+    std::mt19937 _rng; // NOSONAR: seeded for reproducible fills, not a security-sensitive use
 };
 
 } // namespace geck

--- a/src/scripting/ScriptApiReference.h
+++ b/src/scripting/ScriptApiReference.h
@@ -26,6 +26,18 @@ namespace geck {
     X(mapFloorTiles, "(mapPath) -> {id,...}", "A reference map's floor-tile ids, most-used first.")                                                                    \
     X(listMaps, "() -> {path,...}", "Every map file in the mounted data.")                                                                                             \
     X(noise2d, "(x, y) -> [0,1]", "Coherent value noise — a density field for natural clumps/clearings.")                                                              \
+    X(noise3d, "(x, y, z) -> [0,1]", "Coherent 3D value noise; the z axis varies the field per seed/octave.")                                                          \
+    X(objectAt, "(hex) -> pid", "PID of an object occupying hex in the committed map (0 if none).")                                                                    \
+    /* Selection area (host-set per run; empty when no area is bound) */                                                                                               \
+    X(hasArea, "() -> bool", "True if a selection area is bound to this run.")                                                                                         \
+    X(areaHexes, "() -> {hex,...}", "Hex indices in the selection, ascending.")                                                                                        \
+    X(areaFloorTiles, "() -> {tileIndex,...}", "Floor-tile indices in the selection, ascending.")                                                                      \
+    X(areaRoofTiles, "() -> {tileIndex,...}", "Roof-tile indices in the selection, ascending.")                                                                        \
+    X(areaContainsHex, "(hex) -> bool", "Is hex inside the selection?")                                                                                                \
+    X(areaContainsTile, "(tileIndex) -> bool", "Is the floor tile inside the selection?")                                                                              \
+    /* Deterministic seeded helpers (reproducible scatter) */                                                                                                          \
+    X(rng, "() -> [0,1)", "Next draw from the seeded stream, in [0,1).")                                                                                               \
+    X(rngInt, "(lo, hi) -> int", "Next seeded integer draw in [lo,hi].")                                                                                               \
     /* Coordinates (hex grid 200x200, tile grid 100x100; position = row*width + col) */                                                                                \
     X(hexIndex, "(col, row) -> hex", "Hex index from (col, row); -1 if off-grid.")                                                                                     \
     X(tileIndex, "(col, row) -> tileIndex", "Tile index from (col, row); -1 if off-grid.")                                                                             \
@@ -44,7 +56,7 @@ namespace geck {
     X(placeProtoXY, "(proPid, col, row, dir) -> bool", "placeProto at a (col, row) hex.")                                                                              \
     X(placeStamp, "(name, anchorHex, variant) -> int", "Place a pre-loaded stamp (extract_pattern prefab); returns objects placed.")                                   \
     /* Map setup (spawn / exits) */                                                                                                                                    \
-    X(newMap, "() -> nil", "Reset the bound map to a fresh empty Fallout 2 map (destructive, not undoable). Call first to start from a blank slate.")                   \
+    X(newMap, "() -> nil", "Reset the bound map to a fresh empty Fallout 2 map (destructive, not undoable). Call first to start from a blank slate.")                  \
     X(setPlayerStart, "(hex, orientation, elevation) -> nil", "Set the player spawn in the map header (hex, orientation 0..5, elevation 0..2).")                       \
     X(placeExitGrid, "(hex, destMapId, destHex, destElevation, orientation) -> bool", "Place a map-exit grid; destMapId -2 = worldmap, -1 = town map, else a map id.") \
     X(placeExitGridRect, "(centerHex, screenHalfWidth, screenHalfHeight, destMapId, destHex, destElevation, orientation) -> int", "Place a screen-space rectangle border of exit grids around centerHex; returns markers placed.")

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1384,7 +1384,10 @@ namespace {
         selection::SelectionManager& selectionManager) {
         // Sentinel-initialised so each contributing tile just min/max-folds in (no first-vs-rest branch).
         constexpr float INF = std::numeric_limits<float>::max();
-        float minX = INF, minY = INF, maxX = -INF, maxY = -INF;
+        float minX = INF;
+        float minY = INF;
+        float maxX = -INF;
+        float maxY = -INF;
         bool any = false;
         const auto extend = [&](const std::vector<sf::Sprite>& sprites, int index) {
             if (index < 0 || index >= static_cast<int>(sprites.size())) {
@@ -1453,10 +1456,9 @@ bool EditorWidget::hasFillableSelection() const {
     }
     // Any tile or hex makes the selection fillable; a pure-object selection does not (a floor fill
     // needs tiles, scatter needs hexes — objects are neither).
+    using enum selection::SelectionType;
     for (const auto& item : selectionManager->getCurrentSelection().items) {
-        if (item.type == selection::SelectionType::FLOOR_TILE
-            || item.type == selection::SelectionType::ROOF_TILE
-            || item.type == selection::SelectionType::HEX) {
+        if (item.type == FLOOR_TILE || item.type == ROOF_TILE || item.type == HEX) {
             return true;
         }
     }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -2,16 +2,16 @@
 #include "ui/core/EditorHints.h"
 #include "ui/widgets/SFMLWidget.h"
 #include "ui/input/InputHandler.h"
-#ifdef GECK_SCRIPTING_ENABLED
+// The stamp library + MapScriptApi are used by both the (scripting-only) Console and the always-on
+// area fill, so these are included unconditionally — only runScript itself stays #ifdef'd.
 #include "Application.h"
-#include "scripting/MapScriptApi.h"
 #include "pattern/PatternLibrary.h"
 #include "pattern/PatternSerializer.h"
+#include "scripting/MapScriptApi.h"
 #include <QDirIterator>
 #include <QFile>
 #include <QFileInfo>
 #include <QStringList>
-#endif
 #include "editing/commands/ObjectCommandController.h"
 #include "rendering/MapSpriteLoader.h"
 #include "rendering/RenderingEngine.h"
@@ -43,6 +43,10 @@
 #include "pattern/PatternStamper.h"
 #include "pattern/PatternSprite.h"
 #include "editor/HexagonGrid.h"
+
+// Area fill commits its plan through PlacementBatch (MapScriptApi is already included above, used by
+// both the scripting console and the always-on area fill; only the Luau producer is #ifdef'd).
+#include "pattern/PlacementBatch.h"
 
 #include "format/frm/Frm.h"
 #include "format/map/Tile.h"
@@ -382,7 +386,6 @@ void EditorWidget::init() {
     _controller.viewport().initialize(windowSize);
 }
 
-#ifdef GECK_SCRIPTING_ENABLED
 namespace {
     // Load every *.json stamp under `dir` into `api`, keyed by each pattern's name. Appends one
     // diagnostic line per file we couldn't open or that the deserializer rejected, so a bad stamp is
@@ -422,6 +425,7 @@ namespace {
     }
 } // namespace
 
+#ifdef GECK_SCRIPTING_ENABLED
 ScriptResult EditorWidget::runScript(const std::string& source) {
     if (!_session.map()) {
         return { false, "No map loaded", "" };
@@ -963,9 +967,18 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     renderData.selectedRoofTiles = &_controller.visualizer().roofVisuals();
     renderData.dragPreviewObject = &_dragPreviewObject;
     renderData.isDraggingFromPalette = _isDraggingFromPalette;
-    renderData.stampPreview.floorTiles = &_stampPreviewFloorTiles;
-    renderData.stampPreview.objects = &_stampPreviewObjects;
-    renderData.stampPreview.roofTiles = &_stampPreviewRoofTiles;
+    // The ghost-overlay field is shared: a fill preview and a stamp ghost are never live at once, so
+    // point it at whichever is active (A3 reuses the stamp preview's render path rather than adding a
+    // second field).
+    if (_fillPreviewActive) {
+        renderData.stampPreview.floorTiles = &_fillPreviewFloorTiles;
+        renderData.stampPreview.objects = &_fillPreviewObjects;
+        renderData.stampPreview.roofTiles = &_fillPreviewRoofTiles;
+    } else {
+        renderData.stampPreview.floorTiles = &_stampPreviewFloorTiles;
+        renderData.stampPreview.objects = &_stampPreviewObjects;
+        renderData.stampPreview.roofTiles = &_stampPreviewRoofTiles;
+    }
     renderData.selectionRectangle = &_selectionRectangle;
     // Use InputHandler state for drag selection rendering
     renderData.isDragSelecting = _inputHandler && _inputHandler->isDragging();
@@ -1357,6 +1370,202 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
         object->getSprite().setColor(ghostAlpha); // semi-transparent ghost
         _stampPreviewObjects.push_back(std::move(object));
     }
+}
+
+// ---- Area fill over the current selection (driven by a Luau fill script) ------------------------
+
+EditArea EditorWidget::selectionFillArea() const {
+    EditArea area;
+    auto* selectionManager = _session.selectionManager();
+    if (!selectionManager) {
+        return area;
+    }
+    const selection::SelectionState& state = selectionManager->getCurrentSelection();
+    area.floorTiles = state.getFloorTileIndices();
+    area.roofTiles = state.getRoofTileIndices();
+    area.hexes = state.getHexIndices();
+
+    // A tile selection carries no hexes, but object scatter iterates the area's hexes. Derive the
+    // hexes covering the selected tiles from their on-screen bounds, so a floor/area selection can
+    // scatter objects over the same region. Exact for a rectangular drag; a non-rectangular tile
+    // selection over-includes the hexes in its bounding box (acceptable for a scatter region).
+    if (area.hexes.empty() && (!area.floorTiles.empty() || !area.roofTiles.empty())) {
+        const auto& floorSprites = _session.floorSprites();
+        const auto& roofSprites = _session.roofSprites();
+        bool any = false;
+        float minX = 0.f, minY = 0.f, maxX = 0.f, maxY = 0.f;
+        const auto extend = [&](const std::vector<sf::Sprite>& sprites, int index) {
+            if (index < 0 || index >= static_cast<int>(sprites.size())) {
+                return;
+            }
+            const sf::FloatRect b = sprites[index].getGlobalBounds();
+            if (b.size.x <= 0.f || b.size.y <= 0.f) {
+                return; // empty tile: no sprite bounds to contribute
+            }
+            const float l = b.position.x;
+            const float t = b.position.y;
+            const float r = l + b.size.x;
+            const float btm = t + b.size.y;
+            if (!any) {
+                minX = l;
+                minY = t;
+                maxX = r;
+                maxY = btm;
+                any = true;
+            } else {
+                minX = std::min(minX, l);
+                minY = std::min(minY, t);
+                maxX = std::max(maxX, r);
+                maxY = std::max(maxY, btm);
+            }
+        };
+        for (const int tileIndex : area.floorTiles) {
+            extend(floorSprites, tileIndex);
+        }
+        for (const int tileIndex : area.roofTiles) {
+            extend(roofSprites, tileIndex);
+        }
+        if (any) {
+            const sf::FloatRect bounds(sf::Vector2f(minX, minY), sf::Vector2f(maxX - minX, maxY - minY));
+            area.hexes = selectionManager->getHexesInArea(bounds);
+        }
+    }
+
+    // EditArea's contract: each list ascending AND unique (areaContains* binary-searches; the seeded
+    // fill iterates in this canonical order, so the same selection + seed reproduces the same result,
+    // and a duplicated index would be painted/counted twice).
+    const auto sortUnique = [](std::vector<int>& v) {
+        std::ranges::sort(v);
+        v.erase(std::unique(v.begin(), v.end()), v.end());
+    };
+    sortUnique(area.floorTiles);
+    sortUnique(area.roofTiles);
+    sortUnique(area.hexes);
+    return area;
+}
+
+bool EditorWidget::hasFillableSelection() const {
+    auto* selectionManager = _session.selectionManager();
+    if (!selectionManager) {
+        return false;
+    }
+    // Any tile or hex makes the selection fillable; a pure-object selection does not (a floor fill
+    // needs tiles, scatter needs hexes — objects are neither).
+    for (const auto& item : selectionManager->getCurrentSelection().items) {
+        if (item.type == selection::SelectionType::FLOOR_TILE
+            || item.type == selection::SelectionType::ROOF_TILE
+            || item.type == selection::SelectionType::HEX) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#ifdef GECK_SCRIPTING_ENABLED
+ScriptResult EditorWidget::previewLuaFill(const EditArea& area, const std::string& source, uint32_t seed) {
+    // A generous wall-clock cap for a live preview: long enough for a real procedural fill over a
+    // large selection, short enough that an accidental infinite loop aborts instead of hanging the UI.
+    constexpr unsigned FILL_SCRIPT_BUDGET_MS = 3000;
+
+    clearFillPreview();
+    if (!_session.map()) {
+        return { false, "No map loaded", "" };
+    }
+    // Record into the plan sink instead of committing: the script's api:paintFloor/scatter/placeStamp
+    // calls buffer into _fillPlan while the live map stays untouched, so the result previews as a
+    // ghost and applyFillPreview() replays it as one undo entry. setArea exposes the selection to
+    // api:areaFloorTiles()/areaHexes(),
+    // and setSeed makes api:rng()/rngInt() reproducible from the dialog's seed.
+    MapScriptApi api(_resources, _session.hexgrid(), _controller.commandController(), *_session.map(), _session.currentElevation());
+    registerLibraryStamps(api);
+    api.setArea(&area);
+    api.setPlanSink(&_fillPlan);
+    api.setSeed(seed);
+
+    LuaScriptRuntime runtime;
+    ScriptArgs args;
+    args["seed"] = std::to_string(seed); // also reproducible via math.random / args.seed
+    ScriptResult result = runtime.run(
+        source, api, _controller.commandController(), "Fill (script)", args, FILL_SCRIPT_BUDGET_MS);
+
+    if (!result.ok) {
+        clearFillPreview();
+        Q_EMIT statusMessageRequested(QString("Fill script failed: %1").arg(QString::fromStdString(result.error)));
+        return result;
+    }
+    buildFillGhosts();
+    _fillPreviewActive = true;
+    return result;
+}
+#endif
+
+void EditorWidget::buildFillGhosts() {
+    _fillPreviewFloorTiles.clear();
+    _fillPreviewObjects.clear();
+    _fillPreviewRoofTiles.clear();
+
+    const auto ghostAlpha = sf::Color(255, 255, 255, ui::constants::sfml::DRAG_PREVIEW_ALPHA);
+    for (const TileChange& tc : _fillPlan.tiles) {
+        if (auto sprite = pattern::buildTileSprite(_resources, tc.tileIndex, tc.isRoof, tc.after)) {
+            sprite->setColor(ghostAlpha);
+            (tc.isRoof ? _fillPreviewRoofTiles : _fillPreviewFloorTiles).push_back(std::move(*sprite));
+        }
+    }
+    // Rebuild a fresh ghost per object (don't tint the plan's own Object — that one is committed at
+    // full opacity on Apply).
+    for (const pattern::FillPlan::Entry& entry : _fillPlan.objects) {
+        if (!entry.mapObject) {
+            continue;
+        }
+        auto ghost = pattern::buildSpriteObject(_resources, _session.hexgrid(),
+            entry.mapObject->frm_pid, static_cast<int>(entry.mapObject->position), entry.mapObject->direction);
+        if (ghost) {
+            ghost->getSprite().setColor(ghostAlpha);
+            _fillPreviewObjects.push_back(std::move(ghost));
+        }
+    }
+}
+
+void EditorWidget::clearFillPreview() {
+    _fillPreviewActive = false;
+    _fillPreviewFloorTiles.clear();
+    _fillPreviewObjects.clear();
+    _fillPreviewRoofTiles.clear();
+    _fillPlan = pattern::FillPlan{};
+}
+
+void EditorWidget::applyFillPreview(const QString& description) {
+    if (!_session.map() || (_fillPlan.objects.empty() && _fillPlan.tiles.empty())) {
+        clearFillPreview();
+        return;
+    }
+    // Replay the previewed plan as ONE undo entry — no re-run, so the apply matches the preview
+    // exactly (and a multi-thousand-cell fill is a single Ctrl-Z under the UndoStack command cap).
+    const pattern::PlacementBatch::Result result = pattern::PlacementBatch::replay(
+        _controller.commandController(), _fillPlan, /*buildSprites*/ true, description.toStdString());
+
+    // Post-edit resync (mirrors runScript's mutated() path): the fill changed the map and the header
+    // counts, while the selection/visualizer and Map Info still reference the pre-fill state.
+    if (_session.selectionManager()) {
+        _session.selectionManager()->clearSelection();
+    }
+    _controller.visualizer().clearHexPositions();
+    if (_mainWindow) {
+        _mainWindow->updateMapInfo(_session.map());
+    }
+    Q_EMIT mapModifiedByScript();
+    Q_EMIT undoStackChanged();
+
+    QString message = QString("Filled: %1 tiles, %2 objects").arg(result.tilesPainted).arg(result.objectsPlaced);
+    if (result.objectsFailed > 0) {
+        message += QString(" (%1 missing art)").arg(result.objectsFailed);
+    }
+    if (_fillPlan.dropped > 0) {
+        message += QString(" (%1 off-grid)").arg(_fillPlan.dropped);
+    }
+    Q_EMIT statusMessageRequested(message);
+
+    clearFillPreview();
 }
 
 bool EditorWidget::isTilePlacementMode() const {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1374,6 +1374,46 @@ void EditorWidget::updateStampPreview(sf::Vector2f worldPos) {
 
 // ---- Area fill over the current selection (driven by a Luau fill script) ------------------------
 
+namespace {
+    // The bounding hexes covering a set of selected floor/roof tiles, derived from their on-screen sprite
+    // bounds — so a floor/area selection (which carries no hexes) can still scatter objects over the same
+    // region. Exact for a rectangular drag; a non-rectangular selection over-includes its bounding box
+    // (acceptable for a scatter region). Empty when no selected tile has drawable bounds.
+    std::vector<int> hexesCoveringTiles(const std::vector<int>& floorTiles, const std::vector<int>& roofTiles,
+        const std::vector<sf::Sprite>& floorSprites, const std::vector<sf::Sprite>& roofSprites,
+        selection::SelectionManager& selectionManager) {
+        // Sentinel-initialised so each contributing tile just min/max-folds in (no first-vs-rest branch).
+        constexpr float INF = std::numeric_limits<float>::max();
+        float minX = INF, minY = INF, maxX = -INF, maxY = -INF;
+        bool any = false;
+        const auto extend = [&](const std::vector<sf::Sprite>& sprites, int index) {
+            if (index < 0 || index >= static_cast<int>(sprites.size())) {
+                return;
+            }
+            const sf::FloatRect b = sprites[index].getGlobalBounds();
+            if (b.size.x <= 0.f || b.size.y <= 0.f) {
+                return; // empty tile: no sprite bounds to contribute
+            }
+            minX = std::min(minX, b.position.x);
+            minY = std::min(minY, b.position.y);
+            maxX = std::max(maxX, b.position.x + b.size.x);
+            maxY = std::max(maxY, b.position.y + b.size.y);
+            any = true;
+        };
+        for (const int tileIndex : floorTiles) {
+            extend(floorSprites, tileIndex);
+        }
+        for (const int tileIndex : roofTiles) {
+            extend(roofSprites, tileIndex);
+        }
+        if (!any) {
+            return {};
+        }
+        const sf::FloatRect bounds(sf::Vector2f(minX, minY), sf::Vector2f(maxX - minX, maxY - minY));
+        return selectionManager.getHexesInArea(bounds);
+    }
+} // namespace
+
 EditArea EditorWidget::selectionFillArea() const {
     EditArea area;
     auto* selectionManager = _session.selectionManager();
@@ -1386,49 +1426,11 @@ EditArea EditorWidget::selectionFillArea() const {
     area.hexes = state.getHexIndices();
 
     // A tile selection carries no hexes, but object scatter iterates the area's hexes. Derive the
-    // hexes covering the selected tiles from their on-screen bounds, so a floor/area selection can
-    // scatter objects over the same region. Exact for a rectangular drag; a non-rectangular tile
-    // selection over-includes the hexes in its bounding box (acceptable for a scatter region).
+    // covering hexes from the selected tiles' on-screen bounds so a floor/area selection can scatter
+    // objects over the same region.
     if (area.hexes.empty() && (!area.floorTiles.empty() || !area.roofTiles.empty())) {
-        const auto& floorSprites = _session.floorSprites();
-        const auto& roofSprites = _session.roofSprites();
-        bool any = false;
-        float minX = 0.f, minY = 0.f, maxX = 0.f, maxY = 0.f;
-        const auto extend = [&](const std::vector<sf::Sprite>& sprites, int index) {
-            if (index < 0 || index >= static_cast<int>(sprites.size())) {
-                return;
-            }
-            const sf::FloatRect b = sprites[index].getGlobalBounds();
-            if (b.size.x <= 0.f || b.size.y <= 0.f) {
-                return; // empty tile: no sprite bounds to contribute
-            }
-            const float l = b.position.x;
-            const float t = b.position.y;
-            const float r = l + b.size.x;
-            const float btm = t + b.size.y;
-            if (!any) {
-                minX = l;
-                minY = t;
-                maxX = r;
-                maxY = btm;
-                any = true;
-            } else {
-                minX = std::min(minX, l);
-                minY = std::min(minY, t);
-                maxX = std::max(maxX, r);
-                maxY = std::max(maxY, btm);
-            }
-        };
-        for (const int tileIndex : area.floorTiles) {
-            extend(floorSprites, tileIndex);
-        }
-        for (const int tileIndex : area.roofTiles) {
-            extend(roofSprites, tileIndex);
-        }
-        if (any) {
-            const sf::FloatRect bounds(sf::Vector2f(minX, minY), sf::Vector2f(maxX - minX, maxY - minY));
-            area.hexes = selectionManager->getHexesInArea(bounds);
-        }
+        area.hexes = hexesCoveringTiles(area.floorTiles, area.roofTiles,
+            _session.floorSprites(), _session.roofSprites(), *selectionManager);
     }
 
     // EditArea's contract: each list ascending AND unique (areaContains* binary-searches; the seeded

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -29,6 +29,8 @@
 #include "ui/core/EditorController.h"
 #include "ui/core/EditorSession.h"
 #include "pattern/Pattern.h"
+#include "pattern/FillPlan.h"
+#include "scripting/EditArea.h"
 #include "ui/tools/ExitGridContext.h"
 #include "ui/dragdrop/DragDropContext.h"
 #include "editor/TileChange.h"
@@ -157,6 +159,35 @@ public:
     // variant, and cycleStampVariant() advances which orientation is placed.
     void beginStampPattern(pattern::Pattern pattern);
     void cycleStampVariant();
+
+    // --- Area fill over the current selection (driven by a Luau script) ----------------------------
+    // These drive the Fill dialog: it snapshots the area once, previews on each parameter change
+    // (a ghost overlay), and commits the previewed plan on Apply — all without a new EditorMode.
+    //
+    // The current selection projected to a (sorted) EditArea: selected floor/roof tiles, plus the
+    // hexes covering them (so object scatter works over a tile selection) and any selected hexes.
+    EditArea selectionFillArea() const;
+    // True when the selection has any fillable target (floor/roof tiles or hexes), i.e. not a
+    // pure-object selection. Gates the Fill action's enabled state.
+    bool hasFillableSelection() const;
+    // Remove the ghost overlay and drop the retained plan.
+    void clearFillPreview();
+    // Commit the last previewed plan as one undo entry, then run the post-edit resync (clear the
+    // selection, refresh Map Info, flag the map modified). No-op when no plan is pending.
+    void applyFillPreview(const QString& description);
+    // The plan behind the current preview (for the dialog's tile/object summary). Empty when no
+    // preview is active. The Luau preview path populates it.
+    const pattern::FillPlan& fillPlan() const { return _fillPlan; }
+
+#ifdef GECK_SCRIPTING_ENABLED
+    // --- Procedural fill — a Luau script paints the selection --------------------------------------
+    // `source` is a Luau script run (under a wall-clock budget) against the selection via the plan
+    // sink: its api:paintFloor/scatter/… calls RECORD into a fresh plan instead of committing, so the
+    // result previews as a ghost and applyFillPreview() replays it as one undo entry. Returns the
+    // run's ScriptResult (ok/error/print output); on failure it clears the preview and leaves the
+    // plan empty.
+    ScriptResult previewLuaFill(const EditArea& area, const std::string& source, uint32_t seed);
+#endif
 
     // Object refresh methods
     void refreshObjects() override;
@@ -442,6 +473,17 @@ private:
     int _stampPreviewHex = -1;
     void updateStampPreview(sf::Vector2f worldPos);
     void clearStampPreview();
+
+    // A3 fill preview: a semi-transparent ghost of the previewed FillPlan (floor under, objects,
+    // roof over) drawn through the same RenderData.stampPreview path, plus the pristine plan replayed
+    // on Apply. The ghosts are rebuilt from the plan's data so the plan itself stays untouched (its
+    // objects render at full opacity once committed). Stamp and fill previews are never live at once.
+    std::vector<sf::Sprite> _fillPreviewFloorTiles;
+    std::vector<std::shared_ptr<Object>> _fillPreviewObjects;
+    std::vector<sf::Sprite> _fillPreviewRoofTiles;
+    bool _fillPreviewActive = false;
+    pattern::FillPlan _fillPlan;
+    void buildFillGhosts();
 
     // Player position selection state
     bool _playerPositionSelectionMode = false;

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "ui/tools/ExitGridPlacementManager.h"
 #include "ui/dialogs/SettingsDialog.h"
 #include "ui/dialogs/AboutDialog.h"
+#include "ui/dialogs/FillDialog.h"
 #include "ui/dialogs/MapBrowserDialog.h"
 #include "ui/dialogs/PatternBrowserDialog.h"
 #include "ui/UIConstants.h"
@@ -176,6 +177,7 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
 
     QTimer::singleShot(50, this, &MainWindow::updatePanelMenuActions);
     updateUndoRedoActions();
+    updateFillSelectionAction();
 }
 
 void MainWindow::setupUI() {
@@ -428,6 +430,11 @@ void MainWindow::setupMenuBar() {
     addMenuAction(_editMenu, ":/icons/actions/scroll-blocker.svg", "Scroll &Blocker Rectangle", &MainWindow::toggleScrollBlockerRectangleMode, QKeySequence("B"), "Draw rectangle and place scroll blockers on borders");
     addMenuAction(_editMenu, ":/icons/actions/save.svg", "Save Selection as &Pattern...", &MainWindow::showSavePatternDialog, QKeySequence(), "Save the current selection as a reusable prefab pattern");
     addMenuAction(_editMenu, ":/icons/actions/open.svg", "S&tamp Pattern...", &MainWindow::showStampPatternDialog, QKeySequence(), "Load a prefab pattern and click to place it");
+#ifdef GECK_SCRIPTING_ENABLED
+    // Fill is driven entirely by Luau fill scripts, so it is offered only when scripting is built in.
+    // Every use of _fillSelectionAction below is null-guarded, so leaving it null disables the feature.
+    _fillSelectionAction = addMenuAction(_editMenu, ":/icons/actions/paint.svg", "&Fill Selection...", &MainWindow::showFillDialog, QKeySequence(), "Fill the selected area with a Luau fill script");
+#endif
 
     _editMenu->addSeparator();
 
@@ -456,6 +463,7 @@ void MainWindow::setupMenuBar() {
     });
 
     updateUndoRedoActions();
+    updateFillSelectionAction();
 
     _viewMenu = _menuBar->addMenu("&View");
     struct ViewToggleSpec {
@@ -744,6 +752,11 @@ void MainWindow::setupToolBar() {
     _mainToolBar->addSeparator();
 
     setupToolModeActions();
+
+    // "Fill Selection…" (the Edit-menu action) also on the toolbar, beside the tool modes.
+    if (_fillSelectionAction) {
+        _mainToolBar->addAction(_fillSelectionAction);
+    }
 
     _mainToolBar->addSeparator();
 
@@ -1545,6 +1558,11 @@ void MainWindow::connectToEditorWidget() {
             _selectionPanel, &SelectionPanel::handleSelectionChanged);
     }
 
+    // Keep "Fill Selection…" enabled in step with the selection (it needs a fillable layer).
+    connect(_currentEditorWidget, &EditorWidget::selectionChanged, this,
+        [this](const selection::SelectionState&, int) { updateFillSelectionAction(); });
+    updateFillSelectionAction();
+
     if (_tilePalettePanel) {
         _tilePalettePanel->setMap(_currentEditorWidget->getMap());
         _tilePalettePanel->setSelectionManager(_currentEditorWidget->getSelectionManager());
@@ -1648,6 +1666,13 @@ void MainWindow::updateMapInfo(Map* map) {
 
     if (_scriptsPanel) {
         _scriptsPanel->setMap(map);
+    }
+
+    // The selection panel needs the live map to show tile info; without this it
+    // keeps the (often null) map it was given at connect time and every tile
+    // selection falls back to "No tile selected".
+    if (_selectionPanel) {
+        _selectionPanel->setMap(map);
     }
 
     updateElevationMenu(map);
@@ -2026,6 +2051,10 @@ void MainWindow::closeCurrentMap() {
 
     _centralStack->setCurrentWidget(_welcomeWidget);
 
+    // The editor and its Map are gone; clear the panels' borrowed map pointers (Map Info, Scripts,
+    // Selection) so they don't dangle before the next map opens.
+    updateMapInfo(nullptr);
+
     hidePanelsForNoMap();
 
     spdlog::debug("Current map closed successfully");
@@ -2123,6 +2152,30 @@ void MainWindow::showStampPatternDialog() {
     if (selected.has_value()) {
         _currentEditorWidget->beginStampPattern(std::move(*selected));
     }
+}
+
+void MainWindow::showFillDialog() {
+    if (!_currentEditorWidget || !hasActiveMap()) {
+        showStatusMessage("Open a map before filling a selection.");
+        return;
+    }
+    if (!_currentEditorWidget->hasFillableSelection()) {
+        showStatusMessage("Select an area (floor/roof tiles or hexes) to fill first.");
+        return;
+    }
+    // The dialog drives the editor's preview/apply over the current selection; closing it clears any
+    // live ghost (its destructor calls clearFillPreview).
+    FillDialog dialog(*_currentEditorWidget, this);
+    dialog.exec();
+}
+
+void MainWindow::updateFillSelectionAction() {
+    if (!_fillSelectionAction) {
+        return;
+    }
+    const bool enabled = _currentEditorWidget && hasActiveMap()
+        && _currentEditorWidget->hasFillableSelection();
+    _fillSelectionAction->setEnabled(enabled);
 }
 
 void MainWindow::showMapBrowserDialog() {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -117,6 +117,7 @@ private slots:
     void onPlayGame();
     void showSavePatternDialog();
     void showStampPatternDialog();
+    void showFillDialog();
     void showMapBrowserDialog();
 
 public slots:
@@ -151,6 +152,9 @@ private:
     void syncMenuStateToEditorWidget();
     void snapshotPanelVisibility();
     void updateUndoRedoActions();
+    // Enables "Fill Selection…" only when a map is open and the selection has a fillable layer
+    // (floor/roof tiles or hexes). Hooked to selectionChanged and re-seeded on map switch.
+    void updateFillSelectionAction();
     /// Sets the window title to the current map's name (plus the modified "[*]" marker).
     void updateWindowTitle();
     /// Records whether the current map has unsaved edits and reflects it in the title bar.
@@ -219,6 +223,7 @@ private:
     QAction* _exitGridPlaceHexAction = nullptr;   // "Place single hex" -> EditorMode::PlaceExitGrid
     QAction* _exitGridDrawRegionAction = nullptr; // "Draw edge"       -> EditorMode::MarkExits
     QAction* _rotateAction = nullptr;
+    QAction* _fillSelectionAction = nullptr;
     QAction* _undoAction = nullptr;
     QAction* _redoAction = nullptr;
 

--- a/src/ui/dialogs/FillDialog.cpp
+++ b/src/ui/dialogs/FillDialog.cpp
@@ -198,9 +198,9 @@ void FillDialog::runPreview() {
     }
 
 #ifdef GECK_SCRIPTING_ENABLED
-    const ScriptResult result
+    if (const ScriptResult result
         = _editor->previewLuaFill(_area, _scriptSource, static_cast<uint32_t>(_seed->value()));
-    if (!result.ok) {
+        !result.ok) {
         // previewLuaFill already posted the error to the status bar and cleared the ghost.
         _summary->setText(QStringLiteral("Script error: %1").arg(QString::fromStdString(result.error)));
         return;

--- a/src/ui/dialogs/FillDialog.cpp
+++ b/src/ui/dialogs/FillDialog.cpp
@@ -1,0 +1,235 @@
+#include "ui/dialogs/FillDialog.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QRandomGenerator>
+#include <QSpinBox>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include "pattern/FillLibrary.h"
+#include "ui/core/EditorWidget.h"
+
+namespace geck {
+
+namespace {
+    constexpr int PATH_ROLE = Qt::UserRole + 1;
+    constexpr int PREVIEW_DEBOUNCE_MS = 150; // recompute the ghost only after the seed settles
+
+#ifdef GECK_SCRIPTING_ENABLED
+    // A fill script's display label: a leading `-- name: Foo` comment if the file opens with one, else
+    // the file's base name.
+    QString scriptDisplayName(const QString& source, const QString& fallback) {
+        const QStringList lines = source.left(512).split(QLatin1Char('\n'));
+        for (const QString& raw : lines) {
+            const QString line = raw.trimmed();
+            if (!line.startsWith(QStringLiteral("--"))) {
+                break; // a name must lead the file; stop at the first non-comment line
+            }
+            const QString body = line.mid(2).trimmed();
+            if (body.startsWith(QStringLiteral("name:"), Qt::CaseInsensitive)) {
+                const QString name = body.mid(5).trimmed();
+                if (!name.isEmpty()) {
+                    return name;
+                }
+            }
+        }
+        return fallback;
+    }
+#endif
+} // namespace
+
+FillDialog::FillDialog(EditorWidget& editor, QWidget* parent)
+    : QDialog(parent)
+    , _editor(&editor)
+    , _area(editor.selectionFillArea()) {
+    setWindowTitle(QStringLiteral("Fill Selection"));
+    resize(620, 520);
+
+    buildUi();
+    populateBrowser();
+
+    _previewTimer = new QTimer(this);
+    _previewTimer->setSingleShot(true);
+    connect(_previewTimer, &QTimer::timeout, this, &FillDialog::runPreview);
+
+    // A random starting seed (the fill is reproducible from it; Lock keeps it across script changes).
+    _seed->setValue(static_cast<int>(QRandomGenerator::global()->generate() & 0x7FFFFFFFu));
+}
+
+FillDialog::~FillDialog() {
+    // Drop the ghost overlay when the dialog closes (Apply already cleared it; this covers Close/Esc).
+    if (_editor) {
+        _editor->clearFillPreview();
+    }
+}
+
+void FillDialog::buildUi() {
+    _browser = new QListWidget(this);
+    _browser->setViewMode(QListView::ListMode);
+    _browser->setMovement(QListView::Static);
+    _browser->setWordWrap(true);
+    _browser->setMinimumWidth(220);
+    connect(_browser, &QListWidget::itemActivated, this, &FillDialog::onScriptActivated);
+    connect(_browser, &QListWidget::itemClicked, this, &FillDialog::onScriptActivated);
+
+    // --- Seed + options -------------------------------------------------------------------------
+    _seed = new QSpinBox(this);
+    _seed->setRange(0, 0x7FFFFFFF);
+    _randomizeSeed = new QPushButton(QStringLiteral("Randomise"), this);
+    _seedLock = new QCheckBox(QStringLiteral("Lock"), this);
+    _seedLock->setToolTip(QStringLiteral("Keep this seed when switching scripts"));
+    auto* seedRow = new QHBoxLayout;
+    seedRow->addWidget(_seed, 1);
+    seedRow->addWidget(_randomizeSeed);
+    seedRow->addWidget(_seedLock);
+    _livePreview = new QCheckBox(QStringLiteral("Live preview"), this);
+    _livePreview->setChecked(true);
+    auto* optionsForm = new QFormLayout;
+    optionsForm->addRow(QStringLiteral("Seed"), seedRow);
+    optionsForm->addRow(_livePreview);
+
+    _summary = new QLabel(QStringLiteral("Select a fill script."), this);
+    _summary->setWordWrap(true);
+
+    auto* controls = new QVBoxLayout;
+    controls->addLayout(optionsForm);
+    controls->addWidget(_summary);
+    controls->addStretch(1);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    _applyButton = buttons->addButton(QStringLiteral("Apply"), QDialogButtonBox::AcceptRole);
+    _applyButton->setDefault(true);
+
+    auto* top = new QHBoxLayout;
+    top->addWidget(_browser, 1);
+    top->addLayout(controls, 1);
+
+    auto* root = new QVBoxLayout(this);
+    root->addLayout(top, 1);
+    root->addWidget(buttons);
+
+    connect(_seed, &QSpinBox::valueChanged, this, &FillDialog::schedulePreview);
+    connect(_livePreview, &QCheckBox::toggled, this, &FillDialog::schedulePreview);
+    connect(_randomizeSeed, &QPushButton::clicked, this, &FillDialog::onRandomizeSeed);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(_applyButton, &QPushButton::clicked, this, &FillDialog::onApply);
+}
+
+void FillDialog::populateBrowser() {
+    _browser->clear();
+#ifdef GECK_SCRIPTING_ENABLED
+    // Luau procedural fills (the only kind). The user library wins over a bundled example of the same
+    // file name, so scan the user dir first and skip any later bundled file whose name was taken.
+    QStringList seen;
+    const QIcon scriptIcon(QStringLiteral(":/icons/filetypes/script.svg"));
+    for (const QString& dirPath : { pattern::FillLibrary::rootDir(), pattern::FillLibrary::bundledDir() }) {
+        const QDir dir(dirPath);
+        for (const QString& file : dir.entryList({ QStringLiteral("*.luau") }, QDir::Files, QDir::Name)) {
+            if (seen.contains(file)) {
+                continue; // a user script of this name already won
+            }
+            seen.append(file);
+            const QString path = dir.filePath(file);
+            QFile handle(path);
+            if (!handle.open(QIODevice::ReadOnly)) {
+                continue;
+            }
+            const QString source = QString::fromUtf8(handle.readAll());
+            const QString label = scriptDisplayName(source, QFileInfo(file).completeBaseName());
+            auto* item = new QListWidgetItem(scriptIcon, label, _browser);
+            item->setData(PATH_ROLE, path);
+            item->setToolTip(QStringLiteral("Procedural fill script (Luau)"));
+        }
+    }
+#endif
+}
+
+void FillDialog::onScriptActivated(QListWidgetItem* item) {
+    if (item == nullptr) {
+        return;
+    }
+    const QString path = item->data(PATH_ROLE).toString();
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return; // transient read error: keep the prior valid selection rather than half-changing
+    }
+    _scriptSource = file.readAll().toStdString();
+    _selectedName = item->text();
+    schedulePreview();
+}
+
+void FillDialog::onRandomizeSeed() {
+    if (_seedLock->isChecked()) {
+        return;
+    }
+    _seed->setValue(static_cast<int>(QRandomGenerator::global()->generate() & 0x7FFFFFFFu));
+    // valueChanged on _seed triggers schedulePreview.
+}
+
+void FillDialog::schedulePreview() {
+    if (_livePreview->isChecked()) {
+        _previewTimer->start(PREVIEW_DEBOUNCE_MS);
+    } else {
+        if (_editor) {
+            _editor->clearFillPreview();
+        }
+        _summary->setText(QStringLiteral("Live preview off — Apply to fill."));
+    }
+}
+
+void FillDialog::runPreview() {
+    if (!_editor) {
+        return; // editor went away (e.g. its map closed) while the dialog was open
+    }
+    if (_scriptSource.empty()) {
+        _editor->clearFillPreview();
+        _summary->setText(QStringLiteral("Select a fill script."));
+        return;
+    }
+
+#ifdef GECK_SCRIPTING_ENABLED
+    const ScriptResult result
+        = _editor->previewLuaFill(_area, _scriptSource, static_cast<uint32_t>(_seed->value()));
+    if (!result.ok) {
+        // previewLuaFill already posted the error to the status bar and cleared the ghost.
+        _summary->setText(QStringLiteral("Script error: %1").arg(QString::fromStdString(result.error)));
+        return;
+    }
+    const pattern::FillPlan& plan = _editor->fillPlan();
+    QString summary = QStringLiteral("%1 tile(s), %2 object(s)")
+                          .arg(plan.tiles.size())
+                          .arg(plan.objects.size());
+    if (plan.dropped > 0) {
+        summary += QStringLiteral(" (%1 off-grid)").arg(plan.dropped);
+    }
+    _summary->setText(summary);
+#endif
+}
+
+void FillDialog::onApply() {
+    if (!_editor) {
+        reject(); // nothing to apply to
+        return;
+    }
+    if (_scriptSource.empty()) {
+        return; // no script chosen yet: keep the dialog open
+    }
+    // Build/refresh the plan from the current seed (covers live-preview-off), then commit it.
+    runPreview();
+    const QString name
+        = _selectedName.isEmpty() ? QStringLiteral("Fill") : QStringLiteral("Fill: %1").arg(_selectedName);
+    _editor->applyFillPreview(name);
+    accept();
+}
+
+} // namespace geck

--- a/src/ui/dialogs/FillDialog.cpp
+++ b/src/ui/dialogs/FillDialog.cpp
@@ -88,20 +88,20 @@ void FillDialog::buildUi() {
     _randomizeSeed = new QPushButton(QStringLiteral("Randomise"), this);
     _seedLock = new QCheckBox(QStringLiteral("Lock"), this);
     _seedLock->setToolTip(QStringLiteral("Keep this seed when switching scripts"));
-    auto* seedRow = new QHBoxLayout;
+    auto* seedRow = new QHBoxLayout; // NOSONAR: Qt owns this layout once it is added to the widget tree
     seedRow->addWidget(_seed, 1);
     seedRow->addWidget(_randomizeSeed);
     seedRow->addWidget(_seedLock);
     _livePreview = new QCheckBox(QStringLiteral("Live preview"), this);
     _livePreview->setChecked(true);
-    auto* optionsForm = new QFormLayout;
+    auto* optionsForm = new QFormLayout; // NOSONAR: Qt owns this layout once it is added to the widget tree
     optionsForm->addRow(QStringLiteral("Seed"), seedRow);
     optionsForm->addRow(_livePreview);
 
     _summary = new QLabel(QStringLiteral("Select a fill script."), this);
     _summary->setWordWrap(true);
 
-    auto* controls = new QVBoxLayout;
+    auto* controls = new QVBoxLayout; // NOSONAR: Qt owns this layout once it is added to the widget tree
     controls->addLayout(optionsForm);
     controls->addWidget(_summary);
     controls->addStretch(1);
@@ -110,7 +110,7 @@ void FillDialog::buildUi() {
     _applyButton = buttons->addButton(QStringLiteral("Apply"), QDialogButtonBox::AcceptRole);
     _applyButton->setDefault(true);
 
-    auto* top = new QHBoxLayout;
+    auto* top = new QHBoxLayout; // NOSONAR: Qt owns this layout once it is added to the widget tree
     top->addWidget(_browser, 1);
     top->addLayout(controls, 1);
 
@@ -154,7 +154,7 @@ void FillDialog::populateBrowser() {
 #endif
 }
 
-void FillDialog::onScriptActivated(QListWidgetItem* item) {
+void FillDialog::onScriptActivated(const QListWidgetItem* item) {
     if (item == nullptr) {
         return;
     }

--- a/src/ui/dialogs/FillDialog.h
+++ b/src/ui/dialogs/FillDialog.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QDialog>
+#include <QPointer>
+
+#include <string>
+
+#include "scripting/EditArea.h"
+
+class QCheckBox;
+class QLabel;
+class QListWidget;
+class QListWidgetItem;
+class QPushButton;
+class QSpinBox;
+class QTimer;
+
+namespace geck {
+
+class EditorWidget;
+
+/// "Fill Selection…": a one-shot procedural area fill over the current selection (no EditorMode).
+/// Left, a browser of Luau fill scripts (bundled examples + the user's library); right, a seed
+/// (defaults random, can be locked) and a live-preview toggle. The chosen script runs into a ghost
+/// overlay on the editor (debounced, recomputed only when the seed/script changes); Apply commits that
+/// exact previewed plan as one undo entry. The dialog drives EditorWidget::previewLuaFill /
+/// applyFillPreview / clearFillPreview and never mutates the map itself. The fill feature is
+/// scripting-only, so MainWindow offers it only when scripting is compiled in (GECK_SCRIPTING_ENABLED).
+class FillDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    FillDialog(EditorWidget& editor, QWidget* parent = nullptr);
+    ~FillDialog() override;
+
+private slots:
+    void onScriptActivated(QListWidgetItem* item);
+    void onRandomizeSeed();
+    void onApply();
+
+private:
+    void buildUi();
+    void populateBrowser();
+    void schedulePreview();
+    void runPreview();
+
+    // QPointer (not a reference): the editor is owned by MainWindow and could in principle be
+    // deleteLater()'d while this dialog's nested event loop runs; QPointer auto-nulls on its
+    // destruction, so every use is guarded rather than dangling.
+    QPointer<EditorWidget> _editor;
+    EditArea _area; ///< the fill target, snapshotted from the selection at construction
+
+    QListWidget* _browser = nullptr;
+    QSpinBox* _seed = nullptr;
+    QCheckBox* _seedLock = nullptr;
+    QPushButton* _randomizeSeed = nullptr;
+    QCheckBox* _livePreview = nullptr;
+    QLabel* _summary = nullptr;
+    QPushButton* _applyButton = nullptr;
+    QTimer* _previewTimer = nullptr;
+
+    QString _selectedName;     ///< display name of the chosen fill, used in the undo description
+    std::string _scriptSource; ///< source of the selected Luau fill script (empty until one is picked)
+};
+
+} // namespace geck

--- a/src/ui/dialogs/FillDialog.h
+++ b/src/ui/dialogs/FillDialog.h
@@ -34,7 +34,7 @@ public:
     ~FillDialog() override;
 
 private slots:
-    void onScriptActivated(QListWidgetItem* item);
+    void onScriptActivated(const QListWidgetItem* item);
     void onRandomizeSeed();
     void onApply();
 

--- a/src/ui/dialogs/FillDialog.h
+++ b/src/ui/dialogs/FillDialog.h
@@ -30,7 +30,7 @@ class FillDialog : public QDialog {
     Q_OBJECT
 
 public:
-    FillDialog(EditorWidget& editor, QWidget* parent = nullptr);
+    explicit FillDialog(EditorWidget& editor, QWidget* parent = nullptr);
     ~FillDialog() override;
 
 private slots:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(general_tests
     general/test_exit_grid_direction.cpp
     general/test_pattern_stamper.cpp
     general/test_pattern_builder.cpp
+    general/test_fill_plan.cpp
     general/test_map_script_api.cpp
     general/test_resource_repository.cpp
     general/test_script_names.cpp
@@ -73,7 +74,7 @@ endif()
 # no scripting or game data. test_frm_inspect covers the FRM tools' non-GL logic (FID parse/decode,
 # art-name resolution, glob listing) against a temp LST fixture.
 if(TARGET gecko_cli)
-    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp general/test_map_analyzer_scripts.cpp general/test_frm_inspect.cpp)
+    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp general/test_map_analyzer_scripts.cpp general/test_map_dump_grid.cpp general/test_frm_inspect.cpp)
     target_link_libraries(general_tests PRIVATE gecko_cli)
 endif()
 

--- a/tests/general/test_fill_plan.cpp
+++ b/tests/general/test_fill_plan.cpp
@@ -131,8 +131,8 @@ TEST_CASE("placeStamp under a plan sink is captured, not committed", "[scripting
     pat.name = "cluster";
     pattern::PatternVariant v;
     v.anchorHex = 100 * HexagonGrid::GRID_WIDTH + 100;
-    v.objects.push_back({ 0, 0, PRO, FRM, 0u, 0u });
-    v.objects.push_back({ 1, 0, PRO, FRM, 2u, 0u });
+    v.objects.push_back({ 0, 0, PRO, FRM, 0u, 0u }); // NOSONAR: braced-init of an aggregate; emplace_back would need C++20 paren-aggregate-init
+    v.objects.push_back({ 1, 0, PRO, FRM, 2u, 0u }); // NOSONAR: braced-init of an aggregate; emplace_back would need C++20 paren-aggregate-init
     v.floor.push_back({ 0, 0, TILE_A });
     pat.variants.push_back(v);
     api.addStamp("cluster", pat);

--- a/tests/general/test_fill_plan.cpp
+++ b/tests/general/test_fill_plan.cpp
@@ -1,0 +1,234 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include "editor/HexagonGrid.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/Tile.h"
+#include "pattern/FillPlan.h"
+#include "pattern/Pattern.h"
+#include "pattern/PlacementBatch.h"
+#include "scripting/EditArea.h"
+#include "scripting/MapScriptApi.h"
+
+#include "support/ControllerFixture.h"
+
+// The A0 plan-sink core: MapScriptApi mutators record into a FillPlan instead of committing while a
+// sink is installed (preview), and pattern::PlacementBatch::replay applies the captured plan as ONE
+// undo entry (apply). The contract these tests pin down is what makes a fill preview byte-identical
+// to the apply and collapses a whole fill into a single Ctrl-Z.
+
+using namespace geck;
+using geck::test::ControllerFixture;
+
+namespace {
+constexpr int ELEV = 0;
+constexpr uint16_t TILE_A = 271;
+constexpr uint16_t TILE_B = 300;
+constexpr uint16_t EMPTY = static_cast<uint16_t>(Map::EMPTY_TILE);
+constexpr uint32_t PRO = 0x02000066; // Scrub (scenery)
+constexpr uint32_t FRM = 0x02000000; // arbitrary FID; not resolved in data-only mode
+
+// Give elevation 0 a full set of empty tiles so paints have somewhere to land with a readable
+// before-value. Objects are placed data-only (buildSprites=false) so they succeed without art.
+void seedTiles(ControllerFixture& fx) {
+    fx.mapFile().tiles[ELEV] = std::vector<Tile>(Map::TILES_PER_ELEVATION, Tile(EMPTY, EMPTY));
+}
+} // namespace
+
+TEST_CASE("plan sink records edits without committing; replay applies them as one undo entry", "[scripting][fill]") {
+    ControllerFixture fx;
+    seedTiles(fx);
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, /*buildSprites*/ false);
+
+    pattern::FillPlan plan;
+    api.setPlanSink(&plan);
+
+    REQUIRE(api.paintFloor(10, TILE_A));
+    REQUIRE(api.paintFloor(11, TILE_B));
+    REQUIRE(api.placeObject(PRO, FRM, 20100, 0));
+
+    // Captured into the plan, fully built...
+    CHECK(plan.tiles.size() == 2);
+    REQUIRE(plan.objects.size() == 1);
+    CHECK(plan.objects[0].mapObject->pro_pid == PRO);
+
+    // ...but nothing committed: the map is untouched and there is no undo entry.
+    CHECK(fx.mapFile().tiles[ELEV][10].getFloor() == EMPTY);
+    CHECK(fx.mapFile().tiles[ELEV][11].getFloor() == EMPTY);
+    CHECK(fx.mapFile().map_objects[ELEV].empty());
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    // Detach the sink and replay: now it commits, as a SINGLE undo entry.
+    api.setPlanSink(nullptr);
+    const auto r = pattern::PlacementBatch::replay(fx.controller, plan, /*buildSprites*/ false, "Fill selection");
+    CHECK(r.tilesPainted == 2);
+    CHECK(r.objectsPlaced == 1);
+
+    CHECK(fx.mapFile().tiles[ELEV][10].getFloor() == TILE_A);
+    CHECK(fx.mapFile().tiles[ELEV][11].getFloor() == TILE_B);
+    REQUIRE(fx.mapFile().map_objects[ELEV].size() == 1);
+    CHECK(fx.mapFile().map_objects[ELEV][0]->pro_pid == PRO);
+
+    // One undo reverts the whole fill, and the stack is then empty (proof of one entry, not three).
+    REQUIRE(fx.undoStack.canUndo());
+    fx.undoStack.undo();
+    CHECK(fx.mapFile().tiles[ELEV][10].getFloor() == EMPTY);
+    CHECK(fx.mapFile().tiles[ELEV][11].getFloor() == EMPTY);
+    CHECK(fx.mapFile().map_objects[ELEV].empty());
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("a captured-then-replayed run yields the same map as a direct run", "[scripting][fill]") {
+    // Direct run: mutators commit immediately inside one batch.
+    ControllerFixture direct;
+    seedTiles(direct);
+    {
+        MapScriptApi api(direct.resources, direct.hexgrid, direct.controller, *direct.map, ELEV, false);
+        api.beginBatch("Fill");
+        REQUIRE(api.paintFloor(10, TILE_A));
+        REQUIRE(api.placeObject(PRO, FRM, 20100, 0));
+        REQUIRE(api.placeObject(PRO, FRM, 20101, 2));
+        api.endBatch();
+    }
+
+    // Captured run: same calls into a sink, then replayed.
+    ControllerFixture replayed;
+    seedTiles(replayed);
+    {
+        MapScriptApi api(replayed.resources, replayed.hexgrid, replayed.controller, *replayed.map, ELEV, false);
+        pattern::FillPlan plan;
+        api.setPlanSink(&plan);
+        REQUIRE(api.paintFloor(10, TILE_A));
+        REQUIRE(api.placeObject(PRO, FRM, 20100, 0));
+        REQUIRE(api.placeObject(PRO, FRM, 20101, 2));
+        api.setPlanSink(nullptr);
+        pattern::PlacementBatch::replay(replayed.controller, plan, false, "Fill");
+    }
+
+    CHECK(direct.mapFile().tiles[ELEV][10].getFloor() == replayed.mapFile().tiles[ELEV][10].getFloor());
+
+    const auto& a = direct.mapFile().map_objects[ELEV];
+    const auto& b = replayed.mapFile().map_objects[ELEV];
+    REQUIRE(a.size() == b.size());
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        CHECK(a[i]->pro_pid == b[i]->pro_pid);
+        CHECK(a[i]->frm_pid == b[i]->frm_pid);
+        CHECK(a[i]->position == b[i]->position);
+        CHECK(a[i]->direction == b[i]->direction);
+    }
+}
+
+TEST_CASE("placeStamp under a plan sink is captured, not committed", "[scripting][fill][stamper]") {
+    ControllerFixture fx;
+    seedTiles(fx);
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+
+    // A small prefab: two objects + one floor tile.
+    pattern::Pattern pat;
+    pat.name = "cluster";
+    pattern::PatternVariant v;
+    v.anchorHex = 100 * HexagonGrid::GRID_WIDTH + 100;
+    v.objects.push_back({ 0, 0, PRO, FRM, 0u, 0u });
+    v.objects.push_back({ 1, 0, PRO, FRM, 2u, 0u });
+    v.floor.push_back({ 0, 0, TILE_A });
+    pat.variants.push_back(v);
+    api.addStamp("cluster", pat);
+
+    pattern::FillPlan plan;
+    api.setPlanSink(&plan);
+    const int placed = api.placeStamp("cluster", 50 * HexagonGrid::GRID_WIDTH + 50, 0);
+
+    // Without the sink-aware planInto path, placeStamp would open its own ScopedUndoBatch and mutate
+    // the live map during preview. Here it must only record into the plan.
+    CHECK(placed == 2);
+    CHECK(plan.objects.size() == 2);
+    CHECK(plan.tiles.size() == 1);
+    CHECK(fx.mapFile().map_objects[ELEV].empty());
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    // Replay commits the whole stamp as one entry.
+    api.setPlanSink(nullptr);
+    const auto r = pattern::PlacementBatch::replay(fx.controller, plan, false, "Fill: stamp");
+    CHECK(r.objectsPlaced == 2);
+    CHECK(r.tilesPainted == 1);
+    REQUIRE(fx.mapFile().map_objects[ELEV].size() == 2);
+    REQUIRE(fx.undoStack.canUndo());
+    fx.undoStack.undo();
+    CHECK(fx.mapFile().map_objects[ELEV].empty());
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("the same seed yields an identical fill plan; a different seed differs", "[scripting][fill]") {
+    // A seeded scatter over a strip of hexes, captured into a plan. Reproducibility is the contract
+    // that lets a previewed fill match the apply and a saved recipe regenerate the same map.
+    const auto buildPlan = [](uint32_t seed) {
+        ControllerFixture fx;
+        seedTiles(fx);
+        MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+        api.setSeed(seed);
+        pattern::FillPlan plan;
+        api.setPlanSink(&plan);
+        for (int t = 0; t < 300; ++t) {
+            if (api.rng() < 0.4) {
+                api.placeObject(PRO, FRM, 21000 + t, static_cast<uint32_t>(api.rngInt(0, 5)));
+            }
+        }
+        return plan; // owns its MapObjects via shared_ptr, so it outlives the fixture
+    };
+
+    const pattern::FillPlan a = buildPlan(42);
+    const pattern::FillPlan b = buildPlan(42);
+    const pattern::FillPlan c = buildPlan(43);
+
+    // Same seed -> identical placements (count, position and seeded direction).
+    REQUIRE(a.objects.size() == b.objects.size());
+    CHECK(a.objects.size() > 0); // the scatter actually placed something to compare
+    bool identical = true;
+    for (std::size_t i = 0; i < a.objects.size(); ++i) {
+        identical = identical
+            && a.objects[i].mapObject->position == b.objects[i].mapObject->position
+            && a.objects[i].mapObject->direction == b.objects[i].mapObject->direction
+            && a.objects[i].mapObject->pro_pid == b.objects[i].mapObject->pro_pid;
+    }
+    CHECK(identical);
+
+    // A different seed produces a different layout (a count or some position/direction differs).
+    bool differs = a.objects.size() != c.objects.size();
+    for (std::size_t i = 0; !differs && i < a.objects.size(); ++i) {
+        differs = a.objects[i].mapObject->position != c.objects[i].mapObject->position
+            || a.objects[i].mapObject->direction != c.objects[i].mapObject->direction;
+    }
+    CHECK(differs);
+}
+
+TEST_CASE("area accessors report the bound selection and test membership", "[scripting][fill]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+
+    CHECK_FALSE(api.hasArea());
+    CHECK(api.areaHexes().empty());
+    CHECK_FALSE(api.areaContainsHex(100)); // no area bound -> nothing is inside
+
+    EditArea area;
+    area.hexes = { 100, 205, 410 }; // sorted ascending (the EditArea contract)
+    area.floorTiles = { 50, 51, 52 };
+    area.roofTiles = { 50 };
+    api.setArea(&area);
+
+    CHECK(api.hasArea());
+    CHECK(api.areaHexes() == std::vector<int>{ 100, 205, 410 });
+    CHECK(api.areaFloorTiles().size() == 3);
+    CHECK(api.areaRoofTiles() == std::vector<int>{ 50 });
+
+    CHECK(api.areaContainsHex(205));
+    CHECK_FALSE(api.areaContainsHex(206));
+    CHECK(api.areaContainsTile(52));
+    CHECK_FALSE(api.areaContainsTile(53));
+
+    api.setArea(nullptr); // clears
+    CHECK_FALSE(api.hasArea());
+    CHECK_FALSE(api.areaContainsHex(205));
+}

--- a/tests/general/test_lua_script_runtime.cpp
+++ b/tests/general/test_lua_script_runtime.cpp
@@ -5,9 +5,14 @@
 #include <sstream>
 #include <string>
 
+#include "editor/TileChange.h"
 #include "format/map/Map.h"
+#include "format/map/MapObject.h"
 #include "format/map/Tile.h"
+#include "pattern/FillPlan.h"
+#include "pattern/PlacementBatch.h"
 #include "reader/map/MapReader.h"
+#include "scripting/EditArea.h"
 #include "scripting/LuaScriptRuntime.h"
 #include "scripting/MapScriptApi.h"
 #include "scripting/ScriptApiReference.h"
@@ -51,6 +56,186 @@ TEST_CASE("Luau script paints tiles through the host API, as one undo entry", "[
     for (int i = 0; i < 10; ++i) {
         CHECK(fx.mapFile().tiles.at(ELEV)[i].getFloor() == EMPTY);
     }
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("A runaway Luau script is aborted by the time budget", "[scripting][lua][watchdog]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV);
+    LuaScriptRuntime rt;
+
+    // An infinite loop would hang the editor's live preview without a guard. A small wall-clock
+    // budget arms the safepoint interrupt, which aborts the run as a runtime error (not a silent
+    // stop) once the deadline passes — the GUI fill path relies on exactly this.
+    const auto r = rt.run("local n = 0 while true do n = n + 1 end", api, fx.controller, "runaway",
+        {}, /*timeBudgetMs*/ 50);
+    CHECK_FALSE(r.ok);
+    CHECK(r.error.find("time budget") != std::string::npos);
+
+    // A bounded script well inside the same budget still completes normally — the watchdog only
+    // fires past the deadline.
+    const auto ok = rt.run("local s = 0 for i = 1, 1000 do s = s + i end api:paintFloor(0, 271)",
+        api, fx.controller, "bounded", {}, /*timeBudgetMs*/ 2000);
+    INFO("script error: " << ok.error);
+    CHECK(ok.ok);
+    CHECK(fx.mapFile().tiles.at(ELEV)[0].getFloor() == 271);
+}
+
+TEST_CASE("budget 0 means no limit (CLI/batch generation is untimed)", "[scripting][lua][watchdog]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV);
+    LuaScriptRuntime rt;
+
+    // The default budget (0) installs no interrupt at all, so a long-but-finite trusted run is not
+    // capped. Nested loops do millions of back-edges — every one a safepoint that WOULD abort the
+    // run if an interrupt were wrongly armed at budget 0; completing proves none is.
+    const auto r = rt.run(
+        "local s = 0 for i = 1, 3000 do for j = 1, 3000 do s = s + 1 end end print(s)",
+        api, fx.controller, "untimed");
+    INFO("script error: " << r.error);
+    REQUIRE(r.ok);
+    CHECK(r.output == "9000000\n");
+}
+
+TEST_CASE("A Luau fill paints only the selection, recorded into the plan sink", "[scripting][lua][fill]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV);
+    LuaScriptRuntime rt;
+
+    // A small floor-tile selection (EditArea requires ascending order): two partial rows of the
+    // 100-wide tile grid.
+    EditArea area;
+    area.floorTiles = { 0, 1, 2, 100, 101, 102 };
+    pattern::FillPlan plan;
+    api.setArea(&area);
+    api.setPlanSink(&plan);
+
+    // A deterministic per-tile pattern over the selection: parity of (col+row) chooses tile A/B.
+    // (Inline, not a shipped script — this exercises the sink mechanism with a predictable result.)
+    const auto r = rt.run(R"(
+        for _, t in ipairs(api:areaFloorTiles()) do
+            local parity = (api:tileCol(t) + api:tileRow(t)) % 2
+            api:paintFloor(t, (parity == 0) and 271 or 300)
+        end
+    )",
+        api, fx.controller, "checkerboard");
+    INFO("script error: " << r.error);
+    REQUIRE(r.ok);
+
+    // One recorded tile change per selected tile, and NOTHING committed to the live map (sink mode).
+    REQUIRE(plan.tiles.size() == area.floorTiles.size());
+    CHECK(api.paintedTiles() == static_cast<int>(area.floorTiles.size()));
+    for (const int t : area.floorTiles) {
+        CHECK(fx.mapFile().tiles.at(ELEV)[t].getFloor() == EMPTY); // sink => live map untouched
+    }
+
+    // Each recorded tile carries the checkerboard value for its own (col,row) parity.
+    for (const TileChange& tc : plan.tiles) {
+        const int col = tc.tileIndex % 100;
+        const int row = tc.tileIndex / 100;
+        const uint16_t expected = ((col + row) % 2 == 0) ? 271 : 300;
+        CHECK_FALSE(tc.isRoof);
+        CHECK(tc.after == expected);
+    }
+
+    // The undo stack is untouched: a preview records into the plan but commits no command.
+    CHECK_FALSE(fx.undoStack.canUndo());
+
+    // Apply == preview: replaying the SAME plan (what applyFillPreview does) now commits exactly the
+    // recorded tiles, as ONE undo entry — so the applied map matches what the preview recorded.
+    const auto applied = pattern::PlacementBatch::replay(
+        fx.controller, plan, /*buildSprites*/ false, "Fill: checkerboard");
+    CHECK(applied.tilesPainted == static_cast<int>(plan.tiles.size()));
+    for (const TileChange& tc : plan.tiles) {
+        CHECK(fx.mapFile().tiles.at(ELEV)[tc.tileIndex].getFloor() == tc.after);
+    }
+    REQUIRE(fx.undoStack.canUndo());
+    fx.undoStack.undo();
+    for (const int t : area.floorTiles) {
+        CHECK(fx.mapFile().tiles.at(ELEV)[t].getFloor() == EMPTY); // one Ctrl-Z reverts the whole fill
+    }
+    CHECK_FALSE(fx.undoStack.canUndo());
+}
+
+TEST_CASE("The bundled biome fills paint the selection's floor by tile id, headlessly", "[scripting][lua][fill]") {
+    // The biome fills paint the floor with numeric tile ids (no data needed) and try to scatter
+    // scenery (placeProtoXY -> false without data, never raising). So headless they must run clean and
+    // record exactly the selection's floor tiles, with no scenery.
+    for (const std::string& script :
+        { std::string("desert"), std::string("woods"), std::string("badlands"), std::string("overgrown") }) {
+        INFO("script: " << script);
+        std::ifstream file(std::string(GECK_SCRIPTS_DIR) + "/fills/" + script + ".luau");
+        REQUIRE(file.is_open());
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        const std::string source = buffer.str();
+
+        ControllerFixture fx;
+        MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV);
+        LuaScriptRuntime rt;
+
+        EditArea area;
+        area.floorTiles = { 0, 1, 2, 100, 101, 102 }; // floor only -> areaHexes() empty -> no scatter
+        pattern::FillPlan plan;
+        api.setArea(&area);
+        api.setPlanSink(&plan);
+
+        const auto r = rt.run(source, api, fx.controller, "biome-bundled");
+        INFO("script error: " << r.error);
+        REQUIRE(r.ok);
+        CHECK(plan.tiles.size() == area.floorTiles.size());
+        CHECK(plan.objects.empty()); // scenery needs data; headless it is skipped, not faked
+        // Every painted tile id came from the script's grounded GROUND palette (a real floor id).
+        for (const TileChange& tc : plan.tiles) {
+            CHECK_FALSE(tc.isRoof);
+            CHECK(tc.after != EMPTY);
+        }
+        // Live map untouched during the (sink) preview.
+        for (const int t : area.floorTiles) {
+            CHECK(fx.mapFile().tiles.at(ELEV)[t].getFloor() == EMPTY);
+        }
+    }
+}
+
+TEST_CASE("A Luau fill scatters objects into the plan sink, replayable as one undo entry", "[scripting][lua][fill]") {
+    ControllerFixture fx;
+    // Headless/data-only: placeObject records map data with a null visual; replay commits it as data.
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, /*buildSprites*/ false);
+    LuaScriptRuntime rt;
+
+    EditArea area;
+    area.hexes = { 20100, 20102, 20104 };
+    pattern::FillPlan plan;
+    api.setArea(&area);
+    api.setPlanSink(&plan);
+
+    // Scatter Scrub at each selected hex via placeObject (explicit ids, so no data is needed).
+    const auto r = rt.run(R"(
+        for _, h in ipairs(api:areaHexes()) do
+            api:placeObject(0x02000066, 0x02000000, h, 0)
+        end
+    )",
+        api, fx.controller, "scatter");
+    INFO("script error: " << r.error);
+    REQUIRE(r.ok);
+
+    // Recorded into the plan, NOT committed to the live map, and no undo entry yet (it's a preview).
+    REQUIRE(plan.objects.size() == area.hexes.size());
+    CHECK(fx.mapFile().map_objects.at(ELEV).empty());
+    CHECK_FALSE(fx.undoStack.canUndo());
+    for (const auto& entry : plan.objects) {
+        REQUIRE(entry.mapObject);
+        CHECK(entry.mapObject->pro_pid == 0x02000066u);
+    }
+
+    // Apply == preview: replaying the plan commits exactly those objects, as one undo entry.
+    const auto applied = pattern::PlacementBatch::replay(
+        fx.controller, plan, /*buildSprites*/ false, "Fill: scatter");
+    CHECK(applied.objectsPlaced == static_cast<int>(area.hexes.size()));
+    REQUIRE(fx.mapFile().map_objects.at(ELEV).size() == area.hexes.size());
+    REQUIRE(fx.undoStack.canUndo());
+    fx.undoStack.undo();
+    CHECK(fx.mapFile().map_objects.at(ELEV).empty()); // one Ctrl-Z removes the whole scatter
     CHECK_FALSE(fx.undoStack.canUndo());
 }
 

--- a/tests/general/test_map_dump_grid.cpp
+++ b/tests/general/test_map_dump_grid.cpp
@@ -31,7 +31,7 @@ json dumpWrittenMap(Map::MapFile mapFile, const char* mapName, const char* tempP
 
     TempFile out{ tempPrefix, ".map" };
     {
-        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        MapWriter writer{ [&provider](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
         writer.openFile(out.path());
         REQUIRE(writer.write(map.getMapFile()));
     } // flush + close before dump-grid reads it back
@@ -118,7 +118,7 @@ TEST_CASE("dump-grid --no-floor / --no-objects drop those sections", "[cli][dump
     map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
     TempFile out{ "geck_dump_grid_flags", ".map" };
     {
-        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        MapWriter writer{ [&provider](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
         writer.openFile(out.path());
         REQUIRE(writer.write(map.getMapFile()));
     }

--- a/tests/general/test_map_dump_grid.cpp
+++ b/tests/general/test_map_dump_grid.cpp
@@ -25,7 +25,7 @@ namespace {
 // Write `mapFile` to a temp .map and return dump-grid's parsed JSON for `elevation`. No game data is
 // mounted, so dump-grid reads the file back via cli::loadMap's disk fallback (tile ids are raw in the
 // file, so they survive without tiles.lst). Mirrors the analyze tests' harness.
-json dumpWrittenMap(Map::MapFile mapFile, const char* mapName, const char* tempPrefix, StubProvider& provider) {
+json dumpWrittenMap(Map::MapFile mapFile, const char* mapName, const char* tempPrefix, const StubProvider& provider) {
     Map map{ mapName };
     map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
 

--- a/tests/general/test_map_dump_grid.cpp
+++ b/tests/general/test_map_dump_grid.cpp
@@ -1,0 +1,139 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
+
+#include "cli/MapAnalyzer.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+#include "writer/map/MapWriter.h"
+
+#include "support/ProStubProvider.h"
+#include "support/TempFile.h"
+
+using nlohmann::json;
+using namespace geck;
+using namespace geck::test;
+
+namespace {
+
+// Write `mapFile` to a temp .map and return dump-grid's parsed JSON for `elevation`. No game data is
+// mounted, so dump-grid reads the file back via cli::loadMap's disk fallback (tile ids are raw in the
+// file, so they survive without tiles.lst). Mirrors the analyze tests' harness.
+json dumpWrittenMap(Map::MapFile mapFile, const char* mapName, const char* tempPrefix, StubProvider& provider) {
+    Map map{ mapName };
+    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
+
+    TempFile out{ tempPrefix, ".map" };
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(out.path());
+        REQUIRE(writer.write(map.getMapFile()));
+    } // flush + close before dump-grid reads it back
+
+    resource::GameResources resources;
+    cli::DumpGridOptions opts;
+    opts.map = out.path().string();
+    opts.elevation = 0; // just elevation 0, so the assertions below are unambiguous
+    opts.roof = true;
+    std::ostringstream jsonOut;
+    REQUIRE(cli::dumpMapGrid(resources, opts, jsonOut) == 0);
+    return json::parse(jsonOut.str());
+}
+
+} // namespace
+
+TEST_CASE("dump-grid emits the raw floor grid, roof grid and object positions", "[cli][dump-grid]") {
+    StubProvider provider;
+    // A WALL object: walls/critters/misc don't dereference their proto on (de)serialization, so this
+    // round-trips headlessly through cli::loadMap (no data) — unlike scenery, which needs its proto.
+    const uint32_t wallPid = pidOf(Pro::OBJECT_TYPE::WALL, 50);
+
+    auto mapFile = Map::createEmptyMapFile();
+
+    // Paint known floor cells + one roof cell on elevation 0 (index = row*100 + col).
+    auto& tiles = mapFile.tiles[0];
+    tiles[0].setFloor(191);  // (col0, row0)
+    tiles[1].setFloor(194);  // (col1, row0)
+    tiles[100].setFloor(70); // (col0, row1)
+    tiles[5].setRoof(480);   // a roof cell
+
+    // One wall object at hex (col=100, row=100) on elevation 0, facing 2.
+    auto wall = std::make_shared<MapObject>();
+    wall->pro_pid = wallPid;
+    wall->elevation = 0;
+    wall->position = 100 * 200 + 100; // 20100
+    wall->direction = 2;
+    mapFile.map_objects[0].push_back(wall);
+
+    const json root = dumpWrittenMap(std::move(mapFile), "synthetic.map", "geck_dump_grid", provider);
+
+    CHECK(root["tileCols"] == 100);
+    CHECK(root["tileRows"] == 100);
+    CHECK(root["hexCols"] == 200);
+    CHECK(root["emptyTile"] == 1);
+
+    REQUIRE(root["elevations"].is_array());
+    REQUIRE(root["elevations"].size() == 1); // only elevation 0 was requested
+    const json& e = root["elevations"][0];
+    CHECK(e["elevation"] == 0);
+
+    // Floor grid: the full 10000 cells, row-major; painted cells carry their id, the rest emptyTile.
+    REQUIRE(e["floor"].is_array());
+    REQUIRE(e["floor"].size() == 10000);
+    CHECK(e["floor"][0] == 191);
+    CHECK(e["floor"][1] == 194);
+    CHECK(e["floor"][100] == 70);
+    CHECK(e["floor"][2] == 1); // untouched cell -> emptyTile sentinel
+
+    // Roof grid present (roof requested) with the one painted roof cell.
+    REQUIRE(e["roof"].is_array());
+    REQUIRE(e["roof"].size() == 10000);
+    CHECK(e["roof"][5] == 480);
+
+    // The scenery object, with `number` == the PID's low 24 bits (the value api:proto wants).
+    REQUIRE(e["objects"].is_array());
+    REQUIRE(e["objects"].size() == 1);
+    const json& obj = e["objects"][0];
+    CHECK(obj["number"] == 50);
+    CHECK(obj["type"] == "Wall");
+    CHECK(obj["hex"] == 20100);
+    CHECK(obj["col"] == 100);
+    CHECK(obj["row"] == 100);
+    CHECK(obj["dir"] == 2);
+    CHECK(obj.contains("flat"));
+}
+
+TEST_CASE("dump-grid --no-floor / --no-objects drop those sections", "[cli][dump-grid]") {
+    StubProvider provider;
+    auto mapFile = Map::createEmptyMapFile();
+    mapFile.tiles[0][0].setFloor(191);
+
+    Map map{ "synthetic.map" };
+    map.setMapFile(std::make_unique<Map::MapFile>(std::move(mapFile)));
+    TempFile out{ "geck_dump_grid_flags", ".map" };
+    {
+        MapWriter writer{ [&](int32_t pid) { return provider.load(static_cast<uint32_t>(pid)); } };
+        writer.openFile(out.path());
+        REQUIRE(writer.write(map.getMapFile()));
+    }
+
+    resource::GameResources resources;
+    cli::DumpGridOptions opts;
+    opts.map = out.path().string();
+    opts.elevation = 0;
+    opts.floor = false;
+    opts.objects = false;
+    std::ostringstream jsonOut;
+    REQUIRE(cli::dumpMapGrid(resources, opts, jsonOut) == 0);
+
+    const json e = json::parse(jsonOut.str())["elevations"][0];
+    CHECK_FALSE(e.contains("floor"));
+    CHECK_FALSE(e.contains("objects"));
+    CHECK_FALSE(e.contains("roof")); // roof defaults off
+}


### PR DESCRIPTION
## Summary

Adds **Fill Selection** — a one-shot procedural fill over the selected area, driven by a Luau script. A script paints floor/roof tiles and scatters scenery into a *preview plan* that replays as a single undo entry, so the live ghost preview is byte-identical to the committed result and a whole fill collapses to one Ctrl-Z. Scripts run under a wall-clock watchdog so a runaway loop aborts instead of hanging the editor.

The feature is gated on the scripting build (`GECK_SCRIPTING_ENABLED`).

## Bundled fills

Four ready-to-use biome fills in `scripts/fills/`, each built from **art-verified** scatter palettes (every proto was resolved to its FRM and eyeballed, rather than picked by frequency):

| Fill | Scatter |
|------|---------|
| **Desert** | sparse scrub / weed / cactus |
| **Woods** | tree groves (`tre1000`, `tree1`/`4`/`5`/`6`/`7`/`8`/`9`) + edge scrub |
| **Rocky Badlands** | boulder piles (`rock07`–`rock10`, `drock1`/`8`) + dead weed |
| **Overgrown** | dense scrub + weed low ground cover |

All four sit on the shared `edg5000`-series surface ground (in Fallout 2, biome = scenery, not floor).

## Supporting headless tooling (gecko-cli + MCP)

- **`generate`** — run a fill/generation script against a fresh map
- **`dump-grid`** — emit a map's per-cell floor/roof grid + object positions, so real maps can be analysed before generating

## Bug fix

The Selection panel showed **"No tile selected"** for a single-tile selection: the panel's map pointer was set only when an editor first connected and went stale after a load. It is now synced in `updateMapInfo` (every load/create) and cleared on close so it can't dangle. (Object selection was unaffected — that path doesn't need the map.)

## Testing

- Builds clean with scripting **ON and OFF**
- `general_tests` (329 cases) and `qt_tests` (68) pass
- `gecko-cli map generate` + `map dump-grid` verified end-to-end; generated fills rendered and inspected to confirm the scatter art is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
