### PR TITLE
MCP map.msg display names + CLI parse guards and backlog cleanup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -21,32 +21,24 @@ live with their library (`src/resource/`, `src/ui/`).
    (`MapInfoPanel` checkboxes) is still a direct mutation; a cascading script-delete when an
    object is deleted; and the command-controller actions themselves aren't integration-tested
    (they need GameResources/Qt — a `qt_tests` follow-up).
-2. **Exit grids are rectangle-only** — detailed below.
-3. **AI packet / script program are raw values** (engine packet numbers / scripts.lst names),
+2. **AI packet / script program are raw values** (engine packet numbers / scripts.lst names),
    not friendly labels — no invented label tables, per the engine-fidelity rule. Real labels
    need `data/ai.txt` parsing (AI) or the scripts.lst trailing comment (script "description" —
    see the SSL-editing section; the `.int` has no description, Q below).
-4. **Newly created scripts get `local_var_count=0` / `offset=-1`** — exactly what the engine's
+3. **Newly created scripts get `local_var_count=0` / `offset=-1`** — exactly what the engine's
    `scriptAdd` writes; locals are allocated at runtime from the `.int`. The editor does not
    parse `.int` headers, and the local-var *count* lives in `scripts.lst`, not the binary.
-5. **F11 spatial placement is dialog-driven** (enter tile/elevation/radius), not click-to-place
+4. **F11 spatial placement is dialog-driven** (enter tile/elevation/radius), not click-to-place
    with a live hex marker, radius overlay, and a new `EditorMode`. Existing spatial scripts also
    aren't visualized on the map or editable/deletable through the UI yet.
-6. **F16 per-instance kill-type and custom name are out of scope** — not exposed in the engine
+5. **F16 per-instance kill-type and custom name are out of scope** — not exposed in the engine
    mapper and would require new serialized `MapObject` fields.
