### PR TITLE
Visualize spatial scripts on the map

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -621,10 +621,13 @@ The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thum
 
 # Visualize spatial scripts on the map (investigate)
 
-> Status: investigation. Spatial scripts can be created (`SpatialScriptDialog` → F-key flow)
-> but are **invisible on the map** once placed — there's no marker, no radius overlay, and no
-> way to see, select, edit, or delete an existing one (see Known limitations #3). Goal: render
-> existing spatial scripts on the canvas so designers can see where their trigger zones are.
+> Status: **read-only visualization SHIPPED.** `View › Show Spatial Scripts` renders each placed
+> spatial script — the engine's green `msef001` marker at its centre hex plus a translucent
+> hex-distance radius disc (`hexgrid::hexesWithinRadius`, matching the engine's `tileDistanceBetween`
+> trigger test), filtered to the current elevation, as a viewport-culled overlay layer in
+> `RenderingEngine::renderSpatialScripts`. **Remaining (the "M" stretch below):** hit-testing a marker
+> to *select → edit/delete* it via `SpatialScriptDialog`, which ties into the click-to-place
+> `EditorMode` in Known-limitation #3.
 
 ## What the data model gives us
 A spatial script is a `MapScript` (not a saved object) with `pid == 1`, its position packed
@@ -673,8 +676,11 @@ part and overlaps the spatial-placement `EditorMode` follow-up.
 1. **`.edg` map-edge support** *(M)* — vault reader/writer for the big-endian `'EDGE'` v1/v2 format the
    engine authors + enforces (`fallout2-ce map_edge.cc` / `map_edge_setup.cc`), plus a setup overlay.
    The one real format Gecko can't round-trip.
-2. **Spatial-script visualization** *(S–M)* — marker + radius overlay for placed spatial scripts (they
-   are created but invisible today). Also Known-limitation #3 / the "Visualize spatial scripts" section.
+2. ~~**Spatial-script visualization** *(S–M)*~~ — **DONE (read-only).** `View › Show Spatial Scripts`
+   draws the engine's green `msef001` marker at each spatial script's centre hex plus a translucent
+   hex-distance radius disc, filtered to the current elevation (`RenderingEngine::renderSpatialScripts`
+   + `hexgrid::hexesWithinRadius`). Selecting/editing/deleting a placed spatial script via the map is
+   the remaining stretch (Known-limitation #3 / the "Visualize spatial scripts" section below).
 3. ~~**Eyedropper — pick proto/tile from the map** *(S)* + **edge-scroll panning** *(S)*~~ — **DONE.**
    Eyedropper shipped (PR #99); edge-scroll shipped (cursor near a viewport edge auto-pans the view,
    ramped by depth into a 32px margin, gated off during right-drag pan, with a View-menu toggle

--- a/docs/feature-gap-audit.md
+++ b/docs/feature-gap-audit.md
@@ -53,7 +53,7 @@ Feature the reference actually has (not a stub) and Gecko lacks. Effort: S ≈ d
 | # | Feature | In reference | Gecko today | Effort | Notes |
 |---|---|---|---|---|---|
 | 1 | **`.edg` map-edge support** | fallout2-ce `map_edge_setup.cc` — full two-tier authoring UI (Hi-Res tile-rect zones + Angled square edges w/ per-side clip modes), overlay, and a big-endian `'EDGE'` v1/v2 file written beside the `.map` (`map_edge.cc:309/405`), enforced by the `edg_support` gate | **LACKS** — no `.edg` read/write/UI anywhere | **M** | The engine *authors and enforces* these; a real format Gecko can't round-trip. Adopt: reader/writer in vault + a setup overlay. Match the CE format exactly (engine-fidelity). |
-| 2 | **Spatial-script visualization** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **PARTIAL** — spatial scripts can be *created* (`SpatialScriptDialog`) but are **invisible** on the map | **S–M** | Already tracked as Known-limitation #3 + PLAN "Visualize spatial scripts". Add a marker + radius overlay layer + View toggle. |
+| 2 | **Spatial-script visualization** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **DONE (read-only)** — `View › Show Spatial Scripts` draws the engine's green `msef001` marker at each script's centre hex plus a translucent hex-distance radius disc, current-elevation-filtered; `RenderingEngine::renderSpatialScripts` + `hexgrid::hexesWithinRadius`. Select/edit/delete via the map is the remaining stretch (Known-limitation #3). | **S–M** | Shipped. |
 
 ### Priority 2 — strong QoL, both references have it
 
@@ -118,7 +118,7 @@ be retired from TODO.md in favor of this audit.
 ## Recommended sequencing
 
 1. **`.edg` map-edge support** (§2 #1) — the one true format Gecko can't round-trip; engine-authored.
-2. **Spatial-script visualization** (§2 #2) — already a tracked limitation; small overlay work.
+2. ~~**Spatial-script visualization** (§2 #2)~~ — **DONE (read-only overlay).** Map select/edit/delete remains.
 3. ~~**Eyedropper pick-from-map** (§2 #4) + **edge-scroll** (§2 #5)~~ — **DONE** (eyedropper PR #99; edge-scroll shipped).
 4. **Minimap/overview** (§2 #3) — larger, high-visibility.
 5. Defer #6–#8 unless requested.

--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -2,7 +2,9 @@
 
 #include "HexagonGrid.h"
 
+#include <algorithm>
 #include <optional>
+#include <vector>
 
 // Fallout 2 hex-grid geometry: cube coordinates and shape-preserving translation.
 //
@@ -64,6 +66,33 @@ inline std::optional<int> translate(int position, int fromAnchor, int toAnchor) 
         return std::nullopt;
     }
     return cr.row * WIDTH + cr.col;
+}
+
+// All grid positions within hex-distance `radius` of `centerPosition` — a filled hex disc
+// with the centre included, in ascending position order per the row-major cube sweep. This
+// matches the engine's spatial-script trigger test `tileDistanceBetween(centre, h) <= radius`
+// (fallout2-ce tile.cc/scripts.cc): cube distance equals that hex-step distance because the
+// offset<->cube conversion mirrors the engine's `_dir_tile` parity layout. Off-grid hexes are
+// skipped, so a disc near an edge is clipped; `radius` < 0 yields an empty list.
+inline std::vector<int> hexesWithinRadius(int centerPosition, int radius) {
+    std::vector<int> positions;
+    if (radius < 0) {
+        return positions;
+    }
+    const Cube center = cubeOfPosition(centerPosition);
+    for (int dx = -radius; dx <= radius; ++dx) {
+        const int lo = std::max(-radius, -dx - radius);
+        const int hi = std::min(radius, -dx + radius);
+        for (int dy = lo; dy <= hi; ++dy) {
+            const int dz = -dx - dy;
+            const ColRow cr = cubeToOffset(center + Cube{ dx, dy, dz });
+            if (cr.col < 0 || cr.col >= WIDTH || cr.row < 0 || cr.row >= HEIGHT) {
+                continue;
+            }
+            positions.push_back(cr.row * WIDTH + cr.col);
+        }
+    }
+    return positions;
 }
 
 } // namespace geck::hexgrid

--- a/src/format/map/Map.cpp
+++ b/src/format/map/Map.cpp
@@ -17,6 +17,10 @@ Map::MapFile& Map::getMapFile() {
     return *mapFile;
 }
 
+const Map::MapFile& Map::getMapFile() const {
+    return *mapFile;
+}
+
 void Map::setMapFile(std::unique_ptr<MapFile> newMapFile) {
     mapFile = std::move(newMapFile);
 }

--- a/src/format/map/Map.h
+++ b/src/format/map/Map.h
@@ -80,6 +80,7 @@ public:
     int elevations() const;
 
     MapFile& getMapFile();
+    const MapFile& getMapFile() const;
     void setMapFile(std::unique_ptr<MapFile> newMapFile);
 
     /// Builds a blank Fallout 2 map: default header, three empty elevations of

--- a/src/rendering/HexRenderer.cpp
+++ b/src/rendering/HexRenderer.cpp
@@ -79,6 +79,23 @@ void HexRenderer::renderHighlights(sf::RenderTarget& target,
     }
 }
 
+void HexRenderer::renderHexOverlay(sf::RenderTarget& target,
+    const sf::View& view,
+    const HexagonGrid& hexGrid,
+    const std::vector<int>& hexPositions,
+    sf::Color color) const {
+    sf::Sprite overlay = _gridSprite;
+    overlay.setTextureRect(overlayTextureRect(_gridSprite.getTexture()));
+    overlay.setColor(color);
+    for (int hexPosition : hexPositions) {
+        auto hex = hexGrid.getHexByPosition(static_cast<uint32_t>(hexPosition));
+        if (!hex.has_value() || !isHexVisible(hex->get(), view)) {
+            continue;
+        }
+        drawOverlaySprite(target, hex->get(), overlay);
+    }
+}
+
 const sf::Texture& HexRenderer::hexTexture() const {
     [[maybe_unused]] auto* hexFrm = _resources.repository().load<Frm>(ResourcePaths::Frm::HEX_GRID);
     return _resources.textures().get(ResourcePaths::Frm::HEX_GRID);

--- a/src/rendering/HexRenderer.h
+++ b/src/rendering/HexRenderer.h
@@ -29,6 +29,14 @@ public:
         int currentHoverHex,
         int playerPositionHex) const;
 
+    // Draw the translucent filled hex overlay (the HEX.frm overlay frame) tinted `color` at each of
+    // the given hex positions, skipping off-screen ones. Used for the spatial-script radius disc.
+    void renderHexOverlay(sf::RenderTarget& target,
+        const sf::View& view,
+        const HexagonGrid& hexGrid,
+        const std::vector<int>& hexPositions,
+        sf::Color color) const;
+
 private:
     [[nodiscard]] const sf::Texture& hexTexture() const;
     static sf::IntRect overlayTextureRect(const sf::Texture& texture);

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -1,9 +1,12 @@
 #include "RenderingEngine.h"
 #include "editor/Hex.h"
+#include "editor/HexGeometry.h"
 #include "editor/Object.h"
 #include "format/frm/Frm.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "util/BuiltTile.h"
 #include "rendering/ObjectVisibility.h"
 #include "resource/GameResources.h"
 #include "resource/ResourcePaths.h"
@@ -127,6 +130,11 @@ void RenderingEngine::render(sf::RenderTarget& target,
     // Layer 7: Exit grids (if enabled)
     if (visibility.showExitGrids && renderData.map) {
         renderExitGrids(target, view, renderData, renderData.map);
+    }
+
+    // Layer 7b: Spatial-script trigger markers + radius (if enabled)
+    if (visibility.showSpatialScripts && renderData.map) {
+        renderSpatialScripts(target, view, renderData);
     }
 
     // Layer 8: Hex highlights and markers
@@ -469,6 +477,73 @@ void RenderingEngine::renderExitGrids(sf::RenderTarget& target,
         }
         exitGridSprite.setPosition(sf::Vector2f(static_cast<float>(cx), static_cast<float>(cy)));
         target.draw(exitGridSprite);
+    }
+}
+
+void RenderingEngine::renderSpatialScripts(sf::RenderTarget& target,
+    const sf::View& view,
+    const RenderData& renderData) {
+    const Map* map = renderData.map;
+    if (!map || !renderData.hexGrid) {
+        return;
+    }
+
+    constexpr int SPATIAL = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    const auto& scripts = map->getMapFile().map_scripts[SPATIAL];
+    if (scripts.empty()) {
+        return;
+    }
+
+    // Radius disc: translucent green, matching the marker. hexesWithinRadius reproduces the engine's
+    // tileDistanceBetween(centre, h) <= radius trigger zone.
+    const sf::Color radiusFill(80, 220, 110, 110);
+
+    // The engine's spatial-script marker (interface art msef001 — a green hex) lives in the DATs, so
+    // guard the load: if the game art is unavailable, fall back to a solid hex so the centre still shows.
+    const sf::Texture* markerTexture = nullptr;
+    try {
+        markerTexture = &_resources.textures().get(ResourcePaths::Frm::SPATIAL_SCRIPT);
+    } catch (const std::exception& e) {
+        static bool warned = false;
+        if (!warned) {
+            spdlog::warn("Spatial-script marker art unavailable ({}); drawing a plain hex instead", e.what());
+            warned = true;
+        }
+    }
+
+    std::optional<sf::Sprite> markerSprite;
+    if (markerTexture) {
+        markerSprite.emplace(*markerTexture);
+        markerSprite->setOrigin(markerSprite->getLocalBounds().size / 2.f); // centre on the hex
+    }
+
+    for (const MapScript& script : scripts) {
+        if (built_tile::elevationOf(script.timer) != static_cast<uint32_t>(renderData.currentElevation)) {
+            continue;
+        }
+        const int centerHex = static_cast<int>(built_tile::tileOf(script.timer));
+
+        // Radius disc first (viewport-culled per hex inside renderHexOverlay), so the marker sits on top.
+        const auto discHexes = hexgrid::hexesWithinRadius(centerHex, static_cast<int>(script.spatial_radius));
+        _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, discHexes, radiusFill);
+
+        // Centre marker.
+        const auto hex = renderData.hexGrid->getHexByPosition(static_cast<uint32_t>(centerHex));
+        if (!hex.has_value()) {
+            continue;
+        }
+        const int cx = hex->get().x();
+        const int cy = hex->get().y();
+        if (!isHexVisible(cx, cy, view)) {
+            continue;
+        }
+        if (markerSprite) {
+            markerSprite->setPosition(sf::Vector2f(static_cast<float>(cx), static_cast<float>(cy)));
+            target.draw(*markerSprite);
+        } else {
+            _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, { centerHex },
+                sf::Color(80, 220, 110, 200));
+        }
     }
 }
 

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -41,6 +41,7 @@ public:
         bool showHexGrid = false;
         bool showLightOverlays = false;
         bool showExitGrids = false;
+        bool showSpatialScripts = false;
         // Merge touching selected objects of the same category into one union outline (true), or
         // outline every selected object individually so shared edges show too (false).
         bool mergeSelectionOutlines = true;
@@ -232,6 +233,16 @@ private:
         const sf::View& view,
         const RenderData& renderData,
         const Map* map);
+
+    /**
+     * @brief Editor-only "Show spatial scripts" overlay: for each spatial script on the current
+     * elevation, a translucent hex-distance radius disc plus the engine's green marker
+     * (art/intrface/msef001.frm) at its centre hex. Spatial scripts have no MapObject, so this is
+     * driven from the map's script list, not renderData.objects.
+     */
+    void renderSpatialScripts(sf::RenderTarget& target,
+        const sf::View& view,
+        const RenderData& renderData);
 
     /**
      * @brief Render the in-progress exit-grid "Draw edge" preview: the polyline plus each

--- a/src/resource/ResourcePaths.h
+++ b/src/resource/ResourcePaths.h
@@ -53,6 +53,10 @@ namespace ResourcePaths {
         // player-visible directional exitgrd*/ext2grd* art.
         constexpr std::string_view EXIT_GRID = "art/misc/exitgrid.frm";
 
+        // Spatial-script trigger marker — the same green hex the fallout2-ce mapper spawns for its
+        // 'h' toggle (interface art index 3). Drawn at each spatial script's centre hex.
+        constexpr std::string_view SPATIAL_SCRIPT = "art/intrface/msef001.frm";
+
         // Light source (special case)
         constexpr std::string_view LIGHT = "art/misc/light.frm";
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1049,6 +1049,7 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     visibility.showHexGrid = _session.visibility().showHexGrid;
     visibility.showLightOverlays = _session.visibility().showLightOverlays;
     visibility.showExitGrids = _session.visibility().showExitGrids;
+    visibility.showSpatialScripts = _session.visibility().showSpatialScripts;
     visibility.mergeSelectionOutlines = _session.visibility().mergeSelectionOutlines;
 
     RenderingEngine::RenderData renderData;

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -96,6 +96,7 @@ public:
     void setShowHexGrid(bool show) { _session.visibility().showHexGrid = show; }
     void setShowLightOverlays(bool show);
     void setShowExitGrids(bool show) { _session.visibility().showExitGrids = show; }
+    void setShowSpatialScripts(bool show) { _session.visibility().showSpatialScripts = show; }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
     // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -493,7 +493,7 @@ void MainWindow::setupMenuBar() {
         QKeySequence shortcut;
     };
 
