### PR TITLE
Add File > Close Map action (returns to the welcome screen)

### DIFF
--- a/resources/icons.qrc
+++ b/resources/icons.qrc
@@ -5,6 +5,7 @@
         <file alias="actions/new.svg">icons/tabler/actions/file-plus.svg</file>
         <file alias="actions/open.svg">icons/tabler/actions/folder-open.svg</file>
         <file alias="actions/save.svg">icons/tabler/actions/device-floppy.svg</file>
+        <file alias="actions/close.svg">icons/tabler/actions/x.svg</file>
         <file alias="actions/rotate.svg">icons/tabler/actions/rotate-clockwise.svg</file>
         <file alias="actions/select.svg">icons/tabler/actions/pointer.svg</file>
         <file alias="actions/paint.svg">icons/tabler/actions/brush.svg</file>

--- a/resources/icons/tabler/actions/x.svg
+++ b/resources/icons/tabler/actions/x.svg
@@ -1,0 +1,1 @@
+<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-x"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M18 6l-12 12" /><path d="M6 6l12 12" /></svg>

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -175,6 +175,11 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
     _mapModified = false;
     updateWindowTitle();
 
+    // Installing a map must (re)start the render loop: closeCurrentMap() stops it, and it is
+    // otherwise only started once at application startup. startGameLoop() is idempotent, so this is
+    // a no-op when the loop is already running (e.g. the startup map load).
+    startGameLoop();
+
     QTimer::singleShot(50, this, &MainWindow::updatePanelMenuActions);
     updateUndoRedoActions();
     updateFillSelectionAction();
@@ -247,6 +252,15 @@ void MainWindow::connectMenuSignals() {
         if (_currentEditorWidget && _currentEditorWidget->saveMapAs(writableMapsDir())) {
             handleMapSaved();
         }
+    });
+    connect(this, &MainWindow::closeMapRequested, [this]() {
+        if (!hasActiveMap()) {
+            return; // nothing open — the welcome screen is already showing
+        }
+        if (!maybeSaveChanges()) {
+            return; // user cancelled the close to keep their unsaved map
+        }
+        closeCurrentMap();
     });
     connect(this, &MainWindow::selectAllRequested, [this]() {
         if (_currentEditorWidget) {
@@ -415,6 +429,7 @@ void MainWindow::setupMenuBar() {
     addMenuAction(_fileMenu, ":/icons/actions/open.svg", "&Browse Maps...", &MainWindow::showMapBrowserDialog, QKeySequence("Ctrl+B"), "Browse available maps as thumbnails");
     addMenuAction(_fileMenu, ":/icons/actions/save.svg", "&Save Map", &MainWindow::saveMapRequested, QKeySequence::Save, "Save current map");
     addMenuAction(_fileMenu, ":/icons/actions/save.svg", "Save Map &As...", &MainWindow::saveMapAsRequested, QKeySequence::SaveAs, "Save the current map to a chosen file");
+    addMenuAction(_fileMenu, ":/icons/actions/close.svg", "&Close Map", &MainWindow::closeMapRequested, QKeySequence::Close, "Close the current map and return to the welcome screen");
 
     _fileMenu->addSeparator();
     addMenuAction(_fileMenu, ":/icons/actions/settings.svg", "&Preferences...", &MainWindow::showPreferences, QKeySequence::Preferences, "Open application preferences");
@@ -2041,7 +2056,7 @@ void MainWindow::closeCurrentMap() {
         return;
     }
 
-    spdlog::debug("Closing current map due to data path changes");
+    spdlog::debug("Closing current map");
 
     stopGameLoop();
 
@@ -2050,6 +2065,11 @@ void MainWindow::closeCurrentMap() {
     _currentEditorWidget = nullptr;
 
     _centralStack->setCurrentWidget(_welcomeWidget);
+
+    // No map is open now: clear the dirty flag and reset the title off the closed map, otherwise the
+    // title bar keeps the closed map's name (and a stale "*") while the welcome screen is shown.
+    _mapModified = false;
+    updateWindowTitle();
 
     // The editor and its Map are gone; clear the panels' borrowed map pointers (Map Info, Scripts,
     // Selection) so they don't dangle before the next map opens.

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -86,6 +86,7 @@ signals:
     void openMapRequested();
     void saveMapRequested();
     void saveMapAsRequested();
+    void closeMapRequested();
     void selectAllRequested();
     void deselectAllRequested();
     void showObjectsToggled(bool enabled);

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -789,6 +789,30 @@ TEST_CASE("MainWindow panel toggles stay wired in the no-map layout", "[qt][main
     REQUIRE_FALSE(selectionAction->isChecked());
 }
 
+// File > Close Map returns to the welcome screen. It must exist with the standard Close shortcut,
+// and triggering it with nothing open must be a safe no-op (no editor spawned, no crash) — the
+// handler guards on hasActiveMap() before touching the teardown path.
+TEST_CASE("File menu offers Close Map, and closing with no map open is a safe no-op", "[qt][mainwindow]") {
+    removeTestSettings();
+
+    auto resources = std::make_shared<geck::resource::GameResources>();
+    geck::MainWindow window(resources, std::make_shared<geck::Settings>());
+    window.show();
+    QTest::qWait(100);
+
+    QAction* closeMap = findAction(window, "Close Map");
+    REQUIRE(closeMap != nullptr);
+    CHECK(closeMap->shortcut() == QKeySequence(QKeySequence::Close));
+
+    // No map loaded -> the welcome screen is showing and there is no editor widget.
+    REQUIRE(window.findChildren<geck::EditorWidget*>().isEmpty());
+
+    closeMap->trigger();
+    QApplication::processEvents();
+
+    CHECK(window.findChildren<geck::EditorWidget*>().isEmpty());
+}
+
 TEST_CASE("DataPathsWidget shows highest priority on top and preserves stored order", "[qt][datapaths]") {
     auto settings = std::make_shared<geck::Settings>();
     geck::DataPathsWidget widget(settings);


### PR DESCRIPTION
Follow-up to the welcome-screen work (#97): once a map is open there's currently no way back to the welcome screen without relaunching the app.

## What
- **File → Close Map** (Ctrl/Cmd+W, tabler close icon). Reuses the app's existing unsaved-changes prompt (`maybeSaveChanges` — Save/Discard/Cancel) before tearing the map down via `closeCurrentMap()`, exactly like New Map and quit. Guards on `hasActiveMap()`, so it's a safe no-op with nothing open.

## Two latent bugs fixed on the way
`closeCurrentMap()` was previously only reachable via the rare data-path rebuild; making it a common menu action surfaced two pre-existing bugs (both caught by an adversarial review of the change):

1. **Frozen viewport after reopen (high).** `closeCurrentMap()` stops the render loop, but `startGameLoop()` only ever ran once at startup — so closing then reopening/creating a map left the viewport frozen. Fixed by starting the loop in `setEditorWidget()`, the funnel for every map install (idempotent, so startup is unaffected). This also fixes the same freeze after a data-path rebuild.
2. **Stale window title (low).** The title kept the closed map's name and a phantom `*` modified marker on the welcome screen. Now reset on close.

## Tests
New `qt_tests` case for the action's presence, Close shortcut, and no-map no-op. **Full suite: 354/354.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)