-7. **Script attach reassigns the object OID** (`unknown0`) to a fresh unique id (matching the
+6. **Script attach reassigns the object OID** (`unknown0`) to a fresh unique id (matching the
    engine's `objectSetScript`); existing cross-references to the old OID aren't audited/rewritten.
-8. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
-9. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
+7. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
+8. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
    recompute, multi-hex occupancy overlay, or live light-radius overlay beyond the rebuild.
-10. **PRO-dialog animation preview jitters ("shaky camera").** Playback works, but each frame is
-    centred on its own bounding box instead of being anchored to a fixed reference point. FRM
-    frames carry per-frame signed (x, y) pixel **offsets** (the `Object::shiftX()/shiftY()`
-    values) that the engine accumulates so the sprite's anchor stays put across frames; the
-    preview ignores them, so frames with slightly different centres wobble. **Fix:** position
-    each preview frame by its FRM offset relative to a fixed anchor (mirror how the map
-    renderer/`Object` applies `shiftX/shiftY`) instead of re-centering per frame.
-11. **Keybindings are hardcoded — no user remapping.** Shortcuts are scattered and fixed: the
+9. **Keybindings are hardcoded — no user remapping.** Shortcuts are scattered and fixed: the
     menu/toolbar `QKeySequence`s in `MainWindow::setupMenuBar()`/`setupToolBar()` (New/Open/Save,
     Select All `Ctrl+A`, scroll-blocker `B`, exit grids `Ctrl+E`, undo/redo, …), the editor-mode
     keys in `InputHandler::handleKeyPressed` (`R` cycles a stamp variant, `Esc` cancels, `Delete`/
@@ -57,13 +49,13 @@ live with their library (`src/resource/`, `src/ui/`).
     the menu/toolbar `QAction`s *and* the `InputHandler` dispatch from that table instead of
     literals, so a rebind takes effect everywhere and the bindings stay discoverable. Engine-fidelity
     note: this is editor UX only — it changes no map/format data.
-12. **Toolbar is a fixed button set — not user-customizable.** The primary toolbar (New, Browse Maps,
+10. **Toolbar is a fixed button set — not user-customizable.** The primary toolbar (New, Browse Maps,
     Save, Play) is a hardcoded `primaryToolbarActions` array in `MainWindow::setupToolBar()`. Most
     editors let users choose which buttons appear and reorder them. **Add a customizable toolbar:**
-    drive it from the same command/action table proposed in #11 (stable action id → icon/label/handler),
+    drive it from the same command/action table proposed in #9 (stable action id → icon/label/handler),
     with a context-menu / Preferences UI to add, remove, and reorder buttons, persisted via `Settings`.
     Editor UX only; no map/format change.
-13. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
+11. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
     into the *last folder* in Data Paths — `findWritableDataPath` walks the list from the end and takes
     the first real directory (archives skipped). That's implicit and order-dependent: reordering Data
     Paths silently changes where saves land, and nothing in the UI shows which location is the writable
@@ -72,30 +64,6 @@ live with their library (`src/resource/`, `src/ui/`).
     selected folder as the default writable location, shown with a badge in the list and persisted in
     `Settings`; saves then target that folder regardless of list order. If none is marked, keep the
     current last-folder fallback and hint the user to pick one. DAT archives can't be marked (read-only).
-
-### Exit-grid shapes (rectangle-only) — limitation #2 in detail
-
-**Current behaviour:** the reachable exit-grid creation path
-(`ExitGridPlacementManager::selectExitGridsInArea`) fills a **rectangular** drag selection — it
-collects every hex whose footprint intersects the rectangle and makes an exit-grid object on
-each, so only axis-aligned rectangular exit-grid regions can be authored.
-
-**Engine reality (investigated):** exit grids are **independent per-hex MISC objects**
-(pid 16–23), each carrying its own exit destination; there is **no rectangle, perimeter, or
-"interior texture" concept** in the format — the player triggers the transition by stepping on
-any exit-grid hex. The fallout2-ce mapper's **"Mark Exit-Grids"** mode toggles a marker on each
-**individually clicked hex** (`mapper.cc`: `markExitGridMode` → `mapper_mark_exit_grid()` on each
-left-click, mapper.cc:1325), and the legacy `reference/F2_Mapper_Dims-master/Mapper` works the
-same way. Because the playable map area is an iso diamond, real exit grids commonly run
-**diagonally** along the screen edges — the "triangular"/diagonal shapes a rectangle fill cannot
-represent.
-
-**Fix:** drop the rectangle-fill assumption and support arbitrary-shape placement. We already
-have per-hex placement (`ExitGridPlacementManager::placeExitGridAtPosition`), but it's gated
-behind `EditorMode::PlaceExitGrid`, which has **no UI trigger** (see the EditorMode gap above) —
-wiring that one button gives engine-equivalent per-hex marking. Optionally add line/freehand
-placement for fast diagonal runs. There is no perimeter/interior distinction to preserve: every
-exit-grid hex is a full, independent exit-grid object.
 
 ### Generation-side exit placement — current state & smarter follow-up
 
@@ -123,49 +91,6 @@ blind rectangle:
 
 The primitive (`placeExitGridRect`) and the directional-art mapping are the reusable foundation;
 the follow-up is feeding them terrain-derived locations instead of a centred rectangle.
-
-### Unified exit-grid tool + polygonal drawing (UX)
-
-Exit-grid authoring is split across **two toolbar buttons** (place-single vs the rectangular
-"mark exits" drag). Fold them into **one tool with a mode dropdown**:
-- **Place single** — the existing per-hex `placeExitGridAtPosition` (also closes the no-UI-trigger
-  gap for `EditorMode::PlaceExitGrid` noted above).
-- **Draw region** — replace the axis-aligned rectangle fill (`selectExitGridsInArea`) with a
-  **polygonal / freehand** path: the user clicks vertices (or drags) and every hex on the outline /
-  inside the polygon becomes an exit-grid MISC object, so the diagonal iso-edge runs that real maps
-  use are authorable — directly resolving the rectangle-only limitation above.
-
-While drawing, render each prospective hex with its **MISC exit marker texture at the correct
-orientation**, tinted by destination kind: **green for an inter-map exit**, **brown for a world-map
-exit** (the `-2`/`-1` sentinels; cf. the `ExitGrid::RECT_*` directional art), so the author sees the
-region forming with engine-accurate art before committing. One destination per region — the
-properties dialog (now name-annotated via `MapNameResolver`) still sets it.
-
-### Map metadata editing (maps.txt / map.msg in the editor)
-
-The editor can now *read* a map's friendly name and its exits' destinations (`MapNameResolver`:
-`maps.txt` → `MapsTxt`, plus `map.msg` display names, surfaced in the exit-grid dialog). Next: let
-the user **edit** that metadata.
-
-**Surface — where it lives** (decision needed):
-- **In the existing Map Info panel** *(recommended for the per-map fields)* — the current map's
-  `lookup_name`, display name, music, and yes/no flags (saved / pipboy_active / automap) sit
-  naturally beside the map properties the panel already shows. Lowest friction, no new surface.
-- **A new tab in the Map Info panel** — if the field set grows (ambient_sfx list, per-elevation
-  names, random start points), a "Map Registry" tab keeps the basic panel uncluttered.
-- **A dedicated panel/dialog** — only if editing the *whole* `maps.txt` / `map.msg` table (every
-  map, not just the current one) becomes a goal; heavier, likely out of scope for v1.
-
-Recommendation: per-map fields in the **Map Info panel** (or a tab there); defer a full-table editor.
-
-**Editability — the DAT problem.** `maps.txt` and the `*.msg` files usually live **inside
-`master.dat`**, which the editor reads but must not rewrite. So before editing, **copy the file out
-to the native filesystem** (a writable data root / the configured game data dir) and edit *that*
-copy, which then shadows the archive entry (the VFS already layers loose files over the DAT). Flow:
-on first edit, if the path resolves from a DAT, materialize it to the loose data dir, then read/write
-the loose copy. Needs (a) a "writable data root" setting, (b) a VFS helper to tell whether a path is
-archive-backed, and (c) a `maps.txt` *writer* — or, to preserve comments/ordering, keep the raw text
-and patch only the touched keys rather than re-serializing `MapsTxt`.
 
 ---
 
@@ -841,7 +766,8 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
    This is the actual "map of the world + distances between places." Terrain types + encounter group
    tables are now also covered (`worldmap.txt` → `world_encounters`). **Remaining:** the `worldmap.txt`
    `[Tile NN]` sub-tile grid (per-position terrain → terrain-weighted travel cost, geographic
-   encounter placement) and `worldmap.msg` localized names.
+   encounter placement) and `worldmap.msg` encounter descriptions (area/city labels are map.msg, now
+   surfaced as `world_map`'s `displayName`).
 
 8. **Corpus / world index — evidence, not a solver.** The evidence layer now largely exists: the
    `map_graph`↔`world_map` join (`area`/`mapFile`/`lookupName`), the `quests` tool (each quest's area +
@@ -861,10 +787,10 @@ file parsing of its own. (`maps.txt` was moved into vault as `MapsTxt` to set th
 Surveyed from `fallout2-ce` (`configRead` / `messageListLoad`). Each becomes a vault reader + object,
 then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority order:
 
-- **`map.msg` display names** *(high value, low effort — the obvious next step).* `mapGetName` =
-  `map.msg[mapIndex*3 + elevation + 200]`; city names = `map.msg[1500 + city]`. Gives each map (and
-  every `destMap` exit) a friendly per-elevation name ("Arroyo", "Temple of Trials") alongside the
-  `.map` filename `MapsTxt` already resolves. Pairs directly with `MapsTxt`.
+- **`map.msg` display names** ✅ **done** — `MapNameResolver` owns both engine formulas: per-map names
+  `map.msg[mapIndex*3 + elevation + 200]` (`displayName`) and worldmap city labels
+  `map.msg[1500 + areaIndex]` (`areaName`). Surfaced as `displayName` in `analyze`/`describe_map` (each
+  map + every `destMap` exit), `map_graph` nodes, `list_maps` entries, and `world_map` areas.
 - **`data/quests.txt` + `game/quests.msg`** ✅ **done** — `QuestsTxt` vault reader + the `quests` tool:
   each quest's area (map.msg location name), tracking **gvar** (index + `GVAR_*` name + default via
   vault13.gam), display/completed thresholds, and quests.msg description. The progression spine.
@@ -882,9 +808,12 @@ then surfaces through `analyze`/`describe_map` or a dedicated tool. Priority ord
   `wmFindCurSubTileFromPos`, so `world_map` now reports each area's `terrain` and a terrain-weighted
   `travelCost` between areas. **Follow-up (minor):** per-position *encounter* placement (the subtile
   encounter chances) is still unparsed — only the terrain field is kept.
-- **`game/worldmap.msg`** *(follow-up, small)* — localized area/terrain/encounter names to enrich
-  `world_map` / `world_encounters` (city.txt `area_name` and the encounter section names are the
-  internal labels).
+- **`game/worldmap.msg`** *(follow-up — narrowed)* — area/city labels turned out to live in **map.msg**
+  (`[1500 + areaIndex]`, now surfaced as `world_map`'s `displayName`) and terrain names are already
+  readable in worldmap.txt, so the only names genuinely in worldmap.msg are the random-encounter
+  **descriptions** (`worldmap.msg[3000 + 50*tableId + entryId]`, fallout2-ce worldmap.cc:3595) — and
+  those are runtime-index-tied to the encounter table/entry ordering, not a small add. Just that
+  encounter-description join remains.
 - **`data/endgame.txt`** ✅ **done** — `EndgameTxt` vault reader + the `endings` tool: each ending slide
   keyed by `gvar == value` (gvar resolved to its `GVAR_ENDGAME_MOVIE_*` name + a readable condition),
   the slide art, and the narrator/subtitle base name. Slides sharing a gvar at different values are a
@@ -974,7 +903,7 @@ The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thum
 
 > Status: investigation. Spatial scripts can be created (`SpatialScriptDialog` → F-key flow)
 > but are **invisible on the map** once placed — there's no marker, no radius overlay, and no
-> way to see, select, edit, or delete an existing one (see Known limitations #5). Goal: render
+> way to see, select, edit, or delete an existing one (see Known limitations #4). Goal: render
 > existing spatial scripts on the canvas so designers can see where their trigger zones are.
 
 ## What the data model gives us
@@ -1001,7 +930,7 @@ object list. Placement currently flows MapInfoPanel → `EditorWidget::addSpatia
   culled via the viewport like the other overlays.
 - **Interaction (stretch):** hit-test a marker to select → open `SpatialScriptDialog` to
   edit/delete; ties into the F-key click-to-place + new `EditorMode` already sketched in
-  Known limitations #5 (live hex marker + radius preview while placing).
+  Known limitations #4 (live hex marker + radius preview while placing).
 
 ## Rough effort
 S–M for read-only visualization (marker + radius overlay + visibility toggle), reusing the
@@ -1081,8 +1010,9 @@ the rest.
   into sheets. The core work is a preview clock that advances each animated object's frame
   index over time (honouring the FRM `fps` / `framesPerDirection`, looping idle anims), plus
   per-object animation state and only animating culled/on-screen objects for perf at map scale.
-  **Depends on** fixing the per-frame offset handling (known limitation #10) or animations will
-  wobble. No new assets needed.
+  The per-frame FRM offset handling this needs is already correct (the PRO-dialog animation preview
+  was fixed to anchor frames by their `shiftX/shiftY`), so idle playback won't wobble. No new assets
+  needed.
 - **Lighting / darkness — Medium.** Render honouring `header.darkness` and per-object light
   (`light_radius` / `light_intensity`, already in the model) — an additive light pass / ambient
   tint in `RenderingEngine`. The data already exists; it's a rendering feature.
@@ -1599,46 +1529,3 @@ Effort: S ≈ days, M ≈ 1–2 weeks, L ≈ 3–4 weeks for one developer. The 
 - **`blob8` authoring burden** (47 entries). Support both `edges4` and `blob8`; ship `edges4` examples first.
 - **Trust beyond hand-installed plugins.** v1 deliberately ships only the install-time prompt; SHA pinning, re-prompt-on-widening, quarantine, the version triple, `.gplug`, and ed25519 signing are deferred until ABI 1 is frozen and a distribution channel exists. Gate third-party *distribution* until then.
 
----
-
-# Exit-grid rendering vs the engine — DONE (engine-faithful, two real rows)
-
-**DONE — implemented.** Diagonal exit grids now place TWO rows of REAL, selectable objects, each bar
-drawn once centered on its hex like the engine (`Object::applyExitGridOutwardOffset` + the display
-doubling removed; a second row added in `ExitGridPlacementManager::classifySegment` via
-`secondRowNeighbor`/`secondRowHex`, `kSecondRowSteps = 2` so the bars tile into a clean ~2× band).
-Visible bar == selectable object, and the cardinal "hexes outside the texture" is fixed too. The notes
-below record the engine truth and the before→after rationale for reference.
-
-**Both rows are real exit grids → a 2-deep trigger zone (by design).** The inner/second row is
-functionally inert in normal play (walking off-map the player exits at the first row it reaches and never
-steps onto the second), but it IS a real exit in the saved data. A "non-exiting decorative exit-grid bar"
-is **impossible**: the engine fires the map transition on any object whose PID is in the exit-grid range
-(`0x05000010–17`) **unconditionally**, ignoring `exit_map`/flags (`fallout2-ce/object.cc:1425`); no
-`exit_map` value means "no transition" (`0`/`-1`/`-2` are world/town map; the inactive-grid FID swap is
-cosmetic, keyed on FID not PID). So two real selectable rows necessarily means two exits in data — chosen
-(author's call) over a display-only second texture, which would keep one exit line but make the second
-bar un-selectable.
-
-**Engine truth** (verified against shipped maps `ncr1`, `redmtun`, `redwan1`, `artemple` via the new
-`map render --exit-dots` overlay, and against `fallout2-ce/src/object.cc` ~4942): every exit grid is ONE
-bar per object, drawn once, **centered on its hex** — `left = hexScreenX - frameWidth/2`, `bottom =
-hexScreenY`; all eight exit-grid FRMs (`exitgrd1-8` / `ext2grd1-8`) have frame offsets `(0,0)`; there is
-no exit-grid special case in the renderer. The trigger hex == the object's hex == the bar's bottom-center.
-A real exit edge is a SINGLE line of objects (cardinal = straight, diagonal = a one-hex staircase) — never
-a doubled / 2-wide band. It only *looks* wide because the bars (96×24 … 127×48) overlap across the ~16×12
-hex step.
-
-**Editor divergence** (the cause of the known quirks): `Object::applyExitGridOutwardOffset` slides the
-bar off its hex (cardinals onto the bar's inner bbox edge), and `RenderingEngine::renderDiagonalExitGridBars`
-/ `drawDoubledDiagonalBar*` draws diagonal bars TWICE as a doubled display band. Consequences: object
-selection misses the visible bar and instead selects the on-hex object (which renders no bar of its own);
-the trigger hex falls outside the texture; the live preview doesn't match the placement; diagonal pairs
-misalign.
-
-**Fix when prioritized**: delete `renderDiagonalExitGridBars` / `drawDoubledDiagonalBar*` (+ the
-`isDiagonalExitGridObject` skip in `renderObjects`) and `Object::applyExitGridOutwardOffset`; let exit
-grids draw once through the standard object path — the base `setHexPosition` already reproduces the engine
-anchor (centered horizontally, bottom edge at the hex). Then visible bar == real object == selectable. If
-a wider authoring visual is still wanted, do it as a translucent overlay tied to the object's actual hex —
-never an offset or a second copy of the texture, which re-breaks selection.

--- a/TODO.md
+++ b/TODO.md
@@ -50,11 +50,6 @@ Detailed progress dialog with task descriptions and completion estimates for lon
       path's map-copy + ddraw.ini step. (Detection of a Steam-*installed* copy as a regular
       executable install is still supported.)
 
-### Map info panel
-
-- [ ] All fields should be editable and saved when the map is saved (exported)
-- [ ] After the Qt migration, map script, map global variables and map scripts are not displayed in the panel
-
 ### Panels
 - [ ] panels should be displayed above the SFML widget, so that when a panel is closed it doesn't cause redrawing of the SFML widget
 

--- a/src/cli/WorldMap.cpp
+++ b/src/cli/WorldMap.cpp
@@ -34,7 +34,11 @@ namespace {
                     { "mapFile", mapFile.empty() ? ordered_json(nullptr) : ordered_json(mapFile) } });
             }
             const std::string terrain = world.terrainAt(area.worldX, area.worldY); // "" if no tile grid
+            // The on-screen city label (map.msg[1500+index]) the engine shows, distinct from city.txt's
+            // internal area_name in 'name'. null when map.msg isn't mounted or the area is unnamed.
+            const std::string display = names.areaName(area.index);
             areas.push_back({ { "index", area.index }, { "name", area.name },
+                { "displayName", display.empty() ? ordered_json(nullptr) : ordered_json(display) },
                 { "worldPos", { { "x", area.worldX }, { "y", area.worldY } } },
                 { "size", area.size }, { "knownAtStart", area.startOn },
                 { "terrain", terrain.empty() ? ordered_json(nullptr) : ordered_json(terrain) },

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -134,6 +134,53 @@ void printUsage(const char* program) {
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
+// Checked integer parse for `--flag <value>` arguments. std::stoi throws std::invalid_argument /
+// std::out_of_range on bad input, which would otherwise terminate the CLI; this catches that and
+// reports a clean "invalid value" error so the subcommand fails gracefully. Returns false (after
+// printing why) on a non-numeric / out-of-range / trailing-garbage value.
+bool parseIntFlag(const std::string& flag, const std::string& value, int& out, const char* program) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed, 10);
+        if (consumed != value.size()) {
+            std::cerr << "error: " << flag << " expects an integer, got: " << value << "\n";
+            printUsage(program);
+            return false;
+        }
+        out = parsed;
+        return true;
+    } catch (const std::exception&) {
+        std::cerr << "error: " << flag << " expects an integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+}
+
+// Checked unsigned parse for `--flag <value>` (base 0: 0x.. hex, else decimal). Same rationale as
+// parseIntFlag: std::stoul throws on bad input and would terminate the CLI.
+bool parseUnsignedFlag(const std::string& flag, const std::string& value, unsigned long& out, const char* program) {
+    if (value.empty() || value.front() == '-' || value.front() == '+') {
+        std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+    try {
+        std::size_t consumed = 0;
+        const unsigned long parsed = std::stoul(value, &consumed, 0);
+        if (consumed != value.size()) {
+            std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+            printUsage(program);
+            return false;
+        }
+        out = parsed;
+        return true;
+    } catch (const std::exception&) {
+        std::cerr << "error: " << flag << " expects a non-negative integer, got: " << value << "\n";
+        printUsage(program);
+        return false;
+    }
+}
+
 bool isKnownSubcommand(const std::vector<std::string>& args) {
     return args.size() >= 2 && args[0] == "map"
         && (args[1] == "analyze" || args[1] == "generate" || args[1] == "render" || args[1] == "extract-pattern"
@@ -155,20 +202,26 @@ bool extractMissingRequired(const CliArgs& cli) {
     return cli.extract && (cli.ext.mapPath.empty() || cli.ext.outPath.empty() || cli.ext.name.empty());
 }
 
-// Parse a comma-separated list of proto ids/PIDs into `out` (decimal or 0x-hex).
-void parsePids(const std::string& csv, std::vector<std::uint32_t>& out) {
+// Parse a comma-separated list of proto ids/PIDs into `out` (decimal or 0x-hex). Returns false
+// (after printing why) on a non-numeric token, so the caller fails gracefully instead of crashing.
+bool parsePids(const std::string& csv, std::vector<std::uint32_t>& out, const char* program) {
     std::size_t start = 0;
     while (start < csv.size()) {
         const std::size_t comma = csv.find(',', start);
         const std::string token = csv.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
         if (!token.empty()) {
-            out.push_back(static_cast<std::uint32_t>(std::stoul(token, nullptr, 0)));
+            unsigned long value = 0;
+            if (!parseUnsignedFlag("--pids", token, value, program)) {
+                return false;
+            }
+            out.push_back(static_cast<std::uint32_t>(value));
         }
         if (comma == std::string::npos) {
             break;
         }
         start = comma + 1;
     }
+    return true;
 }
 
 // Consume the argument(s) starting at args[i]. Returns how many tokens were consumed (1 for a
@@ -204,8 +257,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.generate && arg == "--elevation") {
-        out.gen.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.gen.elevation, program) ? 2 : 0;
     }
     if (out.generate && arg == "--arg") {
         // key=value -> exposed to the script as args.key
@@ -245,11 +297,14 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.render && arg == "--elevation") {
-        out.ren.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ren.elevation, program) ? 2 : 0;
     }
     if (out.render && arg == "--max-dim") {
-        out.ren.maxDimension = static_cast<unsigned int>(std::stoul(args[i + 1]));
+        unsigned long maxDim = 0;
+        if (!parseUnsignedFlag(arg, args[i + 1], maxDim, program)) {
+            return 0;
+        }
+        out.ren.maxDimension = static_cast<unsigned int>(maxDim);
         return 2;
     }
     if (out.render && arg == "--roof") {
@@ -298,20 +353,16 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.extract && arg == "--elevation") {
-        out.ext.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.elevation, program) ? 2 : 0;
     }
     if (out.extract && arg == "--pids") {
-        parsePids(args[i + 1], out.ext.pids);
-        return 2;
+        return parsePids(args[i + 1], out.ext.pids, program) ? 2 : 0;
     }
     if (out.extract && arg == "--anchor") {
-        out.ext.anchorHex = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.anchorHex, program) ? 2 : 0;
     }
     if (out.extract && arg == "--radius") {
-        out.ext.radius = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.ext.radius, program) ? 2 : 0;
     }
     if (out.extract && arg == "--include-floor") {
         out.ext.includeFloor = true;
@@ -327,8 +378,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 0;
     }
     if (out.describeScript && arg == "--index") {
-        out.desc.programIndex = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.desc.programIndex, program) ? 2 : 0;
     }
     if (out.describeScript && arg == "--locale") {
         out.desc.locale = args[i + 1];
@@ -362,8 +412,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
         return 2;
     }
     if (out.dumpGrid && arg == "--elevation") {
-        out.dumpOpts.elevation = std::stoi(args[i + 1]);
-        return 2;
+        return parseIntFlag(arg, args[i + 1], out.dumpOpts.elevation, program) ? 2 : 0;
     }
     if (out.dumpGrid && arg == "--roof") {
         out.dumpOpts.roof = true;
@@ -505,19 +554,18 @@ bool isFrmAction(const std::string& action) {
     return action == "info" || action == "render" || action == "resolve" || action == "list";
 }
 
-// Apply a `--flag value` pair to `out`. Returns true if `flag` is a recognized value flag (and was
-// applied); false otherwise, so the caller can treat the token as a positional / unknown flag.
-bool applyFrmValueFlag(const std::string& flag, const std::string& value, FrmArgs& out) {
+// Apply a recognized `--flag value` pair to `out`. Returns false (after printing why) when the
+// numeric flags (--dir / --frame) get a non-integer value, so the caller fails gracefully instead
+// of letting std::stoi throw and terminate the CLI.
+bool applyFrmValueFlag(const std::string& flag, const std::string& value, FrmArgs& out, const char* program) {
     if (flag == "--data") {
         out.dataPaths.push_back(value);
     } else if (flag == "--out") {
         out.outPath = value;
     } else if (flag == "--dir") {
-        out.direction = std::stoi(value);
+        return parseIntFlag(flag, value, out.direction, program);
     } else if (flag == "--frame") {
-        out.frame = std::stoi(value);
-    } else {
-        return false;
+        return parseIntFlag(flag, value, out.frame, program);
     }
     return true;
 }
@@ -533,7 +581,9 @@ bool parseFrmArgs(const std::vector<std::string>& args, const char* program, Frm
             return false;
         }
         if (valueFlag) {
-            applyFrmValueFlag(arg, args[i + 1], out);
+            if (!applyFrmValueFlag(arg, args[i + 1], out, program)) {
+                return false;
+            }
             i += 2;
         } else if (arg.rfind("--", 0) == 0) {
             std::cerr << "error: unexpected argument: " << arg << "\n";

--- a/src/editor/Object.cpp
+++ b/src/editor/Object.cpp
@@ -7,7 +7,6 @@
 #include "util/Constants.h"
 #include "util/Coordinates.h"
 #include "util/Exceptions.h"
-#include "util/ExitGridDirection.h"
 #include <algorithm>
 #include <spdlog/spdlog.h>
 
@@ -123,22 +122,6 @@ void Object::setHexPosition(const Hex& hex) {
     if (_showLightOverlay && hasLight()) {
         updateLightOverlay();
     }
-}
-
-int Object::exitGridDirection() const {
-    // Placed markers carry a MapObject whose proto index (16..23) is the direction.
-    if (_mapObject != nullptr && _mapObject->isExitGridMarker()) {
-        return static_cast<int>(_mapObject->protoId()) - static_cast<int>(MapObject::EXIT_GRID_PID_INDEX_FIRST);
-    }
-    // Preview / bare-FRM objects (no MapObject) are identified by art name: exitgrd1..8 / ext2grd1..8.
-    const std::string& fn = _frm != nullptr ? _frm->filename() : std::string();
-    if (fn.size() >= 8 && (fn.rfind("exitgrd", 0) == 0 || fn.rfind("ext2grd", 0) == 0)) {
-        const int dir = fn[7] - '1';
-        if (dir >= 0 && dir < ExitGrid::DIR_COUNT) {
-            return dir;
-        }
-    }
-    return -1;
 }
 
 int16_t Object::shiftX() const {

--- a/src/editor/Object.h
+++ b/src/editor/Object.h
@@ -75,10 +75,6 @@ public:
     [[nodiscard]] int width() const;
     [[nodiscard]] int height() const;
 
-    /// The exit-grid direction (0..7) of this object, or -1 if it is not an exit-grid marker. Real
-    /// markers report it from their MapObject proto index; preview/bare-FRM objects from the art name.
-    [[nodiscard]] int exitGridDirection() const;
-
 private:
     static sf::Texture& createBlankTexture();
     void initializeLightOverlay();

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -19,6 +19,7 @@
 #include "scripting/ScriptApiReference.h"
 #include "format/pro/Pro.h"
 #include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
 #include "util/ProHelper.h"
 
 #include <nlohmann/json.hpp>
@@ -26,6 +27,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <filesystem>
 #include <format>
 #include <functional>
 #include <optional>
@@ -127,8 +129,10 @@ namespace {
 
     // --- tools -------------------------------------------------------------------
     json toolListMaps(resource::GameResources& resources) {
-        std::vector<std::string> paths;
+        json maps = json::array();
         try {
+            const resource::MapNameResolver names(resources); // maps.txt + map.msg, for friendly names
+            std::vector<std::string> paths;
             for (const auto& path : resources.files().list("*")) {
                 std::string ext = path.extension().string();
                 std::ranges::transform(ext, ext.begin(),
@@ -138,10 +142,17 @@ namespace {
                 }
             }
             std::ranges::sort(paths);
+            for (const auto& path : paths) {
+                const int index = names.indexOf(std::filesystem::path(path).filename().string());
+                const std::string display = index >= 0 ? names.displayName(index, 0) : std::string{};
+                maps.push_back({ { "file", path },
+                    { "displayName", display.empty() ? json(nullptr) : json(display) } });
+            }
         } catch (const std::exception&) {
             // no data mounted -> an empty list is a valid answer (mirrors api:listMaps())
+            maps = json::array();
         }
-        return toolText(json(paths).dump()); // json(vector<string>) -> a JSON array, "[]" when empty
+        return toolText(maps.dump()); // a JSON array of { file, displayName }, "[]" when empty
     }
 
     // Optional "maps" string array -> the maps list (empty = every map). Shared by analyze, palette
@@ -470,7 +481,9 @@ namespace {
     // builder is over-long and so a future pass can tag this group readOnlyHint=true en masse.
     void addReadOnlyTools(std::vector<ToolSpec>& t) {
         t.push_back({ "list_maps",
-            "List every .map file in the mounted Fallout 2 data.",
+            "List every .map file in the mounted Fallout 2 data, each as { file, displayName } where "
+            "'displayName' is the friendly map.msg name (elevation 0; null when the map isn't in "
+            "maps.txt or map.msg isn't mounted).",
             json({ { "type", "object" }, { "properties", json::object() } }),
             [](resource::GameResources& r, const json&) { return toolListMaps(r); } });
         t.push_back({ "analyze",
@@ -558,7 +571,9 @@ namespace {
         t.push_back({ "world_map",
             "The WORLDMAP layer from city.txt — the inter-city travel layer that map_graph does not "
             "cover. 'start': where a new game begins ({map, displayName, area} = artemple.map / Arroyo). "
-            "'areas': every location (city/town/encounter site) with its 'name', 'worldPos' {x,y} on the "
+            "'areas': every location (city/town/encounter site) with its 'name' (city.txt's internal "
+            "area_name), 'displayName' (the on-screen city label from map.msg[1500+index], null if "
+            "unnamed), 'worldPos' {x,y} on the "
             "world map, 'size', 'knownAtStart', 'terrain' (from worldmap.txt's tile grid, null if absent), "
             "and 'maps' (the maps it contains — each {map (the lookup_name), on, mapFile}). 'mapFile' is "
             "the .map filename, the JOIN KEY to map_graph: world_map.areas[].maps[].mapFile == "

--- a/src/rendering/MapSpriteLoader.cpp
+++ b/src/rendering/MapSpriteLoader.cpp
@@ -133,10 +133,10 @@ void MapSpriteLoader::loadObjectSprites(
             auto sceneObject = std::make_shared<Object>(frm);
             sf::Sprite objectSprite{ _resources.textures().get(frmName) };
             sceneObject->setSprite(std::move(objectSprite));
-            // setMapObject before setHexPosition: the latter consults isExitGridMarker() to push an
-            // exit-grid bar outward (the trigger hex sits at its inner edge), so the marker info must
-            // be set first. setDirection (which sets the frame rect) also runs before positioning so
-            // the outward nudge measures the correct on-screen bounds.
+            // Order matters: setMapObject first so setDirection/setHexPosition can sync the
+            // MapObject's direction and position fields back onto it. setDirection (which sets the
+            // frame rect) runs before setHexPosition because centering uses the current frame's
+            // width()/height()/shift to seat the sprite on the hex.
             sceneObject->setMapObject(object);
             sceneObject->setDirection(static_cast<ObjectDirection>(object->direction));
             if (auto hex = _hexgrid.getHexByPosition(object->position); hex.has_value()) {

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -508,8 +508,8 @@ std::shared_ptr<Object> RenderingEngine::buildExitGridPreviewObject(const Render
         }
 
         // Anchor exactly like a committed exit grid: setDirection sets the frame rect, then
-        // setHexPosition applies the FRM offset and pushes the bar outward. Order matters — setHexPosition
-        // measures the on-screen bounds, so the frame rect must be set first.
+        // setHexPosition centers the bar on the hex using that frame's FRM offset. Order matters —
+        // setHexPosition reads the current frame's width()/height()/shift, so the rect must be set first.
         auto previewObject = std::make_shared<Object>(frm);
         previewObject->setSprite(sf::Sprite{ _resources.textures().get(frmName) });
         previewObject->setDirection(ObjectDirection(0));

--- a/src/resource/MapNameResolver.cpp
+++ b/src/resource/MapNameResolver.cpp
@@ -48,6 +48,20 @@ std::string MapNameResolver::displayName(int mapIndex, int elevation) const {
     return {};
 }
 
+std::string MapNameResolver::areaName(int areaIndex) const {
+    if (areaIndex < 0) {
+        return {};
+    }
+    try {
+        if (Msg* msg = _resources.repository().load<Msg>("text/english/game/map.msg"); msg != nullptr) {
+            return msg->message(1500 + areaIndex).text;
+        }
+    } catch (const std::exception& e) {
+        spdlog::debug("MapNameResolver: map.msg unavailable: {}", e.what());
+    }
+    return {};
+}
+
 int MapNameResolver::indexOf(const std::string& mapFileName) const {
     const auto info = _doc.findByName(mapFileName); // findByName lowercases + normalizes internally
     return info.has_value() ? info->index : -1;

--- a/src/resource/MapNameResolver.h
+++ b/src/resource/MapNameResolver.h
@@ -36,6 +36,12 @@ public:
     /// The friendly map.msg name for `(mapIndex, elevation)`, or "" when unavailable.
     std::string displayName(int mapIndex, int elevation) const;
 
+    /// The friendly worldmap area/city name for a city.txt `[Area N]` index, via the engine's
+    /// `map.msg[1500 + areaIndex]` formula (fallout2-ce worldmap.cc `wmGetAreaIdxName`; the on-screen
+    /// city label, distinct from city.txt's internal `area_name`). "" when the index is negative or
+    /// map.msg isn't mounted.
+    std::string areaName(int areaIndex) const;
+
     /// The maps.txt index for a .map filename (basename, any case), or -1 if absent.
     int indexOf(const std::string& mapFileName) const;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(general_tests
     general/test_msg_roundtrip.cpp
     general/test_writable_data_root.cpp
     general/test_map_name_editor.cpp
+    general/test_map_name_resolver.cpp
     general/test_city_txt.cpp
     general/test_worldmap_txt.cpp
     general/test_quests_txt.cpp

--- a/tests/general/test_exit_grid_direction.cpp
+++ b/tests/general/test_exit_grid_direction.cpp
@@ -214,16 +214,17 @@ TEST_CASE("exitGridDirectionForLine picks one side for the whole stroke and the 
 }
 
 TEST_CASE("exitGridOutward: the per-direction outward (off-map) screen vector", "[exitgrid][outward]") {
-    // Screen y grows DOWNWARD. The editor slides the bar along this vector so the trigger hex sits at
-    // the bar's inner edge; a flip (dir ^ 1) reverses the sign and swings the byte-identical art to the
-    // OTHER side of the line. Each cardinal caps its named screen edge.
+    // Screen y grows DOWNWARD. This vector is the side a marker's art faces; secondRowNeighbor uses it
+    // to pick the diagonal band's second row (the neighbour leaning most along it). A flip (dir ^ 1)
+    // reverses the sign, mirroring that facing to the OTHER side of the line. Each cardinal caps its
+    // named screen edge.
     CHECK(exitGridOutward(ExitGrid::DIR_LEFT) == std::pair{ -1, 0 });
     CHECK(exitGridOutward(ExitGrid::DIR_RIGHT) == std::pair{ 1, 0 });
     CHECK(exitGridOutward(ExitGrid::DIR_BOTTOM) == std::pair{ 0, 1 });
     CHECK(exitGridOutward(ExitGrid::DIR_TOP) == std::pair{ 0, -1 });
     // The diagonals face PERPENDICULAR to their band's on-screen line (integer approximations of the
-    // measured ~-9° "/" and ~+26° "\" normals; applyExitGridOutwardOffset normalizes before scaling).
-    // The DIRECTION lives here and must flip sign across a dir ^ 1 pair so the band switches sides.
+    // measured ~-9° "/" and ~+26° "\" normals). The DIRECTION lives here and must flip sign across a
+    // dir ^ 1 pair so the band switches sides.
     CHECK(exitGridOutward(ExitGrid::DIR_FWD_A) == std::pair{ 1, 6 });   // "/" side A: down
     CHECK(exitGridOutward(ExitGrid::DIR_FWD_B) == std::pair{ -1, -6 }); // "/" side B: up (the ^1 flip)
     CHECK(exitGridOutward(ExitGrid::DIR_BACK_A) == std::pair{ -1, 2 }); // "\" side A: down-left

--- a/tests/general/test_map_name_resolver.cpp
+++ b/tests/general/test_map_name_resolver.cpp
@@ -1,0 +1,51 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "resource/GameResources.h"
+#include "resource/MapNameResolver.h"
+#include "util/FileIo.h"
+
+#include <filesystem>
+
+#ifndef GECK_TEST_TMP_DIR
+#error "GECK_TEST_TMP_DIR must be defined for this test target (see tests/CMakeLists.txt)"
+#endif
+
+using namespace geck;
+namespace fs = std::filesystem;
+using geck::io::writeFile;
+
+// MapNameResolver is the single home for the engine's map.msg index formulas. These mirror
+// fallout2-ce: per-map names at map.msg[index*3 + elevation + 200] (map.cc mapGetName) and worldmap
+// area/city labels at map.msg[1500 + areaIndex] (worldmap.cc wmGetAreaIdxName). Built on a tiny
+// mounted maps.txt + map.msg fixture so the index math is exercised, not just the no-data fallback.
+TEST_CASE("MapNameResolver resolves map and area names from map.msg", "[mapnameresolver]") {
+    const fs::path base = fs::path{ GECK_TEST_TMP_DIR } / "mapnameresolver";
+    fs::remove_all(base);
+    writeFile(base / "data" / "maps.txt",
+        "[Map 0]\nlookup_name=Arroyo Bridge\nmap_name=artemple\n"
+        "[Map 1]\nlookup_name=Arroyo Village\nmap_name=arvillage");
+    // map.msg: per-map names at index*3+elev+200; area/city labels at 1500+areaIndex.
+    writeFile(base / "text" / "english" / "game" / "map.msg",
+        "{200}{}{Temple of Trials}\n{201}{}{Temple Level 1}\n{203}{}{Arroyo Village}\n"
+        "{1500}{}{Arroyo}\n{1501}{}{Klamath}");
+
+    resource::GameResources resources;
+    resources.files().addDataPath(base.string());
+    const resource::MapNameResolver names(resources);
+
+    SECTION("displayName uses map.msg[index*3 + elevation + 200]") {
+        CHECK(names.displayName(0, 0) == "Temple of Trials");
+        CHECK(names.displayName(0, 1) == "Temple Level 1");
+        CHECK(names.displayName(1, 0) == "Arroyo Village");
+    }
+    SECTION("areaName uses map.msg[1500 + areaIndex]") {
+        CHECK(names.areaName(0) == "Arroyo");
+        CHECK(names.areaName(1) == "Klamath");
+    }
+    SECTION("negative or unmapped indices resolve to empty, never throw") {
+        CHECK(names.areaName(-1).empty());
+        CHECK(names.displayName(-1, 0).empty());
+        CHECK(names.areaName(99).empty()); // no {1599} entry in the fixture
+    }
+    fs::remove_all(base);
+}


### PR DESCRIPTION
This branch bundles two commits against `master` (the area-fill and exit-grid work it was based on is already merged):

## `map.msg` display names in the MCP/CLI map tools
Surfaces the engine's friendly map and area names through the headless tools:
- `MapNameResolver::areaName()` resolves worldmap city labels via `map.msg[1500 + areaIndex]`, matching the engine's `wmGetAreaIdxName` (fallout2-ce `worldmap.cc`).
- `world_map` areas now carry a `displayName` (the on-screen city label, distinct from city.txt's internal `area_name`).
- `list_maps` now returns `{ file, displayName }` instead of bare filename strings (the no-data `"[]"` result is preserved).
- Updated the `list_maps` / `world_map` tool descriptions; added a `MapNameResolver` unit test covering both `map.msg` index formulas.

> Note: `worldmap.msg` was deliberately **not** added — the engine check showed area/city labels actually live in `map.msg` (now done) and terrain names are already in `worldmap.txt`; the only data genuinely in `worldmap.msg` is encounter descriptions at `map.msg[3000 + 50*table + entry]`, which is runtime-index-tied and not a small change. The PLAN follow-up was narrowed accordingly.

## Backlog cleanup (PLAN.md / TODO.md)
Pruned items verified complete against the code: the unified exit-grid tool + polygonal drawing, the rectangle-only exit-grid limitation (#2), the PRO-dialog animation frame-offset fix (#10), map metadata editing, and the exit-grid rendering reference section. Renumbered the known-limitations list (13 → 11) and fixed every cross-reference; removed the matching Map info panel items from TODO.md.

## CLI parse guards (commit `0ba0d75`)
Guards numeric CLI flag parsing, fixes stale exit-grid comments, and drops a dead API.

## Testing
`ctest`/`general_tests` full suite green (335 cases); the new `MapNameResolver` and existing `mcp` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)