### PR TITLE
Add edge-scroll panning to the map viewport

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -675,8 +675,10 @@ part and overlaps the spatial-placement `EditorMode` follow-up.
    The one real format Gecko can't round-trip.
 2. **Spatial-script visualization** *(S–M)* — marker + radius overlay for placed spatial scripts (they
    are created but invisible today). Also Known-limitation #3 / the "Visualize spatial scripts" section.
-3. **Eyedropper — pick proto/tile from the map** *(S)* + **edge-scroll panning** *(S)* — cheap QoL both
-   references have; do together.
+3. ~~**Eyedropper — pick proto/tile from the map** *(S)* + **edge-scroll panning** *(S)*~~ — **DONE.**
+   Eyedropper shipped (PR #99); edge-scroll shipped (cursor near a viewport edge auto-pans the view,
+   ramped by depth into a 32px margin, gated off during right-drag pan, with a View-menu toggle
+   persisted in `Settings`). Pure geometry in `viewport/EdgeScroll`, driven from `EditorWidget::update`.
 4. **Minimap / overview** *(M)* — click-to-navigate + elevation switch, with a viewport rectangle
    (improving on Dims' cursor-sprite locator).
 

--- a/docs/feature-gap-audit.md
+++ b/docs/feature-gap-audit.md
@@ -60,8 +60,8 @@ Feature the reference actually has (not a stub) and Gecko lacks. Effort: S ≈ d
 | # | Feature | In reference | Gecko today | Effort | Notes |
 |---|---|---|---|---|---|
 | 3 | **Minimap / overview** with click-to-navigate + elevation switch | Dims `DrawMiniMap` + `imgMiniMapMouseDown` (click re-centers & picks elevation); fallout2-ce `automapShow` (TAB) | **LACKS** — only static per-map thumbnails in `MapBrowserDialog` | **M** | The one *real* Dims parity gap. Dims' locator is a cursor sprite, not a scaled viewport rect — a viewport rectangle would improve on it. |
-| 4 | **Eyedropper — pick proto/tile from the map** | fallout2-ce `'p'` jumps the toolbar to the proto/tile under the cursor (`mapperPickObject`/`mapperPickTile`) | **LACKS** | **S** | High-value, low-cost: click a placed object/tile → select its palette entry. |
-| 5 | **Edge-scroll panning** | both (cursor at iso edge scrolls one hex; Dims arrow-scroll + hand-pan) | **PARTIAL** — drag/keys pan via `ViewportController`, no auto edge-scroll | **S** | Small viewport addition. |
+| 4 | **Eyedropper — pick proto/tile from the map** | fallout2-ce `'p'` jumps the toolbar to the proto/tile under the cursor (`mapperPickObject`/`mapperPickTile`) | **DONE** (PR #99) — `P` picks the object/tile under the cursor into the matching palette | **S** | Shipped. |
+| 5 | **Edge-scroll panning** | both (cursor at iso edge scrolls one hex; Dims arrow-scroll + hand-pan) | **DONE** — cursor near a viewport edge auto-pans (ramped by depth into a 32px margin), suppressed during right-drag pan, View-menu toggle persisted in `Settings`; `viewport/EdgeScroll` + `EditorWidget::update` + `ViewportController::panBy` | **S** | Shipped. |
 
 ### Priority 3 — defer (substitute exists or niche)
 
@@ -119,6 +119,6 @@ be retired from TODO.md in favor of this audit.
 
 1. **`.edg` map-edge support** (§2 #1) — the one true format Gecko can't round-trip; engine-authored.
 2. **Spatial-script visualization** (§2 #2) — already a tracked limitation; small overlay work.
-3. **Eyedropper pick-from-map** (§2 #4) + **edge-scroll** (§2 #5) — cheap QoL, do together.
+3. ~~**Eyedropper pick-from-map** (§2 #4) + **edge-scroll** (§2 #5)~~ — **DONE** (eyedropper PR #99; edge-scroll shipped).
 4. **Minimap/overview** (§2 #3) — larger, high-visibility.
 5. Defer #6–#8 unless requested.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -488,6 +488,8 @@ add_library(gecko_core STATIC
 
     viewport/ViewportController.h
     viewport/ViewportController.cpp
+    viewport/EdgeScroll.h
+    viewport/EdgeScroll.cpp
 
     selection/SelectionDataProvider.h
     selection/SelectionState.h

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -110,6 +110,7 @@ QJsonObject Settings::toJson() const {
     }
     ui["windowMaximized"] = _windowMaximized;
     ui["mergeSelectionOutlines"] = _mergeSelectionOutlines;
+    ui["edgeScrollEnabled"] = _edgeScrollEnabled;
 
     // Floating dock geometries
     if (!_floatingDockGeometries.isEmpty()) {
@@ -188,6 +189,10 @@ void Settings::fromJson(const QJsonObject& json) {
 
         if (ui.contains("mergeSelectionOutlines")) {
             _mergeSelectionOutlines = ui["mergeSelectionOutlines"].toBool(true); // Default to true
+        }
+
+        if (ui.contains("edgeScrollEnabled")) {
+            _edgeScrollEnabled = ui["edgeScrollEnabled"].toBool(true); // Default to true
         }
 
         if (ui.contains("floatingDockGeometries")) {
@@ -327,6 +332,14 @@ bool Settings::getMergeSelectionOutlines() const {
 
 void Settings::setMergeSelectionOutlines(bool merge) {
     _mergeSelectionOutlines = merge;
+}
+
+bool Settings::getEdgeScrollEnabled() const {
+    return _edgeScrollEnabled;
+}
+
+void Settings::setEdgeScrollEnabled(bool enabled) {
+    _edgeScrollEnabled = enabled;
 }
 
 QByteArray Settings::getDockState() const {

--- a/src/ui/Settings.h
+++ b/src/ui/Settings.h
@@ -62,6 +62,10 @@ public:
     bool getMergeSelectionOutlines() const;
     void setMergeSelectionOutlines(bool merge);
 
+    // Whether the cursor near a viewport edge auto-scrolls the map (View menu toggle).
+    bool getEdgeScrollEnabled() const;
+    void setEdgeScrollEnabled(bool enabled);
+
     // Floating dock geometries
     QByteArray getFloatingDockGeometry(const QString& dockName) const;
     void setFloatingDockGeometry(const QString& dockName, const QByteArray& geometry);
@@ -123,6 +127,7 @@ private:
     QByteArray _dockState;
     bool _windowMaximized = true;        // Default to maximized
     bool _mergeSelectionOutlines = true; // Default: merge touching same-category outlines
+    bool _edgeScrollEnabled = true;      // Default: auto-scroll when the cursor rests near an edge
     QMap<QString, QByteArray> _floatingDockGeometries;
     QMap<QString, bool> _panelVisibilityPreferences;
     QString _version;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -8,9 +8,12 @@
 #include "pattern/PatternLibrary.h"
 #include "pattern/PatternSerializer.h"
 #include "scripting/MapScriptApi.h"
+#include <QCursor>
 #include <QDirIterator>
 #include <QFile>
 #include <QFileInfo>
+#include <QPoint>
+#include <QSize>
 #include <QStringList>
 #include "editing/commands/ObjectCommandController.h"
 #include "rendering/MapSpriteLoader.h"
@@ -18,6 +21,7 @@
 #include "ui/dragdrop/DragDropManager.h"
 #include "ui/tiles/TilePlacementManager.h"
 #include "ui/tools/ExitGridPlacementManager.h"
+#include "viewport/EdgeScroll.h"
 #include "viewport/ViewportController.h"
 #include "ui/panels/ObjectPalettePanel.h"
 #include "ui/panels/TilePalettePanel.h"
@@ -764,8 +768,7 @@ void EditorWidget::bindInteractionCallbacks(InputHandler::Callbacks& callbacks) 
     };
 
     callbacks.onPan = [this](sf::Vector2f delta) {
-        sf::Vector2f center = _controller.viewport().getView().getCenter();
-        _controller.viewport().getView().setCenter(center + delta);
+        _controller.viewport().panBy(delta);
     };
 
     callbacks.onZoom = [this](float direction) {
@@ -974,8 +977,60 @@ void EditorWidget::createScrollBlockersFromHexes(const std::vector<int>& borderH
     spdlog::debug("Scroll blocker rectangle: {} scroll blockers created on border", scrollBlockersCreated);
 }
 
-void EditorWidget::update([[maybe_unused]] const float dt) {
-    // Called by the SFMLWidget's update loop
+void EditorWidget::update(const float dt) {
+    // Called by the SFMLWidget's update loop every frame (independent of input events),
+    // which is what lets a stationary cursor at the edge keep scrolling.
+    updateEdgeScroll(dt);
+}
+
+void EditorWidget::updateEdgeScroll(const float dt) {
+    if (!_edgeScrollEnabled || !_sfmlWidget || !_inputHandler || dt <= 0.f) {
+        return;
+    }
+
+    // Never fight a manual right-drag pan. Every other action (drag-select, object move, tile
+    // paint, mark-exits, ...) benefits from scrolling toward off-screen areas, so only PANNING
+    // is suppressed.
+    if (_inputHandler->getCurrentAction() == InputHandler::EditorAction::PANNING) {
+        return;
+    }
+
+    // Only scroll while the cursor genuinely hovers the map viewport of the active window — not
+    // when it is over a panel, the menu bar, another window, or off-screen.
+    if (!_sfmlWidget->underMouse()) {
+        return;
+    }
+    if (const QWidget* topLevel = _sfmlWidget->window(); topLevel && !topLevel->isActiveWindow()) {
+        return;
+    }
+
+    const QPoint cursor = _sfmlWidget->mapFromGlobal(QCursor::pos());
+    const QSize viewport = _sfmlWidget->size();
+
+    const sf::Vector2f velocity = EdgeScroll::velocity(
+        sf::Vector2f(static_cast<float>(cursor.x()), static_cast<float>(cursor.y())),
+        sf::Vector2f(static_cast<float>(viewport.width()), static_cast<float>(viewport.height())),
+        EdgeScroll::DEFAULT_MARGIN, EdgeScroll::DEFAULT_SPEED);
+
+    if (velocity == sf::Vector2f{ 0.f, 0.f }) {
+        return;
+    }
+
+    // The velocity is a screen-space speed (px/second). Divide by the zoom so the on-screen scroll
+    // rate stays constant regardless of zoom, then scale by the frame time to get this frame's
+    // world-space step.
+    const float zoom = _controller.viewport().getZoomLevel();
+    const float scale = (zoom > 0.f ? 1.0f / zoom : 1.0f) * dt;
+    _controller.viewport().panBy(velocity * scale);
+
+    // Re-fire the move at the (unchanged) cursor pixel against the now-scrolled view, so the hover
+    // highlight, drag-select rectangle, object ghost, and edge-line preview all track the map that
+    // just moved under a possibly-stationary cursor.
+    if (auto* target = _sfmlWidget->getRenderTarget()) {
+        _inputHandler->handleEvent(
+            sf::Event(sf::Event::MouseMoved{ { cursor.x(), cursor.y() } }),
+            *target, _controller.viewport().getView());
+    }
 }
 
 void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float dt) {

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -98,6 +98,11 @@ public:
     void setShowExitGrids(bool show) { _session.visibility().showExitGrids = show; }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
+    // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that
+    // way (parity with the reference mappers). Editor UX only — touches no map data.
+    void setEdgeScrollEnabled(bool enabled) { _edgeScrollEnabled = enabled; }
+    bool isEdgeScrollEnabled() const { return _edgeScrollEnabled; }
+
     // User-configured selection highlight colours (from preferences); forwarded to the renderer.
     void setSelectionColors(const RenderingEngine::SelectionPalette& colors);
 
@@ -407,6 +412,10 @@ private:
     void bindInteractionCallbacks(InputHandler::Callbacks& callbacks);
     void bindToolModeCallbacks(InputHandler::Callbacks& callbacks);
 
+    // Edge-scroll tick: run from update(dt); pans the view while the cursor rests near a viewport
+    // edge, then re-fires the cursor's move so hover/drag previews track the scrolled map.
+    void updateEdgeScroll(float dt);
+
     // UI Components
     QVBoxLayout* _layout;
     SFMLWidget* _sfmlWidget;
@@ -453,6 +462,10 @@ private:
     const ObjectInfo* _previewObjectInfo = nullptr; // Object info from palette
 
     int _currentHoverHex = -1;
+
+    // Edge scrolling: auto-pan when the cursor rests near a viewport edge (see setEdgeScrollEnabled).
+    // Default on to match both reference mappers; the View menu / Settings persist the user's choice.
+    bool _edgeScrollEnabled = true;
 
     // Base positions of the selected floor/roof sprites captured while a region is being dragged, so
     // the live preview can offset them and restore them when the drag ends.

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -524,6 +524,19 @@ void MainWindow::setupMenuBar() {
         }
     });
 
+    _edgeScrollAction = _viewMenu->addAction("&Edge Scrolling");
+    _edgeScrollAction->setCheckable(true);
+    _edgeScrollAction->setChecked(_settings ? _settings->getEdgeScrollEnabled() : true);
+    _edgeScrollAction->setStatusTip("Auto-scroll the map when the cursor rests near a viewport edge");
+    connect(_edgeScrollAction, &QAction::toggled, this, [this](bool enabled) {
+        if (_currentEditorWidget)
+            _currentEditorWidget->setEdgeScrollEnabled(enabled);
+        if (_settings) {
+            _settings->setEdgeScrollEnabled(enabled);
+            _settings->save();
+        }
+    });
+
     _viewMenu->addSeparator();
 
     _panelsMenu = _viewMenu->addMenu("&Panels");
@@ -1674,6 +1687,7 @@ void MainWindow::syncMenuStateToEditorWidget() {
     _currentEditorWidget->setShowLightOverlays(_showLightOverlaysAction->isChecked());
     _currentEditorWidget->setShowExitGrids(_showExitGridsAction->isChecked());
     _currentEditorWidget->setMergeSelectionOutlines(_mergeOutlinesAction->isChecked());
+    _currentEditorWidget->setEdgeScrollEnabled(_edgeScrollAction->isChecked());
     updateUndoRedoActions();
 
     // Reset selection to the default: all layers on (classic "All"), no special tool active.
@@ -2105,6 +2119,16 @@ void MainWindow::showPreferences() {
             rebuildGameResourcesFromSettings();
         }
         applySelectionColorsToEditor();
+
+        // Keep the View-menu toggle and the live editor in step with the dialog's edge-scroll choice.
+        // Block the action's signal so re-checking it doesn't loop back into another settings save.
+        if (_edgeScrollAction && _settings) {
+            const QSignalBlocker block(_edgeScrollAction);
+            _edgeScrollAction->setChecked(_settings->getEdgeScrollEnabled());
+        }
+        if (_currentEditorWidget && _settings) {
+            _currentEditorWidget->setEdgeScrollEnabled(_settings->getEdgeScrollEnabled());
+        }
     });
 
     int result = dialog.exec();

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -297,6 +297,7 @@ private:
     QAction* _showLightOverlaysAction;
     QAction* _showExitGridsAction;
     QAction* _mergeOutlinesAction;
+    QAction* _edgeScrollAction;
 
     bool _isRunning;
 };

--- a/src/ui/dialogs/SettingsDialog.cpp
+++ b/src/ui/dialogs/SettingsDialog.cpp
@@ -12,6 +12,7 @@
 #include <QColorDialog>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QCheckBox>
 #include <array>
 #include <spdlog/spdlog.h>
 
@@ -73,10 +74,33 @@ void SettingsDialog::setupTabs() {
     _tabWidget = new QTabWidget();
 
     setupGeneralTab();
+    setupViewportTab();
     setupEditorTab();
     setupColorsTab();
 
     _mainLayout->addWidget(_tabWidget);
+}
+
+void SettingsDialog::setupViewportTab() {
+    _viewportTab = new QWidget();
+    auto* layout = new QVBoxLayout(_viewportTab);
+    layout->setContentsMargins(SPACING_LOOSE, SPACING_LOOSE, SPACING_LOOSE, SPACING_LOOSE);
+    layout->setSpacing(SPACING_NORMAL);
+
+    _edgeScrollCheckBox = new QCheckBox("Edge scrolling");
+    _edgeScrollCheckBox->setToolTip("Scroll the map when the cursor rests near a viewport edge.");
+    layout->addWidget(_edgeScrollCheckBox);
+
+    auto* hint = new QLabel(
+        "When enabled, moving the cursor near the edge of the map view pans the view in that "
+        "direction (the closer to the edge, the faster). Also toggled from View › Edge Scrolling.");
+    hint->setWordWrap(true);
+    layout->addWidget(hint);
+
+    layout->addStretch();
+    _tabWidget->addTab(_viewportTab, "Viewport");
+
+    connect(_edgeScrollCheckBox, &QCheckBox::toggled, this, &SettingsDialog::onWidgetChanged);
 }
 
 void SettingsDialog::setupColorsTab() {
@@ -199,6 +223,8 @@ void SettingsDialog::loadSettings() {
 
     _dataPathsWidget->setDataPaths(_originalDataPaths);
 
+    _edgeScrollCheckBox->setChecked(settings.getEdgeScrollEnabled());
+
     _textEditorWidget->setEditorMode(settings.getTextEditorMode());
     _textEditorWidget->setCustomEditorPath(settings.getCustomEditorPath());
 
@@ -227,6 +253,8 @@ void SettingsDialog::saveSettings() {
     auto dataPaths = _dataPathsWidget->getDataPaths();
     bool pathsHaveChanged = dataPaths != _originalDataPaths;
     settings.setDataPaths(dataPaths);
+
+    settings.setEdgeScrollEnabled(_edgeScrollCheckBox->isChecked());
 
     settings.setTextEditorMode(_textEditorWidget->getEditorMode());
     if (_textEditorWidget->getEditorMode() == Settings::TextEditorMode::CUSTOM) {

--- a/src/ui/dialogs/SettingsDialog.h
+++ b/src/ui/dialogs/SettingsDialog.h
@@ -6,6 +6,7 @@
 #include <QProgressBar>
 #include <QLabel>
 #include <QPushButton>
+#include <QCheckBox>
 #include <QTabWidget>
 #include <QMap>
 #include <QColor>
@@ -51,6 +52,7 @@ private:
     void setupUI();
     void setupTabs();
     void setupGeneralTab();
+    void setupViewportTab();
     void setupEditorTab();
     void setupColorsTab();
     void updateColorButton(const QString& key) const;
@@ -70,6 +72,10 @@ private:
     QVBoxLayout* _generalTabLayout;
     DataPathsWidget* _dataPathsWidget;
     GameLocationWidget* _gameLocationWidget;
+
+    // Viewport Tab (map-canvas behaviour toggles)
+    QWidget* _viewportTab = nullptr;
+    QCheckBox* _edgeScrollCheckBox = nullptr;
 
     // Editor Tab
     QWidget* _editorTab;

--- a/src/viewport/EdgeScroll.cpp
+++ b/src/viewport/EdgeScroll.cpp
@@ -1,0 +1,51 @@
+#include "EdgeScroll.h"
+
+#include <algorithm>
+
+namespace geck {
+
+sf::Vector2f EdgeScroll::velocity(sf::Vector2f cursorPx,
+    sf::Vector2f viewportPx,
+    float marginPx,
+    float speedPxPerSec) {
+    // Degenerate viewport or a disabled margin: nothing to scroll.
+    if (viewportPx.x <= 0.f || viewportPx.y <= 0.f || marginPx <= 0.f) {
+        return {};
+    }
+
+    // A cursor off the viewport does not scroll (the caller only asks while it hovers,
+    // but stay robust to a cursor sitting exactly on/just past an edge).
+    if (cursorPx.x < 0.f || cursorPx.y < 0.f || cursorPx.x > viewportPx.x || cursorPx.y > viewportPx.y) {
+        return {};
+    }
+
+    // Ramp factor in [0,1]: 0 at (or outside) the margin boundary, 1 at the edge.
+    const auto ramp = [marginPx](float distanceFromEdge) -> float {
+        if (distanceFromEdge >= marginPx) {
+            return 0.f;
+        }
+        return std::clamp((marginPx - distanceFromEdge) / marginPx, 0.f, 1.f);
+    };
+
+    sf::Vector2f velocity{ 0.f, 0.f };
+
+    const float leftRamp = ramp(cursorPx.x);
+    const float rightRamp = ramp(viewportPx.x - cursorPx.x);
+    if (leftRamp > 0.f) {
+        velocity.x = -leftRamp * speedPxPerSec;
+    } else if (rightRamp > 0.f) {
+        velocity.x = rightRamp * speedPxPerSec;
+    }
+
+    const float topRamp = ramp(cursorPx.y);
+    const float bottomRamp = ramp(viewportPx.y - cursorPx.y);
+    if (topRamp > 0.f) {
+        velocity.y = -topRamp * speedPxPerSec;
+    } else if (bottomRamp > 0.f) {
+        velocity.y = bottomRamp * speedPxPerSec;
+    }
+
+    return velocity;
+}
+
+} // namespace geck

--- a/src/viewport/EdgeScroll.cpp
+++ b/src/viewport/EdgeScroll.cpp
@@ -13,9 +13,10 @@ sf::Vector2f EdgeScroll::velocity(sf::Vector2f cursorPx,
         return {};
     }
 
-    // A cursor off the viewport does not scroll (the caller only asks while it hovers,
-    // but stay robust to a cursor sitting exactly on/just past an edge).
-    if (cursorPx.x < 0.f || cursorPx.y < 0.f || cursorPx.x > viewportPx.x || cursorPx.y > viewportPx.y) {
+    // A cursor off the viewport does not scroll. Pixel coordinates are half-open [0, size), so the
+    // right/bottom edges are exclusive; the caller only asks while the cursor hovers, but stay robust
+    // to a cursor sitting exactly on or past an edge.
+    if (cursorPx.x < 0.f || cursorPx.y < 0.f || cursorPx.x >= viewportPx.x || cursorPx.y >= viewportPx.y) {
         return {};
     }
 

--- a/src/viewport/EdgeScroll.h
+++ b/src/viewport/EdgeScroll.h
@@ -15,10 +15,11 @@ namespace geck {
  * units.
  *
  * The magnitude ramps linearly from 0 at the inner edge of the margin band to
- * @p speedPxPerSec at the very edge (or beyond), so the closer the cursor is to
- * an edge the faster it scrolls; a corner scrolls diagonally. The result is the
- * zero vector when the cursor sits outside the margin band, or off the viewport
- * entirely.
+ * @p speedPxPerSec at the viewport edge, so the closer the cursor is to an edge
+ * the faster it scrolls; a corner scrolls diagonally. The result is the zero
+ * vector when the cursor sits outside the margin band, or off the viewport
+ * entirely (pixel coordinates are half-open [0, size), so the right/bottom edges
+ * are exclusive).
  *
  * Deliberately free of Qt and any render target so it stays headless-unit-testable.
  */

--- a/src/viewport/EdgeScroll.h
+++ b/src/viewport/EdgeScroll.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <SFML/System/Vector2.hpp>
+
+namespace geck {
+
+/**
+ * @brief Pure geometry for cursor-at-edge auto-scroll ("edge scrolling").
+ *
+ * When the cursor rests near a viewport edge the view should pan that way, the
+ * way both reference Fallout 2 mappers do. This holds only the maths: given the
+ * cursor's pixel position inside the viewport and the viewport's pixel size, it
+ * returns the screen-space scroll velocity (pixels/second) the camera should
+ * move at this instant. The caller scales by frame time and converts to world
+ * units.
+ *
+ * The magnitude ramps linearly from 0 at the inner edge of the margin band to
+ * @p speedPxPerSec at the very edge (or beyond), so the closer the cursor is to
+ * an edge the faster it scrolls; a corner scrolls diagonally. The result is the
+ * zero vector when the cursor sits outside the margin band, or off the viewport
+ * entirely.
+ *
+ * Deliberately free of Qt and any render target so it stays headless-unit-testable.
+ */
+struct EdgeScroll {
+    /// Distance (px) from an edge within which the cursor triggers scrolling.
+    static constexpr float DEFAULT_MARGIN = 32.0f;
+    /// Peak scroll speed at the very edge, in screen pixels per second.
+    static constexpr float DEFAULT_SPEED = 900.0f;
+
+    /**
+     * @brief Screen-space scroll velocity for the current cursor position.
+     * @param cursorPx      Cursor position inside the viewport, in pixels.
+     * @param viewportPx    Viewport size in pixels.
+     * @param marginPx      Edge band width in pixels (<= 0 disables scrolling).
+     * @param speedPxPerSec Peak speed at the edge, screen pixels per second.
+     * @return Velocity in screen pixels/second; zero when no edge is engaged.
+     */
+    [[nodiscard]] static sf::Vector2f velocity(sf::Vector2f cursorPx,
+        sf::Vector2f viewportPx,
+        float marginPx,
+        float speedPxPerSec);
+};
+
+} // namespace geck

--- a/src/viewport/ViewportController.cpp
+++ b/src/viewport/ViewportController.cpp
@@ -33,6 +33,10 @@ void ViewportController::centerViewOnMap() {
     spdlog::debug("ViewportController: Centered view on ({:.1f}, {:.1f})", centerX, centerY);
 }
 
+void ViewportController::panBy(sf::Vector2f worldDelta) {
+    _view.move(worldDelta);
+}
+
 void ViewportController::zoomView(float direction) {
     float newZoom = _zoomLevel;
 

--- a/src/viewport/ViewportController.h
+++ b/src/viewport/ViewportController.h
@@ -45,6 +45,15 @@ public:
     void centerViewOnMap();
 
     /**
+     * @brief Pan the view by a delta expressed in world units.
+     *
+     * The single place that moves the camera; both the drag-pan and the
+     * edge-scroll paths route through here so panning stays defined once.
+     * @param worldDelta Offset added to the current view centre.
+     */
+    void panBy(sf::Vector2f worldDelta);
+
+    /**
      * @brief Zoom the view in or out
      * @param direction Positive for zoom in, negative for zoom out
      */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(general_tests
     general/test_map_object_views.cpp
     general/test_frm_resolver.cpp
     general/test_viewport_controller.cpp
+    general/test_edge_scroll.cpp
     general/test_map_factory.cpp
     general/test_map_roundtrip.cpp
     general/test_undo_stack.cpp

--- a/tests/general/test_edge_scroll.cpp
+++ b/tests/general/test_edge_scroll.cpp
@@ -79,6 +79,13 @@ TEST_CASE("EdgeScroll: a cursor off the viewport does not scroll", "[edge_scroll
     CHECK(vel({ kViewport.x + 5.0f, 300.0f }).x == 0.0f);
     CHECK(vel({ 400.0f, -5.0f }).y == 0.0f);
     CHECK(vel({ 400.0f, kViewport.y + 5.0f }).y == 0.0f);
+
+    // Pixel coordinates are half-open [0, size): the right/bottom edges are exclusive, so a cursor
+    // exactly on them is inert, while the left/top edges (0) are the valid full-speed positions.
+    CHECK(vel({ kViewport.x, 300.0f }).x == 0.0f);
+    CHECK(vel({ 400.0f, kViewport.y }).y == 0.0f);
+    CHECK(vel({ 0.0f, 300.0f }).x < 0.0f);
+    CHECK(vel({ 400.0f, 0.0f }).y < 0.0f);
 }
 
 TEST_CASE("EdgeScroll: degenerate inputs are inert", "[edge_scroll]") {

--- a/tests/general/test_edge_scroll.cpp
+++ b/tests/general/test_edge_scroll.cpp
@@ -1,0 +1,89 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <SFML/System/Vector2.hpp>
+
+#include "viewport/EdgeScroll.h"
+
+using namespace geck;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+constexpr float kMargin = 32.0f;
+constexpr float kSpeed = 900.0f;
+constexpr sf::Vector2f kViewport{ 800.0f, 600.0f };
+
+sf::Vector2f vel(sf::Vector2f cursor) {
+    return EdgeScroll::velocity(cursor, kViewport, kMargin, kSpeed);
+}
+} // namespace
+
+TEST_CASE("EdgeScroll: cursor in the interior does not scroll", "[edge_scroll]") {
+    const sf::Vector2f v = vel({ 400.0f, 300.0f });
+    CHECK(v.x == 0.0f);
+    CHECK(v.y == 0.0f);
+}
+
+TEST_CASE("EdgeScroll: just inside the margin does not scroll", "[edge_scroll]") {
+    // Exactly at the margin boundary (distanceFromEdge == margin) is treated as outside.
+    CHECK(vel({ kMargin, 300.0f }).x == 0.0f);
+    CHECK(vel({ kViewport.x - kMargin, 300.0f }).x == 0.0f);
+    CHECK(vel({ 400.0f, kMargin }).y == 0.0f);
+}
+
+TEST_CASE("EdgeScroll: near each edge scrolls toward that edge", "[edge_scroll]") {
+    // Left edge -> negative X, no Y.
+    const sf::Vector2f left = vel({ 8.0f, 300.0f });
+    CHECK(left.x < 0.0f);
+    CHECK(left.y == 0.0f);
+
+    // Right edge -> positive X.
+    const sf::Vector2f right = vel({ kViewport.x - 8.0f, 300.0f });
+    CHECK(right.x > 0.0f);
+    CHECK(right.y == 0.0f);
+
+    // Top edge -> negative Y.
+    const sf::Vector2f top = vel({ 400.0f, 8.0f });
+    CHECK(top.y < 0.0f);
+    CHECK(top.x == 0.0f);
+
+    // Bottom edge -> positive Y.
+    const sf::Vector2f bottom = vel({ 400.0f, kViewport.y - 8.0f });
+    CHECK(bottom.y > 0.0f);
+    CHECK(bottom.x == 0.0f);
+}
+
+TEST_CASE("EdgeScroll: speed ramps with depth into the margin", "[edge_scroll]") {
+    // At the very edge (distanceFromEdge == 0) the ramp is full speed.
+    CHECK_THAT(vel({ 0.0f, 300.0f }).x, WithinAbs(-kSpeed, 0.001f));
+
+    // Halfway into the band (distanceFromEdge == margin/2) is half speed.
+    CHECK_THAT(vel({ kMargin / 2.0f, 300.0f }).x, WithinAbs(-kSpeed * 0.5f, 0.001f));
+
+    // Deeper into the band is faster than shallower.
+    CHECK(std::abs(vel({ 4.0f, 300.0f }).x) > std::abs(vel({ 20.0f, 300.0f }).x));
+}
+
+TEST_CASE("EdgeScroll: a corner scrolls diagonally", "[edge_scroll]") {
+    const sf::Vector2f topLeft = vel({ 4.0f, 4.0f });
+    CHECK(topLeft.x < 0.0f);
+    CHECK(topLeft.y < 0.0f);
+
+    const sf::Vector2f bottomRight = vel({ kViewport.x - 4.0f, kViewport.y - 4.0f });
+    CHECK(bottomRight.x > 0.0f);
+    CHECK(bottomRight.y > 0.0f);
+}
+
+TEST_CASE("EdgeScroll: a cursor off the viewport does not scroll", "[edge_scroll]") {
+    CHECK(vel({ -5.0f, 300.0f }).x == 0.0f);
+    CHECK(vel({ kViewport.x + 5.0f, 300.0f }).x == 0.0f);
+    CHECK(vel({ 400.0f, -5.0f }).y == 0.0f);
+    CHECK(vel({ 400.0f, kViewport.y + 5.0f }).y == 0.0f);
+}
+
+TEST_CASE("EdgeScroll: degenerate inputs are inert", "[edge_scroll]") {
+    // Zero-size viewport.
+    CHECK(EdgeScroll::velocity({ 0.0f, 0.0f }, { 0.0f, 0.0f }, kMargin, kSpeed) == sf::Vector2f{});
+    // Non-positive margin disables scrolling.
+    CHECK(EdgeScroll::velocity({ 0.0f, 300.0f }, kViewport, 0.0f, kSpeed) == sf::Vector2f{});
+}


### PR DESCRIPTION
## What & why

Parks the cursor near a viewport edge → the map auto-pans that way, matching both reference Fallout 2 mappers (fallout2-ce edge-scroll and the Dims mapper's scroll/pan). This is feature-gap audit **#5**, the explicit companion to the just-merged eyedropper (#4). Editor UX only — it touches no map/format data.

The scroll speed ramps with how deep into a 32px edge margin the cursor sits (faster nearer the edge, diagonal in corners), and it runs from the frame loop, so a stationary cursor at the edge keeps scrolling.

## How it's built

- **`viewport/EdgeScroll`** — pure, Qt-free geometry (lives in `gecko_core`): `velocity(cursorPx, viewportPx, margin, speed)` → screen-space scroll velocity. All the non-trivial logic is here so it is headless-unit-testable.
- **`ViewportController::panBy(worldDelta)`** — a real camera-move method (there wasn't one); the existing drag-pan callback now routes through it, so panning is defined once.
- **`EditorWidget::update(dt)`** — previously empty, now runs the tick: polls the cursor via Qt, computes the velocity, converts screen→world (÷ zoom, so on-screen speed is zoom-independent), pans via `panBy`, then **re-fires a synthetic mouse-move** so the hover highlight, drag-select rectangle, object ghost and edge-line preview all track the scrolled map (this is what makes "drag a selection past the edge" work).
- **Gating** — off during a manual right-drag pan; only while the cursor genuinely hovers the map viewport of the *active* window (not over a panel/menu/other window/off-screen).
- **Toggles** — `View › Edge Scrolling` (mirrors the existing Merge-Outlines action) **and** a new **Viewport** tab in Preferences with an "Edge scrolling" checkbox; both persisted in `Settings` and kept in sync. Default **on** (parity with both references).

## Testing

- `tests/general/test_edge_scroll.cpp` — 7 cases / 26 assertions: interior (no scroll), each edge, corners (diagonal), the speed ramp, off-viewport, and degenerate inputs.
- Full suite green: **362/362** ctest (general + performance + qt_tests). No regression from the `panBy`/viewport refactor.
- `gecko` builds clean; the app launches and constructs the new menu/dialog wiring without crashing.

## Notes for review

- **Default-on**: matches the reference mappers; toggleable + persisted. Easy to flip to default-off if preferred.
- **Re-fire-move-on-scroll**: makes drag-select extend past the edge; during an object drag it means the ghost follows the cursor across the scrolling map. Intentional, but flagged in case a simpler no-re-fire scroll is wanted.
- Margin (32px) and speed (900px/s) are single constants in `EdgeScroll.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)