### PR TITLE
Add New Map / Browse Maps buttons to the welcome screen

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -692,7 +692,6 @@ the same selection; Ctrl-drag to remove). This is the natural companion to #1 �
 The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thumbnail grid + filter
 + preview, lazy render, in-memory cache). Possible follow-ups:
 - **Source grouping** — separate vanilla `master.dat` maps from user/filesystem maps.
-- **Welcome-screen entry point** — reach the browser from the no-map welcome screen.
 - **Persisted cross-session thumbnail cache** (keyed by map path + mtime) — only if cold-start
   render latency proves annoying; the current cache is in-memory `QPixmapCache`.
 

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -184,8 +184,10 @@ void MainWindow::setupUI() {
     _centralStack = new QStackedWidget(this);
     setCentralWidget(_centralStack);
 
-    // Welcome widget is shown when no map is loaded
+    // Welcome widget is shown when no map is loaded; its buttons reuse the File-menu handlers.
     _welcomeWidget = new WelcomeWidget(this);
+    connect(_welcomeWidget, &WelcomeWidget::newMapRequested, this, &MainWindow::newMapRequested);
+    connect(_welcomeWidget, &WelcomeWidget::browseMapsRequested, this, &MainWindow::showMapBrowserDialog);
     _centralStack->addWidget(_welcomeWidget);
     _centralStack->setCurrentWidget(_welcomeWidget);
 

--- a/src/ui/widgets/WelcomeWidget.cpp
+++ b/src/ui/widgets/WelcomeWidget.cpp
@@ -1,8 +1,10 @@
 #include "WelcomeWidget.h"
 
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QPixmap>
+#include <QPushButton>
 #include <QSvgRenderer>
 #include <QPainter>
 #include <QCoreApplication>
@@ -21,7 +23,9 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
     : QWidget(parent)
     , _layout(nullptr)
     , _imageLabel(nullptr)
-    , _versionLabel(nullptr) {
+    , _versionLabel(nullptr)
+    , _newMapButton(nullptr)
+    , _browseButton(nullptr) {
     setupUI();
 }
 
@@ -49,7 +53,32 @@ void WelcomeWidget::setupUI() {
     if (_versionLabel) {
         _layout->addWidget(_versionLabel, 0, Qt::AlignCenter);
     }
+    createActionButtons();
     _layout->addStretch();
+}
+
+void WelcomeWidget::createActionButtons() {
+    // Give the no-map screen a way to act: create a map or open the browser, mirroring the
+    // File menu's New Map / Browse Maps actions. MainWindow connects these signals to those handlers.
+    _newMapButton = new QPushButton(createIcon(":/icons/actions/new.svg"), "New Map", this);
+    _browseButton = new QPushButton(createIcon(":/icons/actions/open.svg"), "Browse Maps…", this);
+    for (QPushButton* button : { _newMapButton, _browseButton }) {
+        button->setCursor(Qt::PointingHandCursor);
+        button->setMinimumWidth(150);
+    }
+
+    connect(_newMapButton, &QPushButton::clicked, this, &WelcomeWidget::newMapRequested);
+    connect(_browseButton, &QPushButton::clicked, this, &WelcomeWidget::browseMapsRequested);
+
+    auto* buttonRow = new QHBoxLayout();
+    buttonRow->addStretch();
+    buttonRow->addWidget(_newMapButton);
+    buttonRow->addSpacing(ui::theme::spacing::NORMAL);
+    buttonRow->addWidget(_browseButton);
+    buttonRow->addStretch();
+
+    _layout->addSpacing(ui::theme::spacing::LOOSE);
+    _layout->addLayout(buttonRow);
 }
 
 void WelcomeWidget::renderSvgToLabel(QSvgRenderer& svgRenderer) {

--- a/src/ui/widgets/WelcomeWidget.h
+++ b/src/ui/widgets/WelcomeWidget.h
@@ -5,6 +5,7 @@
 #include <QVBoxLayout>
 
 class QSvgRenderer;
+class QPushButton;
 
 namespace geck {
 
@@ -21,14 +22,23 @@ public:
     explicit WelcomeWidget(QWidget* parent = nullptr);
     ~WelcomeWidget() = default;
 
+signals:
+    /// The user asked to create a new map from the welcome screen.
+    void newMapRequested();
+    /// The user asked to open the map browser from the welcome screen.
+    void browseMapsRequested();
+
 private:
     void setupUI();
     void renderSvgToLabel(QSvgRenderer& svgRenderer);
     void createVersionLabel();
+    void createActionButtons();
 
     QVBoxLayout* _layout;
     QLabel* _imageLabel;
     QLabel* _versionLabel;
+    QPushButton* _newMapButton;
+    QPushButton* _browseButton;
 };
 
 } // namespace geck

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -40,6 +40,7 @@
 #include "ui/widgets/ObjectPreviewWidget.h"
 #include "ui/widgets/ProInfoPanelWidget.h"
 #include "ui/widgets/ProPreviewPanelWidget.h"
+#include "ui/widgets/WelcomeWidget.h"
 #include "ui/widgets/pro/ProAmmoWidget.h"
 #include "ui/widgets/pro/ProCritterWidget.h"
 #include "ui/widgets/pro/ProDrugWidget.h"
@@ -1510,4 +1511,35 @@ TEST_CASE("Exit-grid stroke creates on the non-overlapping hexes (partial overla
 
     // Empty line -> empty.
     CHECK(ExitGridPlacementManager::freshHexesForLine({}, { 1 }).empty());
+}
+
+// The no-map welcome screen offers New Map / Browse Maps buttons; each must emit the matching
+// request signal (MainWindow wires these to the File-menu handlers) so the screen is actionable.
+TEST_CASE("Welcome screen buttons request New Map and Browse Maps", "[qt][welcome]") {
+    geck::WelcomeWidget welcome;
+
+    QSignalSpy newSpy(&welcome, &geck::WelcomeWidget::newMapRequested);
+    QSignalSpy browseSpy(&welcome, &geck::WelcomeWidget::browseMapsRequested);
+    REQUIRE(newSpy.isValid());
+    REQUIRE(browseSpy.isValid());
+
+    QPushButton* newMapButton = nullptr;
+    QPushButton* browseButton = nullptr;
+    for (QPushButton* button : welcome.findChildren<QPushButton*>()) {
+        if (button->text().contains("New")) {
+            newMapButton = button;
+        } else if (button->text().contains("Browse")) {
+            browseButton = button;
+        }
+    }
+    REQUIRE(newMapButton != nullptr);
+    REQUIRE(browseButton != nullptr);
+
+    newMapButton->click();
+    CHECK(newSpy.count() == 1);
+    CHECK(browseSpy.count() == 0);
+
+    browseButton->click();
+    CHECK(browseSpy.count() == 1);
+    CHECK(newSpy.count() == 1); // the New Map click above, unchanged
 }


### PR DESCRIPTION
Easy task from PLAN.md ("Map loader panel — remaining enhancements → Welcome-screen entry point").

The no-map welcome screen was a static Vault Boy image with no way to act — the only way to load or create a map was the File menu. This adds **New Map** and **Browse Maps…** buttons to the welcome screen. Each emits a request signal that `MainWindow` connects to the existing `newMapRequested` / `showMapBrowserDialog()` handlers, so they behave exactly like the File-menu actions (same icons too).

- `WelcomeWidget`: two wired buttons + `newMapRequested()` / `browseMapsRequested()` signals.
- `MainWindow`: connects those signals to the existing handlers.
- `qt_tests`: new case asserting each button emits its matching signal.
- PLAN.md: removed the now-done "Welcome-screen entry point" follow-up.

**Verification:** 354/354 tests pass locally; gecko builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)