### PR TITLE
Fix object selection and make AI packets & scripts readable

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -38,24 +38,20 @@ live with their library (`src/resource/`, `src/ui/`).
    (`MapInfoPanel` checkboxes) is still a direct mutation; a cascading script-delete when an
    object is deleted; and the command-controller actions themselves aren't integration-tested
    (they need GameResources/Qt — a `qt_tests` follow-up).
-2. **AI packet / script program are raw values** (engine packet numbers / scripts.lst names),
-   not friendly labels — no invented label tables, per the engine-fidelity rule. Real labels
-   need `data/ai.txt` parsing (AI) or the scripts.lst trailing comment (script "description" —
-   see the SSL-editing section; the `.int` has no description, Q below).
-3. **Newly created scripts get `local_var_count=0` / `offset=-1`** — exactly what the engine's
+2. **Newly created scripts get `local_var_count=0` / `offset=-1`** — exactly what the engine's
    `scriptAdd` writes; locals are allocated at runtime from the `.int`. The editor does not
    parse `.int` headers, and the local-var *count* lives in `scripts.lst`, not the binary.
-4. **F11 spatial placement is dialog-driven** (enter tile/elevation/radius), not click-to-place
+3. **F11 spatial placement is dialog-driven** (enter tile/elevation/radius), not click-to-place
    with a live hex marker, radius overlay, and a new `EditorMode`. Existing spatial scripts also
    aren't visualized on the map or editable/deletable through the UI yet.
-5. **F16 per-instance kill-type and custom name are out of scope** — not exposed in the engine
+4. **F16 per-instance kill-type and custom name are out of scope** — not exposed in the engine
    mapper and would require new serialized `MapObject` fields.