-    const std::array<ViewToggleSpec, 9> viewToggleSpecs = { {
+    const std::array<ViewToggleSpec, 10> viewToggleSpecs = { {
         { &_showObjectsAction, ":/icons/actions/view-objects.svg", "Show &Objects", UI::DEFAULT_SHOW_OBJECTS, &MainWindow::showObjectsToggled, {}, {} },
         { &_showCrittersAction, ":/icons/actions/view-critters.svg", "Show &Critters", UI::DEFAULT_SHOW_CRITTERS, &MainWindow::showCrittersToggled, {}, {} },
         { &_showWallsAction, ":/icons/actions/view-walls.svg", "Show &Walls", UI::DEFAULT_SHOW_WALLS, &MainWindow::showWallsToggled, {}, {} },
@@ -503,6 +503,7 @@ void MainWindow::setupMenuBar() {
         { &_showHexGridAction, ":/icons/actions/view-grid.svg", "Show &Hex Grid", UI::DEFAULT_SHOW_HEX_GRID, &MainWindow::showHexGridToggled, {}, {} },
         { &_showLightOverlaysAction, ":/icons/actions/view-light.svg", "Show &Light Overlays", false, &MainWindow::showLightOverlaysToggled, {}, {} },
         { &_showExitGridsAction, ":/icons/actions/view-exits.svg", "Show &Exit Grids", false, &MainWindow::showExitGridsToggled, "Show exit grid markers", QKeySequence("Ctrl+E") },
+        { &_showSpatialScriptsAction, ":/icons/actions/target-arrow.svg", "Show Spatial &Scripts", false, &MainWindow::showSpatialScriptsToggled, "Show spatial-script trigger markers and their radius", {} },
     } };
 
     for (const ViewToggleSpec& spec : viewToggleSpecs) {
@@ -1017,6 +1018,10 @@ void MainWindow::setupDockWidgets() {
     connect(this, &MainWindow::showExitGridsToggled, this, [this](bool enabled) {
         if (_currentEditorWidget)
             _currentEditorWidget->setShowExitGrids(enabled);
+    });
+    connect(this, &MainWindow::showSpatialScriptsToggled, this, [this](bool enabled) {
+        if (_currentEditorWidget)
+            _currentEditorWidget->setShowSpatialScripts(enabled);
     });
     connect(this, &MainWindow::elevationChanged, this, [this](int elevation) {
         if (_currentEditorWidget)
@@ -1686,6 +1691,7 @@ void MainWindow::syncMenuStateToEditorWidget() {
     _currentEditorWidget->setShowHexGrid(_showHexGridAction->isChecked());
     _currentEditorWidget->setShowLightOverlays(_showLightOverlaysAction->isChecked());
     _currentEditorWidget->setShowExitGrids(_showExitGridsAction->isChecked());
+    _currentEditorWidget->setShowSpatialScripts(_showSpatialScriptsAction->isChecked());
     _currentEditorWidget->setMergeSelectionOutlines(_mergeOutlinesAction->isChecked());
     _currentEditorWidget->setEdgeScrollEnabled(_edgeScrollAction->isChecked());
     updateUndoRedoActions();

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -103,6 +103,7 @@ signals:
     void showHexGridToggled(bool enabled);
     void showLightOverlaysToggled(bool enabled);
     void showExitGridsToggled(bool enabled);
+    void showSpatialScriptsToggled(bool enabled);
     void elevationChanged(int elevation);
     void selectionModeRequested();
     void rotateObjectRequested();
@@ -296,6 +297,7 @@ private:
     QAction* _showHexGridAction;
     QAction* _showLightOverlaysAction;
     QAction* _showExitGridsAction;
+    QAction* _showSpatialScriptsAction;
     QAction* _mergeOutlinesAction;
     QAction* _edgeScrollAction;
 

--- a/src/ui/core/VisibilitySettings.h
+++ b/src/ui/core/VisibilitySettings.h
@@ -22,6 +22,7 @@ struct VisibilitySettings {
     bool showHexGrid = UI::DEFAULT_SHOW_HEX_GRID;
     bool showLightOverlays = false;
     bool showExitGrids = false;
+    bool showSpatialScripts = false;
     // Merge touching same-category selected objects into one union outline (vs. one per object).
     bool mergeSelectionOutlines = true;
 };

--- a/tests/general/test_hex_geometry.cpp
+++ b/tests/general/test_hex_geometry.cpp
@@ -1,12 +1,20 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <cstdlib>
+#include <unordered_set>
 
 #include "editor/HexGeometry.h"
 
 using namespace geck::hexgrid;
 
 namespace {
+
+// Hex-step distance via the cube model, i.e. the engine's tileDistanceBetween.
+int cubeDistance(int a, int b) {
+    const Cube d = cubeOfPosition(a) - cubeOfPosition(b);
+    return (std::abs(d.x) + std::abs(d.y) + std::abs(d.z)) / 2;
+}
 
 // Unit cube vectors for the six Fallout 2 hex directions (derived so the even-q
 // offset<->cube conversion reproduces the engine's neighbour deltas).
@@ -98,4 +106,52 @@ TEST_CASE("translate reports positions that fall off the grid", "[hex_geometry]"
     const int toAnchor = 0 * WIDTH + 0;   // top-left corner
     const int authored = 98 * WIDTH + 98; // up-left of the authoring anchor
     CHECK_FALSE(translate(authored, fromAnchor, toAnchor).has_value());
+}
+
+TEST_CASE("hexesWithinRadius is the centre only at radius 0", "[hex_geometry]") {
+    const int center = 100 * WIDTH + 100;
+    const auto disc = hexesWithinRadius(center, 0);
+    REQUIRE(disc.size() == 1);
+    CHECK(disc[0] == center);
+}
+
+TEST_CASE("hexesWithinRadius yields the full disc away from edges", "[hex_geometry]") {
+    const int center = 100 * WIDTH + 100; // well interior for these radii
+    for (int radius = 1; radius <= 6; ++radius) {
+        INFO("radius " << radius);
+        const auto disc = hexesWithinRadius(center, radius);
+
+        // A complete hex disc has 3*R*(R+1) + 1 cells.
+        CHECK(disc.size() == static_cast<size_t>(3 * radius * (radius + 1) + 1));
+
+        const std::unordered_set<int> members(disc.begin(), disc.end());
+        CHECK(members.size() == disc.size()); // no duplicates
+        CHECK(members.contains(center));      // centre included
+
+        // Every returned hex is within the radius; no hex just outside it is included.
+        for (int h : disc) {
+            CHECK(cubeDistance(center, h) <= radius);
+        }
+        for (int d = 0; d < 6; ++d) {
+            CHECK(members.contains(stepInDirection(center, d))); // all 6 immediate neighbours present
+        }
+    }
+}
+
+TEST_CASE("hexesWithinRadius clips at the grid edge and stays in bounds", "[hex_geometry]") {
+    const int corner = 0; // top-left; most of a disc here is off-grid
+    const auto disc = hexesWithinRadius(corner, 3);
+
+    // Clipped, so fewer than a full disc, but non-empty and every hex is on-grid.
+    CHECK(disc.size() < static_cast<size_t>(3 * 3 * 4 + 1));
+    CHECK_FALSE(disc.empty());
+    for (int h : disc) {
+        CHECK(h >= 0);
+        CHECK(h < WIDTH * HEIGHT);
+        CHECK(cubeDistance(corner, h) <= 3);
+    }
+}
+
+TEST_CASE("hexesWithinRadius is empty for a negative radius", "[hex_geometry]") {
+    CHECK(hexesWithinRadius(100 * WIDTH + 100, -1).empty());
 }


### PR DESCRIPTION
## What & why

Spatial scripts are trigger zones (a hex position + a hex radius) that Gecko could **create** but never **showed** — once placed they were invisible, with no way to see where a trigger zone sits. This adds a read-only overlay, mirroring the fallout2-ce mapper's `h` toggle. Feature-gap audit **#2** (and the PLAN "Visualize spatial scripts" section / Known-limitation #3). Editor-only cue — touches no map data.

## Engine-fidelity groundwork (confirmed from fallout2-ce before coding)

- **Marker** = interface art index 3 = `art/intrface/msef001.frm` — the green hex the CE mapper spawns (`mp_scrpt.cc` `map_scr_toggle_hexes`). The engine draws **only** the marker, not the radius.
- **Position** = `built_tile & 0x3FFFFFF` is a **hex index (0–39999)**, not a floor tile (the "tile" naming trap CLAUDE.md warns about); elevation = `built_tile >> 29`.
- **Radius** is **hex-distance**: the engine trigger test is `tileDistanceBetween(centre, hex) <= radius` (`scripts.cc`), so the zone is a filled hex disc in hex-step metric — not a screen circle.

## How it's built

- **`hexgrid::hexesWithinRadius`** (new, in `HexGeometry.h`) — enumerates the disc via cube coordinates, reproducing the engine's `tileDistanceBetween` metric (the existing `_dir_tile`-matching cube conversion). Headless, unit-tested.
- **`RenderingEngine::renderSpatialScripts`** — a viewport-culled overlay layer modelled on `renderExitGrids`: iterate `map_scripts[SPATIAL]`, filter by `built_tile::elevationOf == currentElevation`, draw a translucent-green radius disc (reusing `HexRenderer`'s hex overlay sprite) + the `msef001` marker centred on the hex. The marker load is guarded, so missing art degrades to a plain hex instead of throwing mid-frame.
- **`View › Show Spatial Scripts`** toggle wired exactly like `Show Exit Grids` (`VisibilitySettings` in both structs, `EditorWidget::setShowSpatialScripts`, apply-on-load).
- Adds a `const Map::getMapFile() const` so the const renderer can read the script list.

## Testing

- **`test_hex_geometry.cpp`** — `hexesWithinRadius`: radius-0 (centre only), full-disc count `3R(R+1)+1` for R=1..6, every hex within `cubeDistance ≤ R`, all six neighbours present, edge-clipping stays in bounds, negative radius empty. (Full suite: **366/366** ctest.)
- **Visual** — rendered the real Toxic Caves (`klatoxcv.map`, 20 "Goo" zones) and Temple of Trials traps through the actual `RenderingEngine` off-screen: the green marker lands on each script's decoded hex on the correct elevation, with the radius disc around it (a radius-4 disc projects to the expected iso "lens", matching the unit-tested hex-distance membership).
- Clean build; app launches with the overlay active.

## Follow-up (out of scope)

Hit-testing a marker to **select → edit/delete** via `SpatialScriptDialog` — ties into the click-to-place `EditorMode` in Known-limitation #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)