### PR TITLE
Address review: guard CLI numeric parsing + exit-grid comment/dead-code cleanup

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -134,6 +134,53 @@ void printUsage(const char* program) {
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
+// Checked integer parse for `--flag <value>` arguments. std::stoi throws std::invalid_argument /
+// std::out_of_range on bad input, which would otherwise terminate the CLI; this catches that and
+// reports a clean "invalid value" error so the subcommand fails gracefully. Returns false (after
+// printing why) on a non-numeric / out-of-range / trailing-garbage value.
+bool parseIntFlag(const std::string& flag, const std::string& value, int& out, const char* program) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed, 10);
+        if (consumed != value.size()) {
+            std::cerr << "error: " << flag << " expects an integer, got: " << value << "\n";
+            printUsage(program);
+            return false;
+        }
+        out = parsed;
+        return true;
+    } catch (const std::exception&) {
+        std::cerr << "error: " << flag << " expects an integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+}
+
+// Checked unsigned parse for `--flag <value>` (base 0: 0x.. hex, else decimal). Same rationale as
+// parseIntFlag: std::stoul throws on bad input and would terminate the CLI.
+bool parseUnsignedFlag(const std::string& flag, const std::string& value, unsigned long& out, const char* program) {
+    if (value.empty() || value.front() == '-' || value.front() == '+') {
+        std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+    try {
+        std::size_t consumed = 0;
+        const unsigned long parsed = std::stoul(value, &consumed, 0);
+        if (consumed != value.size()) {
+            std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+            printUsage(program);
+            return false;
+        }
+        out = parsed;
+        return true;
+    } catch (const std::exception&) {
+        std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+}
+
 bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
@@ -155,20 +202,26 @@ bool extractMissingRequired(const CliArgs& cli) {
     return cli.extract && (cli.ext.mapPath.empty() || cli.ext.outPath.empty() || cli.ext.name.empty());
 }
 
-// Parse a comma-separated list of proto ids/PIDs into `out` (decimal or 0x-hex).
-void parsePids(const std::string& csv, std::vector<std::uint32_t>& out) {
+// Parse a comma-separated list of proto ids/PIDs into `out` (decimal or 0x-hex). Returns false
+// (after printing why) on a non-numeric token, so the caller fails gracefully instead of crashing.
+bool parsePids(const std::string& csv, std::vector<std::uint32_t>& out, const char* program) {
     std::size_t start = 0;
     while (start < csv.size()) {
         const std::size_t comma = csv.find(',', start);
         const std::string token = csv.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
         if (!token.empty()) {
-            out.push_back(static_cast<std::uint32_t>(std::stoul(token, nullptr, 0)));
+            unsigned long value = 0;
+            if (!parseUnsignedFlag("--pids", token, value, program)) {
+                return false;
+            }
+            out.push_back(static_cast<std::uint32_t>(value));
         }
         if (comma == std::string::npos) {
             break;
         }
         start = comma + 1;
     }
+    return true;
 }
 
 // Consume the argument(s) starting at args[i]. Returns how many tokens were consumed (1 for a
@@ -204,8 +257,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.generate && arg == "--elevation") {
-        out.gen.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.gen.elevation, program) ? 2 : 0;
     }
     if (out.generate && arg == "--arg") {
         // key=value -> exposed to the script as args.key
@@ -245,11 +297,14 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.render && arg == "--elevation") {
-        out.ren.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ren.elevation, program) ? 2 : 0;
     }
     if (out.render && arg == "--max-dim") {
-        out.ren.maxDimension = static_cast<unsigned int>(std::stoul(args[i + 1]));
+        unsigned long maxDim = 0;
+        if (!parseUnsignedFlag(arg, args[i + 1], maxDim, program)) {
+            return 0;
+        }
+        out.ren.maxDimension = static_cast<unsigned int>(maxDim);
         return 2;
     }
     if (out.render && arg == "--roof") {
@@ -298,20 +353,16 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.extract && arg == "--elevation") {
-        out.ext.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.elevation, program) ? 2 : 0;
     }
     if (out.extract && arg == "--pids") {
-        parsePids(args[i + 1], out.ext.pids);
-        return 2;
+        return parsePids(args[i + 1], out.ext.pids, program) ? 2 : 0;
     }
     if (out.extract && arg == "--anchor") {
-        out.ext.anchorHex = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.anchorHex, program) ? 2 : 0;
     }
     if (out.extract && arg == "--radius") {
-        out.ext.radius = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.radius, program) ? 2 : 0;
     }
     if (out.extract && arg == "--include-floor") {
         out.ext.includeFloor = true;
@@ -327,8 +378,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 0;
     }
     if (out.describeScript && arg == "--index") {
-        out.desc.programIndex = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.desc.programIndex, program) ? 2 : 0;
     }
     if (out.describeScript && arg == "--locale") {
         out.desc.locale = args[i + 1];
@@ -362,8 +412,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.dumpGrid && arg == "--elevation") {
-        out.dumpOpts.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.dumpOpts.elevation, program) ? 2 : 0;
     }
     if (out.dumpGrid && arg == "--roof") {
         out.dumpOpts.roof = true;
@@ -505,19 +554,18 @@ bool isFrmAction(const std::string& action) {
     return action == "info" || action == "render" || action == "resolve" || action == "list";
 }
 
-// Apply a `--flag value` pair to `out`. Returns true if `flag` is a recognized value flag (and was
-// applied); false otherwise, so the caller can treat the token as a positional / unknown flag.
-bool applyFrmValueFlag(const std::string& flag, const std::string& value, FrmArgs& out) {
+// Apply a recognized `--flag value` pair to `out`. Returns false (after printing why) when the
+// numeric flags (--dir / --frame) get a non-integer value, so the caller fails gracefully instead
+// of letting std::stoi throw and terminate the CLI.
+bool applyFrmValueFlag(const std::string& flag, const std::string& value, FrmArgs& out, const char* program) {
     if (flag == "--data") {
         out.dataPaths.push_back(value);
     } else if (flag == "--out") {
         out.outPath = value;
     } else if (flag == "--dir") {
-        out.direction = std::stoi(value);
+        return parseIntFlag(flag, value, out.direction, program);
     } else if (flag == "--frame") {
-        out.frame = std::stoi(value);
-    } else {
-        return false;
+        return parseIntFlag(flag, value, out.frame, program);
     }
     return true;
 }
@@ -533,7 +581,9 @@ bool parseFrmArgs(const std::vector<std::string>& args, const char* program, Frm
             return false;
         }
         if (valueFlag) {
-            applyFrmValueFlag(arg, args[i + 1], out);
+            if (!applyFrmValueFlag(arg, args[i + 1], out, program)) {
+                return false;
+            }
             i += 2;
         } else if (arg.rfind("--", 0) == 0) {
             std::cerr << "error: unexpected argument: " << arg << "\n";

--- a/src/editor/Object.cpp
+++ b/src/editor/Object.cpp
@@ -7,7 +7,6 @@
 #include "util/Constants.h"
 #include "util/Coordinates.h"
 #include "util/Exceptions.h"
-#include "util/ExitGridDirection.h"
 #include <algorithm>
 #include <spdlog/spdlog.h>
 
@@ -123,22 +122,6 @@ void Object::setHexPosition(const Hex& hex) {
     if (_showLightOverlay && hasLight()) {
         updateLightOverlay();
     }
-}
-
-int Object::exitGridDirection() const {
-    // Placed markers carry a MapObject whose proto index (16..23) is the direction.
-    if (_mapObject != nullptr && _mapObject->isExitGridMarker()) {
-        return static_cast<int>(_mapObject->protoId()) - static_cast<int>(MapObject::EXIT_GRID_PID_INDEX_FIRST);
-    }
-    // Preview / bare-FRM objects (no MapObject) are identified by art name: exitgrd1..8 / ext2grd1..8.
-    const std::string& fn = _frm != nullptr ? _frm->filename() : std::string();
-    if (fn.size() >= 8 && (fn.rfind("exitgrd", 0) == 0 || fn.rfind("ext2grd", 0) == 0)) {
-        const int dir = fn[7] - '1';
-        if (dir >= 0 && dir < ExitGrid::DIR_COUNT) {
-            return dir;
-        }
-    }
-    return -1;
 }
 
 int16_t Object::shiftX() const {

--- a/src/editor/Object.h
+++ b/src/editor/Object.h
@@ -75,10 +75,6 @@ public:
     [[nodiscard]] int width() const;
     [[nodiscard]] int height() const;
 
-    /// The exit-grid direction (0..7) of this object, or -1 if it is not an exit-grid marker. Real
-    /// markers report it from their MapObject proto index; preview/bare-FRM objects from the art name.
-    [[nodiscard]] int exitGridDirection() const;
-
 private:
     static sf::Texture& createBlankTexture();
     void initializeLightOverlay();

--- a/src/rendering/MapSpriteLoader.cpp
+++ b/src/rendering/MapSpriteLoader.cpp
@@ -133,10 +133,10 @@ void MapSpriteLoader::loadObjectSprites(
             auto sceneObject = std::make_shared<Object>(frm);
             sf::Sprite objectSprite{ _resources.textures().get(frmName) };
             sceneObject->setSprite(std::move(objectSprite));
-            // setMapObject before setHexPosition: the latter consults isExitGridMarker() to push an
-            // exit-grid bar outward (the trigger hex sits at its inner edge), so the marker info must
-            // be set first. setDirection (which sets the frame rect) also runs before positioning so
-            // the outward nudge measures the correct on-screen bounds.
+            // Order matters: setMapObject first so setDirection/setHexPosition can sync the
+            // MapObject's direction and position fields back onto it. setDirection (which sets the
+            // frame rect) runs before setHexPosition because centering uses the current frame's
+            // width()/height()/shift to seat the sprite on the hex.
             sceneObject->setMapObject(object);
             sceneObject->setDirection(static_cast<ObjectDirection>(object->direction));
             if (auto hex = _hexgrid.getHexByPosition(object->position); hex.has_value()) {

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -508,8 +508,8 @@ std::shared_ptr<Object> RenderingEngine::buildExitGridPreviewObject(const Render
         }
 
         // Anchor exactly like a committed exit grid: setDirection sets the frame rect, then
-        // setHexPosition applies the FRM offset and pushes the bar outward. Order matters — setHexPosition
-        // measures the on-screen bounds, so the frame rect must be set first.
+        // setHexPosition centers the bar on the hex using that frame's FRM offset. Order matters —
+        // setHexPosition reads the current frame's width()/height()/shift, so the rect must be set first.
         auto previewObject = std::make_shared<Object>(frm);
         previewObject->setSprite(sf::Sprite{ _resources.textures().get(frmName) });
         previewObject->setDirection(ObjectDirection(0));

--- a/tests/general/test_exit_grid_direction.cpp
+++ b/tests/general/test_exit_grid_direction.cpp
@@ -214,16 +214,17 @@ TEST_CASE("exitGridDirectionForLine picks one side for the whole stroke and the 
 }
 
 TEST_CASE("exitGridOutward: the per-direction outward (off-map) screen vector", "[exitgrid][outward]") {
-    // Screen y grows DOWNWARD. The editor slides the bar along this vector so the trigger hex sits at
-    // the bar's inner edge; a flip (dir ^ 1) reverses the sign and swings the byte-identical art to the
-    // OTHER side of the line. Each cardinal caps its named screen edge.
+    // Screen y grows DOWNWARD. This vector is the side a marker's art faces; secondRowNeighbor uses it
+    // to pick the diagonal band's second row (the neighbour leaning most along it). A flip (dir ^ 1)
+    // reverses the sign, mirroring that facing to the OTHER side of the line. Each cardinal caps its
+    // named screen edge.
     CHECK(exitGridOutward(ExitGrid::DIR_LEFT) == std::pair{ -1, 0 });
     CHECK(exitGridOutward(ExitGrid::DIR_RIGHT) == std::pair{ 1, 0 });
     CHECK(exitGridOutward(ExitGrid::DIR_BOTTOM) == std::pair{ 0, 1 });
     CHECK(exitGridOutward(ExitGrid::DIR_TOP) == std::pair{ 0, -1 });
     // The diagonals face PERPENDICULAR to their band's on-screen line (integer approximations of the
-    // measured ~-9° "/" and ~+26° "\" normals; applyExitGridOutwardOffset normalizes before scaling).
-    // The DIRECTION lives here and must flip sign across a dir ^ 1 pair so the band switches sides.
+    // measured ~-9° "/" and ~+26° "\" normals). The DIRECTION lives here and must flip sign across a
+    // dir ^ 1 pair so the band switches sides.
     CHECK(exitGridOutward(ExitGrid::DIR_FWD_A) == std::pair{ 1, 6 });   // "/" side A: down
     CHECK(exitGridOutward(ExitGrid::DIR_FWD_B) == std::pair{ -1, -6 }); // "/" side B: up (the ^1 flip)
     CHECK(exitGridOutward(ExitGrid::DIR_BACK_A) == std::pair{ -1, 2 }); // "\" side A: down-left


### PR DESCRIPTION
Follow-up to #92 (merged), addressing Copilot's review feedback.

## CLI: graceful numeric-flag parsing
`std::stoi`/`std::stoul` on the CLI's numeric flags **threw and terminated** the program on bad input (e.g. `frm render --dir nope`). Every numeric flag now goes through checked `parseIntFlag`/`parseUnsignedFlag` helpers that reject non-numeric / trailing-garbage / out-of-range values with a clean error + usage and fail gracefully (`consumeArg` returns 0 → caller exits with code 2). Swept all of them: `--elevation` (generate/render/extract/dump-grid), `--max-dim`, `--anchor`, `--radius`, `--index`, `--pids`, and `frm --dir`/`--frame` — not just the one Copilot flagged.

## Stale comments + dead code
- Corrected comments in `MapSpriteLoader` / `RenderingEngine` / the direction tests that claimed `setHexPosition` pushes exit-grid bars outward — that offset logic was removed; bars now center on their hex.
- Removed the now-unused `Object::exitGridDirection()` (dead after the offset revert) and its include.

Build clean; 342 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6Pw1wpjwVwedbSjgWrXiT