-6. **Script attach reassigns the object OID** (`unknown0`) to a fresh unique id (matching the
+5. **Script attach reassigns the object OID** (`unknown0`) to a fresh unique id (matching the
    engine's `objectSetScript`); existing cross-references to the old OID aren't audited/rewritten.
-7. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
-8. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
+6. **Inventory "Add" uses a numeric proto index**, not a browsable item picker.
+7. **Edit visuals are sprite-rebuild only** — no engine-style `_obj_toggle_flat` outline
    recompute, multi-hex occupancy overlay, or live light-radius overlay beyond the rebuild.
-9. **Keybindings are hardcoded — no user remapping.** Shortcuts are scattered and fixed: the
+8. **Keybindings are hardcoded — no user remapping.** Shortcuts are scattered and fixed: the
     menu/toolbar `QKeySequence`s in `MainWindow::setupMenuBar()`/`setupToolBar()` (New/Open/Save,
     Select All `Ctrl+A`, scroll-blocker `B`, exit grids `Ctrl+E`, undo/redo, …), the editor-mode
     keys in `InputHandler::handleKeyPressed` (`R` cycles a stamp variant, `Esc` cancels, `Delete`/
@@ -66,13 +62,13 @@ live with their library (`src/resource/`, `src/ui/`).
     the menu/toolbar `QAction`s *and* the `InputHandler` dispatch from that table instead of
     literals, so a rebind takes effect everywhere and the bindings stay discoverable. Engine-fidelity
     note: this is editor UX only — it changes no map/format data.
-10. **Toolbar is a fixed button set — not user-customizable.** The primary toolbar (New, Browse Maps,
+9. **Toolbar is a fixed button set — not user-customizable.** The primary toolbar (New, Browse Maps,
     Save, Play) is a hardcoded `primaryToolbarActions` array in `MainWindow::setupToolBar()`. Most
     editors let users choose which buttons appear and reorder them. **Add a customizable toolbar:**
-    drive it from the same command/action table proposed in #9 (stable action id → icon/label/handler),
+    drive it from the same command/action table proposed in #8 (stable action id → icon/label/handler),
     with a context-menu / Preferences UI to add, remove, and reorder buttons, persisted via `Settings`.
     Editor UX only; no map/format change.
-11. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
+10. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
     into the *last folder* in Data Paths — `findWritableDataPath` walks the list from the end and takes
     the first real directory (archives skipped). That's implicit and order-dependent: reordering Data
     Paths silently changes where saves land, and nothing in the UI shows which location is the writable
@@ -706,7 +702,7 @@ The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thum
 
 > Status: investigation. Spatial scripts can be created (`SpatialScriptDialog` → F-key flow)
 > but are **invisible on the map** once placed — there's no marker, no radius overlay, and no
-> way to see, select, edit, or delete an existing one (see Known limitations #4). Goal: render
+> way to see, select, edit, or delete an existing one (see Known limitations #3). Goal: render
 > existing spatial scripts on the canvas so designers can see where their trigger zones are.
 
 ## What the data model gives us
@@ -733,7 +729,7 @@ object list. Placement currently flows MapInfoPanel → `EditorWidget::addSpatia
   culled via the viewport like the other overlays.
 - **Interaction (stretch):** hit-test a marker to select → open `SpatialScriptDialog` to
   edit/delete; ties into the F-key click-to-place + new `EditorMode` already sketched in
-  Known limitations #4 (live hex marker + radius preview while placing).
+  Known limitations #3 (live hex marker + radius preview while placing).
 
 ## Rough effort
 S–M for read-only visualization (marker + radius overlay + visibility toggle), reusing the
@@ -773,29 +769,6 @@ partly covered — see the exit-grid limitation above).
 ## Rough effort
 S to produce the catalogue (read-only audit of two known codebases); the individual features
 it surfaces are then sized and sequenced separately.
-
----
-
-# Clean and verify TODO.md (housekeeping)
-
-> Status: to do. `TODO.md` has drifted and needs the same "track what's left, not what's done"
-> pass this plan just had.
-
-## What needs doing
-- **Remove completed items.** Several Code Quality / Architecture entries are done now that the
-  architecture roadmap landed — e.g. splitting the resource singleton (`Settings` is injected;
-  resource access is the `GameResources`/`DataFileSystem` facade), the MAP read/write refactor
-  + round-trip coverage, and the `ProEditorDialog` decomposition. Verify each against the
-  current code and delete the ones that shipped.
-- **De-duplicate.** "placing lights - light.frm" is listed twice; collapse duplicates.
-- **Verify the rest still applies** — some bugs/usability items may already be fixed (e.g. the
-  scroll-blocker isometric-rectangle bug is also tracked here in the exit-grid section).
-- **Reconcile with this plan.** Fold the "Legacy F2_Mapper_Dims Missing Features" section into
-  the feature-gap audit above so there is one backlog, not two.
-
-## Rough effort
-S. Pure housekeeping — read TODO.md against current code, delete done/dupe items, cross-link
-the rest.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,9 +14,6 @@ Extend existing multi-selection system with batch property editing for multiple 
 ### Script Integration
 Script assignment UI for object properties with dropdown, validation, and preview capabilities.
 
-### Template System
-Preset object configurations for complex placement patterns (furniture sets, defensive positions, etc.). Save and load object placement patterns.
-
 ### Advanced Search & Filter
 Property-based filtering and complex query support for finding specific objects across the entire map.
 
@@ -30,10 +27,6 @@ Detailed progress dialog with task descriptions and completion estimates for lon
 ### Usability
 
 - [ ] Ctrl+C - copy object, Ctrl+V paste object
-- [ ] Proto view
-- [ ] Ctrl-toggle deselection: Ctrl+clicking an already-selected item, or Ctrl+dragging an
-      area that covers already-selected items, should *remove* those items from the selection
-      (toggle them off) instead of re-adding them. Today Ctrl only adds to the selection.
 
 ### Hex palette
 
@@ -55,26 +48,17 @@ Detailed progress dialog with task descriptions and completion estimates for lon
 
 ### Presets
 - [ ] TBD: paint a pattern of tiles
-- [ ] TBD: paste a preset into the map, e.g. hut from Arroyo. Presets should be stored in a JSON/YAML/...
-
-### Performance
-- [ ] Optimize hex grid rendering to only draw visible hexes
 
 ### Code Quality / Architecture
-- [ ] Split `ResourceManager` into narrower engine-facing services instead of a global singleton handling VFS, FRM decoding, message lookup, and texture caching
 - [ ] Break up `EditorWidget` into smaller controllers/services for editing, input/tool orchestration, and rendering coordination
 - [ ] Move application/workspace lifecycle out of `MainWindow` and into dedicated controllers or services
 - [ ] Refactor map reading and writing into smaller section-level parsers/serializers and add round-trip coverage
-- [ ] Finish the `ProEditorDialog` decomposition so type-specific behavior, previews, and persistence are not coordinated from one oversized dialog
 - [ ] Replace placeholder inventory mutations with a shared model-backed inventory editing service used by all inventory UIs
 - [ ] Remove remaining `const_cast` usage by fixing const-correctness and ownership boundaries
-- [ ] Fix tile hit testing so object/tile selection is accurate near tile/object boundaries
 
 ### Known bugs
 
 - [ ] placing lights - light.frm
-- [ ] clicking on an object is not pixel perfect and sometimes a tile underneath or an object close by is selected instead
 - [ ] scroll block drawing mode draws the rectangle in the isometric projection (diagonal) instead of screen projection
-- [ ] placing lights - light.frm
 - [ ] file browser panel has issues with resizing. It is sometimes impossible to change its size or requires several clicks
 - [ ] make sure changing elevations works with the recent changes (probably not)

--- a/src/resource/ScriptNames.h
+++ b/src/resource/ScriptNames.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "format/lst/Lst.h"
 #include "format/msg/Msg.h"
 #include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
 
+#include <cstddef>
 #include <exception>
 #include <string>
 
@@ -27,6 +30,31 @@ inline std::string scriptDisplayName(GameResources& resources, int programIndex)
         }
     } catch (const std::exception&) {
         // scrname.msg not mounted -> no friendly name; callers use the .lst name.
+    }
+    return {};
+}
+
+/// The best human-readable label for the script at 0-based `programIndex`: the scrname.msg display name
+/// if present, otherwise the scripts.lst trailing comment (the developer description the engine data
+/// ships), otherwise "". scrname.msg only names talking/critter scripts, so this gives spatial-trigger
+/// and generic-scenery scripts a friendly label too, instead of the bare `.int` filename. Both sources
+/// are real engine data — no invented labels, per the engine-fidelity rule.
+inline std::string scriptDescription(GameResources& resources, int programIndex) {
+    if (std::string name = scriptDisplayName(resources, programIndex); !name.empty()) {
+        return name;
+    }
+    if (programIndex < 0) {
+        return {};
+    }
+    try {
+        if (const Lst* lst = resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS); lst != nullptr) {
+            const auto& comments = lst->comments();
+            if (static_cast<std::size_t>(programIndex) < comments.size()) {
+                return comments[static_cast<std::size_t>(programIndex)];
+            }
+        }
+    } catch (const std::exception&) {
+        // scripts.lst not mounted -> no comment; callers fall back to the .lst filename.
     }
     return {};
 }

--- a/src/selection/SelectionManager.cpp
+++ b/src/selection/SelectionManager.cpp
@@ -202,8 +202,9 @@ SelectionResult SelectionManager::addToSelection(sf::Vector2f worldPos, Selectio
 
         case SelectionMode::ALL:
             // ALL mode adds the first available item in priority order (roof, object, floor)
-            // without cycling, restricted to the user-enabled layers.
-            if (_layers.roofTiles) {
+            // without cycling, restricted to the user-enabled layers. A hidden roof is skipped so
+            // it can't shadow the object beneath it (consistent with cycleThroughItemsAtPosition).
+            if (_layers.roofTiles && _provider.isRoofVisible()) {
                 auto tileIndex = getRoofTileAtPosition(worldPos, currentElevation);
                 if (tileIndex) {
                     SelectedItem item{ SelectionType::ROOF_TILE, tileIndex.value() };
@@ -699,7 +700,13 @@ SelectionResult SelectionManager::cycleThroughItemsAtPosition(sf::Vector2f world
     // and only walks the user-enabled layers.
     auto objectsAtPos = _layers.objects ? getObjectsAtPosition(worldPos, elevation)
                                         : std::vector<std::shared_ptr<Object>>{};
-    auto roofTileIndex = _layers.roofTiles ? getRoofTileAtPosition(worldPos, elevation) : std::nullopt;
+    // A roof you cannot see must never shadow a click on the object (or floor) beneath it. Point
+    // selection used to gate the roof only on the layer flag, so hiding the roof to edit interior
+    // objects still selected the hidden roof tile under the cursor. This mirrors the area-select
+    // path (collectItemsInArea) and itemsToDeselectInArea, which already check isRoofVisible().
+    auto roofTileIndex = (_layers.roofTiles && _provider.isRoofVisible())
+        ? getRoofTileAtPosition(worldPos, elevation)
+        : std::nullopt;
     auto floorTileIndex = _layers.floorTiles ? getFloorTileAtPosition(worldPos, elevation) : std::nullopt;
 
     bool roofSelected = false;

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -546,9 +546,9 @@ void MapInfoPanel::loadScriptVars() {
             const auto& scriptList = scripts->list();
             if (map_script_id <= static_cast<int>(scriptList.size()) && map_script_id >= 1) {
                 _mapScriptName = scripts->at(map_script_id - 1); // script id starts at 1
-                // Append the scrname.msg description for the same script (its 0-based index is id - 1),
-                // mirroring how object scripts are named in the script picker.
-                const std::string desc = resource::scriptDisplayName(_resources, map_script_id - 1);
+                // Append the friendly description for the same script (its 0-based index is id - 1):
+                // the scrname.msg name, or the scripts.lst comment when scrname.msg doesn't name it.
+                const std::string desc = resource::scriptDescription(_resources, map_script_id - 1);
                 if (!desc.empty()) {
                     _mapScriptName += " — " + desc;
                 }

--- a/src/ui/panels/ScriptsPanel.cpp
+++ b/src/ui/panels/ScriptsPanel.cpp
@@ -161,7 +161,7 @@ void ScriptsPanel::addRow(const QString& section, int programIndex, qulonglong r
     }
     _table->setItem(row, COL_FILENAME, new QTableWidgetItem(filename));
     _table->setItem(row, COL_NAME,
-        new QTableWidgetItem(QString::fromStdString(resource::scriptDisplayName(_resources, programIndex))));
+        new QTableWidgetItem(QString::fromStdString(resource::scriptDescription(_resources, programIndex))));
 
     // Owned rows carry a numeric DisplayRole so the Owner column sorts numerically; NONE/0 shows "—".
     auto* ownerItem = new QTableWidgetItem;

--- a/src/ui/panels/SelectionPanel.cpp
+++ b/src/ui/panels/SelectionPanel.cpp
@@ -1215,7 +1215,7 @@ void SelectionPanel::updateScriptSection() {
                     auto* lst = _resources.repository().load<Lst>(ResourcePaths::Lst::SCRIPTS);
                     if (lst && s.script_id < lst->list().size()) {
                         text = QString::fromStdString(lst->list().at(s.script_id));
-                        const std::string desc = resource::scriptDisplayName(_resources, static_cast<int>(s.script_id));
+                        const std::string desc = resource::scriptDescription(_resources, static_cast<int>(s.script_id));
                         if (!desc.empty()) {
                             text += " — " + QString::fromStdString(desc);
                         }

--- a/src/ui/widgets/pro/ProCritterWidget.cpp
+++ b/src/ui/widgets/pro/ProCritterWidget.cpp
@@ -1,5 +1,6 @@
 #include "ProCritterWidget.h"
 
+#include "resource/AiTxtLoader.h"
 #include "resource/GameResources.h"
 #include "ui/theme/ThemeManager.h"
 #include "ui/UIConstants.h"
@@ -37,6 +38,7 @@ ProCritterWidget::ProCritterWidget(resource::GameResources& resources, QWidget* 
     , _headFidSelectorButton(nullptr)
     , _headFid(0)
     , _aiPacketEdit(nullptr)
+    , _aiPacketNameLabel(nullptr)
     , _teamNumberEdit(nullptr)
     , _barterCheck(nullptr)
     , _noStealCheck(nullptr)
@@ -76,6 +78,9 @@ ProCritterWidget::ProCritterWidget(resource::GameResources& resources, QWidget* 
     for (auto& widget : _damageResistEdits) {
         widget = nullptr;
     }
+
+    // Load ai.txt once so the AI Packet field can show the packet name; empty if no data mounted.
+    _aiTxt = resource::loadAiTxt(_resources);
 
     setupUI();
 }
@@ -295,7 +300,19 @@ void ProCritterWidget::setupGeneralTab(QTabWidget* parentTabs) {
     critterLayout->addRow("Head FID:", headFidWidget);
 
     _aiPacketEdit = this->createSpinBox(0, INT_MAX, "AI packet number for critter behavior");
-    critterLayout->addRow("AI Packet:", _aiPacketEdit);
+    // Show the ai.txt packet name next to the raw number so the field is readable without a lookup.
+    _aiPacketNameLabel = new QLabel(this);
+    _aiPacketNameLabel->setStyleSheet(ui::theme::styles::smallLabel());
+    _aiPacketNameLabel->setToolTip("AI behaviour packet name from the game's ai.txt");
+    auto* aiPacketRow = new QWidget(this);
+    auto* aiPacketRowLayout = new QHBoxLayout(aiPacketRow);
+    aiPacketRowLayout->setContentsMargins(0, 0, 0, 0);
+    aiPacketRowLayout->addWidget(_aiPacketEdit);
+    aiPacketRowLayout->addWidget(_aiPacketNameLabel, 1);
+    critterLayout->addRow("AI Packet:", aiPacketRow);
+    connect(_aiPacketEdit, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [this](int) { updateAiPacketNameLabel(); });
+    updateAiPacketNameLabel();
 
     _teamNumberEdit = this->createSpinBox(0, INT_MAX, "Team number for faction identification");
     critterLayout->addRow("Team Number:", _teamNumberEdit);
@@ -377,6 +394,7 @@ void ProCritterWidget::loadFromPro(const std::shared_ptr<Pro>& pro) {
     updateHeadFidLabel();
 
     _aiPacketEdit->setValue(static_cast<int>(critterData.aiPacket));
+    updateAiPacketNameLabel();
     _teamNumberEdit->setValue(static_cast<int>(critterData.teamNumber));
     _barterCheck->setChecked(Pro::hasFlag(critterData.flags, Pro::CritterFlags::CRITTER_BARTER));
     _noStealCheck->setChecked(Pro::hasFlag(critterData.flags, Pro::CritterFlags::CRITTER_NO_STEAL));
@@ -453,6 +471,21 @@ bool ProCritterWidget::canHandle(const std::shared_ptr<Pro>& pro) const {
 
 QString ProCritterWidget::getTabLabel() const {
     return "Critter";
+}
+
+void ProCritterWidget::updateAiPacketNameLabel() {
+    if (_aiPacketNameLabel == nullptr) {
+        return;
+    }
+    const int packetNum = _aiPacketEdit->value();
+    if (const AiPacket* packet = _aiTxt.byPacketNum(packetNum)) {
+        _aiPacketNameLabel->setText(QString::fromStdString(packet->name));
+    } else if (_aiTxt.size() == 0) {
+        // No ai.txt mounted: nothing to resolve against, so let the raw number speak for itself.
+        _aiPacketNameLabel->clear();
+    } else {
+        _aiPacketNameLabel->setText(QStringLiteral("(not in ai.txt)"));
+    }
 }
 
 void ProCritterWidget::updateHeadFidLabel() {

--- a/src/ui/widgets/pro/ProCritterWidget.h
+++ b/src/ui/widgets/pro/ProCritterWidget.h
@@ -2,6 +2,8 @@
 
 #include "ProTabWidget.h"
 
+#include "format/ai/AiPacket.h"
+
 class QTabWidget;
 class QPushButton;
 
@@ -25,7 +27,13 @@ private:
     void setupDefenceTab(QTabWidget* parentTabs);
     void setupGeneralTab(QTabWidget* parentTabs);
     void updateHeadFidLabel();
+    // Resolve the AI Packet spin box value to its ai.txt name and show it beside the number.
+    void updateAiPacketNameLabel();
     uint32_t currentCritterFlags() const;
+
+    // data/ai.txt packet -> name table, loaded once so the AI Packet field reads as a name
+    // (engine-fidelity: the spin box still stores the raw packet number). Empty if unmounted.
+    AiTxt _aiTxt;
 
     static constexpr Frm::FRM_TYPE HeadFrmObjectType = Frm::FRM_TYPE::CRITTER;
 
@@ -39,6 +47,7 @@ private:
     int32_t _headFid;
 
     QSpinBox* _aiPacketEdit;
+    QLabel* _aiPacketNameLabel;
     QSpinBox* _teamNumberEdit;
     QCheckBox* _barterCheck;
     QCheckBox* _noStealCheck;

--- a/tests/general/test_script_names.cpp
+++ b/tests/general/test_script_names.cpp
@@ -43,3 +43,31 @@ TEST_CASE("scriptDisplayName is empty when scrname.msg isn't mounted", "[scriptn
     resource::GameResources resources; // nothing mounted
     CHECK(resource::scriptDisplayName(resources, 0).empty());
 }
+
+// scriptDescription is the label the editor shows for a script program: prefer the scrname.msg name,
+// then fall back to the scripts.lst trailing comment (which names spatial/generic scripts scrname.msg
+// leaves blank), then "" so callers show the bare .int filename.
+TEST_CASE("scriptDescription falls back to the scripts.lst comment when scrname.msg is blank", "[scriptnames]") {
+    const fs::path root = fs::path(GECK_TEST_TMP_DIR) / "scriptdesc_test";
+    fs::remove_all(root);
+
+    // scrname.msg names only index 0 (id 101).
+    writeFile(root / "text/english/game/scrname.msg", "{101}{}{Combat AI}\n");
+    // scripts.lst: index 0 has a comment (ignored, scrname wins), index 1 has only a comment, index 2
+    // has neither. The "# local_vars=N" metadata must be stripped from the comment.
+    writeFile(root / "scripts/scripts.lst",
+        "combatai.int    ; unused because scrname wins   # local_vars=0\n"
+        "zispatch.int    ; Spatial trigger for the bridge # local_vars=2\n"
+        "generic.int\n");
+
+    resource::GameResources resources;
+    resources.files().addDataPath(root.string());
+
+    CHECK(resource::scriptDescription(resources, 0) == "Combat AI");                      // scrname.msg wins
+    CHECK(resource::scriptDescription(resources, 1) == "Spatial trigger for the bridge"); // .lst comment
+    CHECK(resource::scriptDescription(resources, 2).empty());                             // neither -> ""
+    CHECK(resource::scriptDescription(resources, 99).empty());                            // past the list
+    CHECK(resource::scriptDescription(resources, -1).empty());                            // negative index
+
+    fs::remove_all(root);
+}

--- a/tests/general/test_selection_manager.cpp
+++ b/tests/general/test_selection_manager.cpp
@@ -450,6 +450,32 @@ TEST_CASE("ALL-mode click cycles the stack then deselects", "[selection_manager_
     REQUIRE_FALSE(mgr.hasSelection());
 }
 
+// Regression: a roof you have hidden must not shadow a click on what is beneath it. Point selection
+// used to gate the roof candidate only on the layer flag (not isRoofVisible), so hiding the roof to
+// edit interior objects still selected the invisible roof tile under the cursor instead of the
+// object/floor below. The floor stands in for "the layer beneath the roof": objects rank above the
+// floor in the same cycle, so skipping the hidden roof lets an object beneath it win the click too.
+TEST_CASE("A hidden roof does not shadow a click on what is beneath it", "[selection_manager_real][regression]") {
+    MockEditorWidget mockWidget;
+    geck::selection::SelectionManager mgr(mockWidget);
+
+    const sf::Vector2f clickPos{ 32.0f, 24.0f };
+    const int tileIndex = 1 * MAP_WIDTH + 1;
+
+    SECTION("roof shown: the click selects the roof drawn on top") {
+        mockWidget.roofVisible = true;
+        mgr.selectAtPosition(clickPos, SelectionMode::ALL, 0);
+        CHECK(mgr.getCurrentSelection().getRoofTileIndices() == std::vector<int>{ tileIndex });
+    }
+
+    SECTION("roof hidden: the click falls through to the layer beneath, not the invisible roof") {
+        mockWidget.roofVisible = false;
+        mgr.selectAtPosition(clickPos, SelectionMode::ALL, 0);
+        CHECK(mgr.getCurrentSelection().getRoofTileIndices().empty());
+        CHECK(mgr.getCurrentSelection().getFloorTileIndices() == std::vector<int>{ tileIndex });
+    }
+}
+
 // Ctrl+drag is deselect-only: it removes already-selected covered items but never adds.
 // Uses HEXES mode (the hex grid is pure geometry — no graphics context needed).
 TEST_CASE("deselectArea removes only selected covered items (Ctrl+drag)", "[selection_manager_real][regression]") {


### PR DESCRIPTION
Follow-up work after PR #95 (squash-merged), on a fresh branch off `master`.

## Object selection
Point selection gated the roof candidate only on the roof-layer flag, not on whether the roof is actually **visible** — so hiding the roof to edit interior objects still selected the invisible roof tile under the cursor instead of the object beneath it. Area selection already checked `isRoofVisible()`; the two point paths did not. Now they do, matching the engine mapper (which blocks object picking only while the cursor is over a *visible* roof). Regression test added.

## Readable AI packet
The `.pro` critter editor showed the AI packet as a bare number (the per-instance dialog already resolved it). `ProCritterWidget` now loads `data/ai.txt` (`resource::loadAiTxt`) and shows the packet **name** in a live label beside the number; the spin box still stores the exact packet number (engine-fidelity).

## Readable script labels
Scripts were labeled by their bare `.int` filename whenever `scrname.msg` didn't name them (common for spatial triggers / generic scenery). New `resource::scriptDescription` prefers the scrname.msg name, then falls back to the **scripts.lst trailing comment** (the description shipped in the game data). Wired into the Map Info panel, Selection panel, and Scripts panel. Test added for the fallback.

## Backlog
Pruned the resolved items from `TODO.md` / `PLAN.md` and renumbered the Known-limitations list.

**Verification:** 354/354 tests pass; the identical content already went green on Linux/Windows/macOS (Debug+Release) via a dispatched CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)