### PR TITLE
Visualize, select, edit, and delete spatial scripts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -621,10 +621,13 @@ The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thum
 
 # Visualize spatial scripts on the map (investigate)
 
-> Status: investigation. Spatial scripts can be created (`SpatialScriptDialog` → F-key flow)
-> but are **invisible on the map** once placed — there's no marker, no radius overlay, and no
-> way to see, select, edit, or delete an existing one (see Known limitations #3). Goal: render
-> existing spatial scripts on the canvas so designers can see where their trigger zones are.
+> Status: **read-only visualization SHIPPED.** `View › Show Spatial Scripts` renders each placed
+> spatial script — the engine's green `msef001` marker at its centre hex plus a translucent
+> hex-distance radius disc (`hexgrid::hexesWithinRadius`, matching the engine's `tileDistanceBetween`
+> trigger test), filtered to the current elevation, as a viewport-culled overlay layer in
+> `RenderingEngine::renderSpatialScripts`. **Remaining (the "M" stretch below):** hit-testing a marker
+> to *select → edit/delete* it via `SpatialScriptDialog`, which ties into the click-to-place
+> `EditorMode` in Known-limitation #3.
 
 ## What the data model gives us
 A spatial script is a `MapScript` (not a saved object) with `pid == 1`, its position packed
@@ -673,8 +676,11 @@ part and overlaps the spatial-placement `EditorMode` follow-up.
 1. **`.edg` map-edge support** *(M)* — vault reader/writer for the big-endian `'EDGE'` v1/v2 format the
    engine authors + enforces (`fallout2-ce map_edge.cc` / `map_edge_setup.cc`), plus a setup overlay.
    The one real format Gecko can't round-trip.
-2. **Spatial-script visualization** *(S–M)* — marker + radius overlay for placed spatial scripts (they
-   are created but invisible today). Also Known-limitation #3 / the "Visualize spatial scripts" section.
+2. ~~**Spatial-script visualization** *(S–M)*~~ — **DONE (read-only).** `View › Show Spatial Scripts`
+   draws the engine's green `msef001` marker at each spatial script's centre hex plus a translucent
+   hex-distance radius disc, filtered to the current elevation (`RenderingEngine::renderSpatialScripts`
+   + `hexgrid::hexesWithinRadius`). Selecting/editing/deleting a placed spatial script via the map is
+   the remaining stretch (Known-limitation #3 / the "Visualize spatial scripts" section below).
 3. ~~**Eyedropper — pick proto/tile from the map** *(S)* + **edge-scroll panning** *(S)*~~ — **DONE.**
    Eyedropper shipped (PR #99); edge-scroll shipped (cursor near a viewport edge auto-pans the view,
    ramped by depth into a 32px margin, gated off during right-drag pan, with a View-menu toggle

--- a/PLAN.md
+++ b/PLAN.md
@@ -621,13 +621,16 @@ The visual map picker shipped (`MapBrowserDialog`, File → Browse Maps…: thum
 
 # Visualize spatial scripts on the map (investigate)
 
-> Status: **read-only visualization SHIPPED.** `View › Show Spatial Scripts` renders each placed
-> spatial script — the engine's green `msef001` marker at its centre hex plus a translucent
+> Status: **SHIPPED (visualize + select + edit + delete).** `View › Show Spatial Scripts` renders each
+> placed spatial script — the engine's green `msef001` marker at its centre hex plus a translucent
 > hex-distance radius disc (`hexgrid::hexesWithinRadius`, matching the engine's `tileDistanceBetween`
-> trigger test), filtered to the current elevation, as a viewport-culled overlay layer in
-> `RenderingEngine::renderSpatialScripts`. **Remaining (the "M" stretch below):** hit-testing a marker
-> to *select → edit/delete* it via `SpatialScriptDialog`, which ties into the click-to-place
-> `EditorMode` in Known-limitation #3.
+> trigger test), filtered to the current elevation, as a viewport-culled overlay in
+> `RenderingEngine::renderSpatialScripts`. A placed spatial script can now be **selected** (click its
+> marker on the map, or its row in the Scripts panel — one shared selection keyed on the SID, the
+> selected marker/disc highlighted amber), **edited** (double-click / context menu → pre-filled
+> `SpatialScriptDialog`, in-place so the SID survives) and **deleted** (`Delete` / context menu), all
+> undoable via `ScriptEditService::editSpatialScript` / `removeSpatialScript`. Known-limitation #3 is
+> now fully closed.
 
 ## What the data model gives us
 A spatial script is a `MapScript` (not a saved object) with `pid == 1`, its position packed
@@ -676,11 +679,11 @@ part and overlaps the spatial-placement `EditorMode` follow-up.
 1. **`.edg` map-edge support** *(M)* — vault reader/writer for the big-endian `'EDGE'` v1/v2 format the
    engine authors + enforces (`fallout2-ce map_edge.cc` / `map_edge_setup.cc`), plus a setup overlay.
    The one real format Gecko can't round-trip.
-2. ~~**Spatial-script visualization** *(S–M)*~~ — **DONE (read-only).** `View › Show Spatial Scripts`
-   draws the engine's green `msef001` marker at each spatial script's centre hex plus a translucent
-   hex-distance radius disc, filtered to the current elevation (`RenderingEngine::renderSpatialScripts`
-   + `hexgrid::hexesWithinRadius`). Selecting/editing/deleting a placed spatial script via the map is
-   the remaining stretch (Known-limitation #3 / the "Visualize spatial scripts" section below).
+2. ~~**Spatial-script visualization** *(S–M)*~~ — **DONE.** `View › Show Spatial Scripts` draws the
+   engine's green `msef001` marker + a hex-distance radius disc (`RenderingEngine::renderSpatialScripts`
+   + `hexgrid::hexesWithinRadius`). Placed spatial scripts can now be **selected, edited, and deleted**
+   from both the map (marker click / double-click / `Delete`) and the Scripts panel, with a shared
+   selection and undo — fully closing Known-limitation #3 / the "Visualize spatial scripts" section below.
 3. ~~**Eyedropper — pick proto/tile from the map** *(S)* + **edge-scroll panning** *(S)*~~ — **DONE.**
    Eyedropper shipped (PR #99); edge-scroll shipped (cursor near a viewport edge auto-pans the view,
    ramped by depth into a 32px margin, gated off during right-drag pan, with a View-menu toggle

--- a/docs/feature-gap-audit.md
+++ b/docs/feature-gap-audit.md
@@ -53,7 +53,7 @@ Feature the reference actually has (not a stub) and Gecko lacks. Effort: S ≈ d
 | # | Feature | In reference | Gecko today | Effort | Notes |
 |---|---|---|---|---|---|
 | 1 | **`.edg` map-edge support** | fallout2-ce `map_edge_setup.cc` — full two-tier authoring UI (Hi-Res tile-rect zones + Angled square edges w/ per-side clip modes), overlay, and a big-endian `'EDGE'` v1/v2 file written beside the `.map` (`map_edge.cc:309/405`), enforced by the `edg_support` gate | **LACKS** — no `.edg` read/write/UI anywhere | **M** | The engine *authors and enforces* these; a real format Gecko can't round-trip. Adopt: reader/writer in vault + a setup overlay. Match the CE format exactly (engine-fidelity). |
-| 2 | **Spatial-script visualization** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **PARTIAL** — spatial scripts can be *created* (`SpatialScriptDialog`) but are **invisible** on the map | **S–M** | Already tracked as Known-limitation #3 + PLAN "Visualize spatial scripts". Add a marker + radius overlay layer + View toggle. |
+| 2 | **Spatial-script visualization** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **DONE (read-only)** — `View › Show Spatial Scripts` draws the engine's green `msef001` marker at each script's centre hex plus a translucent hex-distance radius disc, current-elevation-filtered; `RenderingEngine::renderSpatialScripts` + `hexgrid::hexesWithinRadius`. Select/edit/delete via the map is the remaining stretch (Known-limitation #3). | **S–M** | Shipped. |
 
 ### Priority 2 — strong QoL, both references have it
 
@@ -118,7 +118,7 @@ be retired from TODO.md in favor of this audit.
 ## Recommended sequencing
 
 1. **`.edg` map-edge support** (§2 #1) — the one true format Gecko can't round-trip; engine-authored.
-2. **Spatial-script visualization** (§2 #2) — already a tracked limitation; small overlay work.
+2. ~~**Spatial-script visualization** (§2 #2)~~ — **DONE (read-only overlay).** Map select/edit/delete remains.
 3. ~~**Eyedropper pick-from-map** (§2 #4) + **edge-scroll** (§2 #5)~~ — **DONE** (eyedropper PR #99; edge-scroll shipped).
 4. **Minimap/overview** (§2 #3) — larger, high-visibility.
 5. Defer #6–#8 unless requested.

--- a/docs/feature-gap-audit.md
+++ b/docs/feature-gap-audit.md
@@ -53,7 +53,7 @@ Feature the reference actually has (not a stub) and Gecko lacks. Effort: S ≈ d
 | # | Feature | In reference | Gecko today | Effort | Notes |
 |---|---|---|---|---|---|
 | 1 | **`.edg` map-edge support** | fallout2-ce `map_edge_setup.cc` — full two-tier authoring UI (Hi-Res tile-rect zones + Angled square edges w/ per-side clip modes), overlay, and a big-endian `'EDGE'` v1/v2 file written beside the `.map` (`map_edge.cc:309/405`), enforced by the `edg_support` gate | **LACKS** — no `.edg` read/write/UI anywhere | **M** | The engine *authors and enforces* these; a real format Gecko can't round-trip. Adopt: reader/writer in vault + a setup overlay. Match the CE format exactly (engine-fidelity). |
-| 2 | **Spatial-script visualization** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **DONE (read-only)** — `View › Show Spatial Scripts` draws the engine's green `msef001` marker at each script's centre hex plus a translucent hex-distance radius disc, current-elevation-filtered; `RenderingEngine::renderSpatialScripts` + `hexgrid::hexesWithinRadius`. Select/edit/delete via the map is the remaining stretch (Known-limitation #3). | **S–M** | Shipped. |
+| 2 | **Spatial-script visualization + editing** | fallout2-ce `'h'` toggle draws interface-art markers at each spatial-script tile (`mp_scrpt.cc:110`) | **DONE** — `View › Show Spatial Scripts` draws the engine's green `msef001` marker + a hex-distance radius disc. **Select/edit/delete** now work from both the map (click marker, double-click to edit, `Delete` to remove) and the Scripts panel (shared selection, context menu), all undoable. Fully closes Known-limitation #3. | **S–M** | Shipped. |
 
 ### Priority 2 — strong QoL, both references have it
 
@@ -118,7 +118,7 @@ be retired from TODO.md in favor of this audit.
 ## Recommended sequencing
 
 1. **`.edg` map-edge support** (§2 #1) — the one true format Gecko can't round-trip; engine-authored.
-2. ~~**Spatial-script visualization** (§2 #2)~~ — **DONE (read-only overlay).** Map select/edit/delete remains.
+2. ~~**Spatial-script visualization** (§2 #2)~~ — **DONE.** Overlay + shared map/panel select, edit, delete.
 3. ~~**Eyedropper pick-from-map** (§2 #4) + **edge-scroll** (§2 #5)~~ — **DONE** (eyedropper PR #99; edge-scroll shipped).
 4. **Minimap/overview** (§2 #3) — larger, high-visibility.
 5. Defer #6–#8 unless requested.

--- a/src/editing/commands/ObjectCommandController.cpp
+++ b/src/editing/commands/ObjectCommandController.cpp
@@ -155,6 +155,18 @@ bool ObjectCommandController::addSpatialScript(uint32_t programIndex, int tile, 
     return _scriptService.addSpatialScript(programIndex, tile, elevation, radius);
 }
 
+bool ObjectCommandController::editSpatialScript(uint32_t sid, uint32_t programIndex, int tile, int elevation, int radius) {
+    return _scriptService.editSpatialScript(sid, programIndex, tile, elevation, radius);
+}
+
+bool ObjectCommandController::removeSpatialScript(uint32_t sid) {
+    return _scriptService.removeSpatialScript(sid);
+}
+
+const MapScript* ObjectCommandController::findSpatialScript(uint32_t sid) const {
+    return _scriptService.findSpatialScript(sid);
+}
+
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {
     return _batcher.push(std::move(cmd));
 }

--- a/src/editing/commands/ObjectCommandController.h
+++ b/src/editing/commands/ObjectCommandController.h
@@ -146,6 +146,11 @@ public:
     bool attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex);
     bool detachScript(const std::shared_ptr<MapObject>& object);
     bool addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
+    // Edit / remove an existing spatial script by SID (undoable); findSpatialScript reads its
+    // current values (e.g. to pre-fill an edit dialog). See ScriptEditService for details.
+    bool editSpatialScript(uint32_t sid, uint32_t programIndex, int tile, int elevation, int radius);
+    bool removeSpatialScript(uint32_t sid);
+    const MapScript* findSpatialScript(uint32_t sid) const;
 
 private:
     resource::GameResources& _resources;

--- a/src/editing/commands/ScriptEditService.cpp
+++ b/src/editing/commands/ScriptEditService.cpp
@@ -3,6 +3,7 @@
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "editing/commands/UndoBatcher.h"
+#include "util/BuiltTile.h"
 #include "util/UndoStack.h"
 
 #include <algorithm>
@@ -182,6 +183,63 @@ bool ScriptEditService::addSpatialScript(uint32_t programIndex, int tile, int el
     mapFile.scripts_in_section[section] = static_cast<int>(mapFile.map_scripts[section].size());
 
     return recordScriptEdit("Add Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
+}
+
+const MapScript* ScriptEditService::findSpatialScript(uint32_t sid) const {
+    if (!_map) {
+        return nullptr;
+    }
+    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    if (MapScript::sidSection(sid) != section) {
+        return nullptr;
+    }
+    const auto& vec = _map->getMapFile().map_scripts[section];
+    const auto it = std::find_if(vec.begin(), vec.end(),
+        [sid](const MapScript& s) { return s.pid == sid; });
+    return it == vec.end() ? nullptr : &*it;
+}
+
+bool ScriptEditService::editSpatialScript(uint32_t sid, uint32_t programIndex,
+    int tile, int elevation, int radius) {
+    if (!_map) {
+        return false;
+    }
+    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    if (MapScript::sidSection(sid) != section) {
+        return false;
+    }
+    auto& vec = _map->getMapFile().map_scripts[section];
+    const auto it = std::find_if(vec.begin(), vec.end(),
+        [sid](const MapScript& s) { return s.pid == sid; });
+    if (it == vec.end()) {
+        return false;
+    }
+
+    std::vector<MapScript> beforeSection = vec;
+    // In-place: keep pid and script_oid, update program index, packed position and radius.
+    it->script_id = programIndex;
+    it->timer = built_tile::create(static_cast<uint32_t>(tile), static_cast<uint32_t>(elevation));
+    it->spatial_radius = static_cast<uint32_t>(radius);
+
+    return recordScriptEdit("Edit Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
+}
+
+bool ScriptEditService::removeSpatialScript(uint32_t sid) {
+    if (!_map) {
+        return false;
+    }
+    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    if (MapScript::sidSection(sid) != section) {
+        return false;
+    }
+    auto& vec = _map->getMapFile().map_scripts[section];
+    std::vector<MapScript> beforeSection = vec;
+    const std::size_t sizeBefore = vec.size();
+    eraseScript(sid);
+    if (vec.size() == sizeBefore) {
+        return false; // nothing matched
+    }
+    return recordScriptEdit("Delete Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
 }
 
 } // namespace geck

--- a/src/editing/commands/ScriptEditService.cpp
+++ b/src/editing/commands/ScriptEditService.cpp
@@ -7,8 +7,14 @@
 #include "util/UndoStack.h"
 
 #include <algorithm>
+#include <memory>
 
 namespace geck {
+
+namespace {
+    // The map_scripts section index for spatial scripts (== the SPATIAL script type).
+    constexpr int SPATIAL_SECTION = static_cast<int>(MapScript::ScriptType::SPATIAL);
+} // namespace
 
 ScriptEditService::ScriptEditService(std::unique_ptr<Map>& map, UndoBatcher& batcher)
     : _map(map)
@@ -186,31 +192,21 @@ bool ScriptEditService::addSpatialScript(uint32_t programIndex, int tile, int el
 }
 
 const MapScript* ScriptEditService::findSpatialScript(uint32_t sid) const {
-    if (!_map) {
+    if (!_map || MapScript::fromPid(sid) != MapScript::ScriptType::SPATIAL) {
         return nullptr;
     }
-    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
-    if (MapScript::sidSection(sid) != section) {
-        return nullptr;
-    }
-    const auto& vec = _map->getMapFile().map_scripts[section];
-    const auto it = std::find_if(vec.begin(), vec.end(),
-        [sid](const MapScript& s) { return s.pid == sid; });
-    return it == vec.end() ? nullptr : &*it;
+    const auto& vec = _map->getMapFile().map_scripts[SPATIAL_SECTION];
+    const auto it = std::ranges::find_if(vec, [sid](const MapScript& s) { return s.pid == sid; });
+    return it == vec.end() ? nullptr : std::to_address(it);
 }
 
 bool ScriptEditService::editSpatialScript(uint32_t sid, uint32_t programIndex,
     int tile, int elevation, int radius) {
-    if (!_map) {
+    if (!_map || MapScript::fromPid(sid) != MapScript::ScriptType::SPATIAL) {
         return false;
     }
-    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
-    if (MapScript::sidSection(sid) != section) {
-        return false;
-    }
-    auto& vec = _map->getMapFile().map_scripts[section];
-    const auto it = std::find_if(vec.begin(), vec.end(),
-        [sid](const MapScript& s) { return s.pid == sid; });
+    auto& vec = _map->getMapFile().map_scripts[SPATIAL_SECTION];
+    const auto it = std::ranges::find_if(vec, [sid](const MapScript& s) { return s.pid == sid; });
     if (it == vec.end()) {
         return false;
     }
@@ -221,25 +217,21 @@ bool ScriptEditService::editSpatialScript(uint32_t sid, uint32_t programIndex,
     it->timer = built_tile::create(static_cast<uint32_t>(tile), static_cast<uint32_t>(elevation));
     it->spatial_radius = static_cast<uint32_t>(radius);
 
-    return recordScriptEdit("Edit Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
+    return recordScriptEdit("Edit Spatial Script", SPATIAL_SECTION, nullptr, std::move(beforeSection), 0, -1);
 }
 
 bool ScriptEditService::removeSpatialScript(uint32_t sid) {
-    if (!_map) {
+    if (!_map || MapScript::fromPid(sid) != MapScript::ScriptType::SPATIAL) {
         return false;
     }
-    const int section = static_cast<int>(MapScript::ScriptType::SPATIAL);
-    if (MapScript::sidSection(sid) != section) {
-        return false;
-    }
-    auto& vec = _map->getMapFile().map_scripts[section];
+    const auto& vec = _map->getMapFile().map_scripts[SPATIAL_SECTION];
     std::vector<MapScript> beforeSection = vec;
     const std::size_t sizeBefore = vec.size();
     eraseScript(sid);
     if (vec.size() == sizeBefore) {
         return false; // nothing matched
     }
-    return recordScriptEdit("Delete Spatial Script", section, nullptr, std::move(beforeSection), 0, -1);
+    return recordScriptEdit("Delete Spatial Script", SPATIAL_SECTION, nullptr, std::move(beforeSection), 0, -1);
 }
 
 } // namespace geck

--- a/src/editing/commands/ScriptEditService.h
+++ b/src/editing/commands/ScriptEditService.h
@@ -43,6 +43,14 @@ public:
     bool attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex);
     bool detachScript(const std::shared_ptr<MapObject>& object);
     bool addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
+    // Edit an existing spatial script in place, keeping its SID (pid) stable so a live selection
+    // survives the edit; updates program index, position (tile+elevation) and radius. Undoable.
+    bool editSpatialScript(uint32_t sid, uint32_t programIndex, int tile, int elevation, int radius);
+    // Remove the spatial script with this SID. Undoable. No-op (returns false) if none matches.
+    bool removeSpatialScript(uint32_t sid);
+    // The spatial script with this SID, or nullptr — for reading its current values (e.g. to
+    // pre-fill an edit dialog). The pointer is invalidated by any script-section mutation.
+    const MapScript* findSpatialScript(uint32_t sid) const;
 
     // Section snapshot/restore + targeted erase, shared with bulk object operations.
     ScriptSections snapshotScripts() const;

--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -2,7 +2,9 @@
 
 #include "HexagonGrid.h"
 
+#include <algorithm>
 #include <optional>
+#include <vector>
 
 // Fallout 2 hex-grid geometry: cube coordinates and shape-preserving translation.
 //
@@ -64,6 +66,33 @@ inline std::optional<int> translate(int position, int fromAnchor, int toAnchor) 
         return std::nullopt;
     }
     return cr.row * WIDTH + cr.col;
+}
+
+// All grid positions within hex-distance `radius` of `centerPosition` — a filled hex disc
+// with the centre included, in ascending position order per the row-major cube sweep. This
+// matches the engine's spatial-script trigger test `tileDistanceBetween(centre, h) <= radius`
+// (fallout2-ce tile.cc/scripts.cc): cube distance equals that hex-step distance because the
+// offset<->cube conversion mirrors the engine's `_dir_tile` parity layout. Off-grid hexes are
+// skipped, so a disc near an edge is clipped; `radius` < 0 yields an empty list.
+inline std::vector<int> hexesWithinRadius(int centerPosition, int radius) {
+    std::vector<int> positions;
+    if (radius < 0) {
+        return positions;
+    }
+    const Cube center = cubeOfPosition(centerPosition);
+    for (int dx = -radius; dx <= radius; ++dx) {
+        const int lo = std::max(-radius, -dx - radius);
+        const int hi = std::min(radius, -dx + radius);
+        for (int dy = lo; dy <= hi; ++dy) {
+            const int dz = -dx - dy;
+            const ColRow cr = cubeToOffset(center + Cube{ dx, dy, dz });
+            if (cr.col < 0 || cr.col >= WIDTH || cr.row < 0 || cr.row >= HEIGHT) {
+                continue;
+            }
+            positions.push_back(cr.row * WIDTH + cr.col);
+        }
+    }
+    return positions;
 }
 
 } // namespace geck::hexgrid

--- a/src/format/map/Map.cpp
+++ b/src/format/map/Map.cpp
@@ -17,6 +17,10 @@ Map::MapFile& Map::getMapFile() {
     return *mapFile;
 }
 
+const Map::MapFile& Map::getMapFile() const {
+    return *mapFile;
+}
+
 void Map::setMapFile(std::unique_ptr<MapFile> newMapFile) {
     mapFile = std::move(newMapFile);
 }

--- a/src/format/map/Map.h
+++ b/src/format/map/Map.h
@@ -80,6 +80,7 @@ public:
     int elevations() const;
 
     MapFile& getMapFile();
+    const MapFile& getMapFile() const;
     void setMapFile(std::unique_ptr<MapFile> newMapFile);
 
     /// Builds a blank Fallout 2 map: default header, three empty elevations of

--- a/src/rendering/HexRenderer.cpp
+++ b/src/rendering/HexRenderer.cpp
@@ -79,6 +79,23 @@ void HexRenderer::renderHighlights(sf::RenderTarget& target,
     }
 }
 
+void HexRenderer::renderHexOverlay(sf::RenderTarget& target,
+    const sf::View& view,
+    const HexagonGrid& hexGrid,
+    const std::vector<int>& hexPositions,
+    sf::Color color) const {
+    sf::Sprite overlay = _gridSprite;
+    overlay.setTextureRect(overlayTextureRect(_gridSprite.getTexture()));
+    overlay.setColor(color);
+    for (int hexPosition : hexPositions) {
+        auto hex = hexGrid.getHexByPosition(static_cast<uint32_t>(hexPosition));
+        if (!hex.has_value() || !isHexVisible(hex->get(), view)) {
+            continue;
+        }
+        drawOverlaySprite(target, hex->get(), overlay);
+    }
+}
+
 const sf::Texture& HexRenderer::hexTexture() const {
     [[maybe_unused]] auto* hexFrm = _resources.repository().load<Frm>(ResourcePaths::Frm::HEX_GRID);
     return _resources.textures().get(ResourcePaths::Frm::HEX_GRID);

--- a/src/rendering/HexRenderer.h
+++ b/src/rendering/HexRenderer.h
@@ -29,6 +29,14 @@ public:
         int currentHoverHex,
         int playerPositionHex) const;
 
+    // Draw the translucent filled hex overlay (the HEX.frm overlay frame) tinted `color` at each of
+    // the given hex positions, skipping off-screen ones. Used for the spatial-script radius disc.
+    void renderHexOverlay(sf::RenderTarget& target,
+        const sf::View& view,
+        const HexagonGrid& hexGrid,
+        const std::vector<int>& hexPositions,
+        sf::Color color) const;
+
 private:
     [[nodiscard]] const sf::Texture& hexTexture() const;
     static sf::IntRect overlayTextureRect(const sf::Texture& texture);

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -495,8 +495,14 @@ void RenderingEngine::renderSpatialScripts(sf::RenderTarget& target,
     }
 
     // Radius disc: translucent green, matching the marker. hexesWithinRadius reproduces the engine's
-    // tileDistanceBetween(centre, h) <= radius trigger zone.
+    // tileDistanceBetween(centre, h) <= radius trigger zone. The selected script switches to a
+    // brighter amber so it reads as highlighted against the green of the others.
     const sf::Color radiusFill(80, 220, 110, 110);
+    const sf::Color selectedRadiusFill(255, 205, 70, 150);
+    const sf::Color markerTint(255, 255, 255);         // unselected: no colour shift
+    const sf::Color selectedMarkerTint(255, 235, 130); // selected: shifts the green marker to amber
+    const sf::Color fallbackHex(80, 220, 110, 200);
+    const sf::Color selectedFallbackHex(255, 205, 70, 230);
 
     // The engine's spatial-script marker (interface art msef001 — a green hex) lives in the DATs, so
     // guard the load: if the game art is unavailable, fall back to a solid hex so the centre still shows.
@@ -521,11 +527,13 @@ void RenderingEngine::renderSpatialScripts(sf::RenderTarget& target,
         if (built_tile::elevationOf(script.timer) != static_cast<uint32_t>(renderData.currentElevation)) {
             continue;
         }
+        const bool selected = script.pid == renderData.selectedSpatialScriptSid;
         const int centerHex = static_cast<int>(built_tile::tileOf(script.timer));
 
         // Radius disc first (viewport-culled per hex inside renderHexOverlay), so the marker sits on top.
         const auto discHexes = hexgrid::hexesWithinRadius(centerHex, static_cast<int>(script.spatial_radius));
-        _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, discHexes, radiusFill);
+        _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, discHexes,
+            selected ? selectedRadiusFill : radiusFill);
 
         // Centre marker.
         const auto hex = renderData.hexGrid->getHexByPosition(static_cast<uint32_t>(centerHex));
@@ -538,11 +546,12 @@ void RenderingEngine::renderSpatialScripts(sf::RenderTarget& target,
             continue;
         }
         if (markerSprite) {
+            markerSprite->setColor(selected ? selectedMarkerTint : markerTint);
             markerSprite->setPosition(sf::Vector2f(static_cast<float>(cx), static_cast<float>(cy)));
             target.draw(*markerSprite);
         } else {
             _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, { centerHex },
-                sf::Color(80, 220, 110, 200));
+                selected ? selectedFallbackHex : fallbackHex);
         }
     }
 }

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -1,9 +1,12 @@
 #include "RenderingEngine.h"
 #include "editor/Hex.h"
+#include "editor/HexGeometry.h"
 #include "editor/Object.h"
 #include "format/frm/Frm.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "util/BuiltTile.h"
 #include "rendering/ObjectVisibility.h"
 #include "resource/GameResources.h"
 #include "resource/ResourcePaths.h"
@@ -127,6 +130,11 @@ void RenderingEngine::render(sf::RenderTarget& target,
     // Layer 7: Exit grids (if enabled)
     if (visibility.showExitGrids && renderData.map) {
         renderExitGrids(target, view, renderData, renderData.map);
+    }
+
+    // Layer 7b: Spatial-script trigger markers + radius (if enabled)
+    if (visibility.showSpatialScripts && renderData.map) {
+        renderSpatialScripts(target, view, renderData);
     }
 
     // Layer 8: Hex highlights and markers
@@ -469,6 +477,73 @@ void RenderingEngine::renderExitGrids(sf::RenderTarget& target,
         }
         exitGridSprite.setPosition(sf::Vector2f(static_cast<float>(cx), static_cast<float>(cy)));
         target.draw(exitGridSprite);
+    }
+}
+
+void RenderingEngine::renderSpatialScripts(sf::RenderTarget& target,
+    const sf::View& view,
+    const RenderData& renderData) {
+    const Map* map = renderData.map;
+    if (!map || !renderData.hexGrid) {
+        return;
+    }
+
+    constexpr int SPATIAL = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    const auto& scripts = map->getMapFile().map_scripts[SPATIAL];
+    if (scripts.empty()) {
+        return;
+    }
+
+    // Radius disc: translucent green, matching the marker. hexesWithinRadius reproduces the engine's
+    // tileDistanceBetween(centre, h) <= radius trigger zone.
+    const sf::Color radiusFill(80, 220, 110, 110);
+
+    // The engine's spatial-script marker (interface art msef001 — a green hex) lives in the DATs, so
+    // guard the load: if the game art is unavailable, fall back to a solid hex so the centre still shows.
+    const sf::Texture* markerTexture = nullptr;
+    try {
+        markerTexture = &_resources.textures().get(ResourcePaths::Frm::SPATIAL_SCRIPT);
+    } catch (const std::exception& e) {
+        static bool warned = false;
+        if (!warned) {
+            spdlog::warn("Spatial-script marker art unavailable ({}); drawing a plain hex instead", e.what());
+            warned = true;
+        }
+    }
+
+    std::optional<sf::Sprite> markerSprite;
+    if (markerTexture) {
+        markerSprite.emplace(*markerTexture);
+        markerSprite->setOrigin(markerSprite->getLocalBounds().size / 2.f); // centre on the hex
+    }
+
+    for (const MapScript& script : scripts) {
+        if (built_tile::elevationOf(script.timer) != static_cast<uint32_t>(renderData.currentElevation)) {
+            continue;
+        }
+        const int centerHex = static_cast<int>(built_tile::tileOf(script.timer));
+
+        // Radius disc first (viewport-culled per hex inside renderHexOverlay), so the marker sits on top.
+        const auto discHexes = hexgrid::hexesWithinRadius(centerHex, static_cast<int>(script.spatial_radius));
+        _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, discHexes, radiusFill);
+
+        // Centre marker.
+        const auto hex = renderData.hexGrid->getHexByPosition(static_cast<uint32_t>(centerHex));
+        if (!hex.has_value()) {
+            continue;
+        }
+        const int cx = hex->get().x();
+        const int cy = hex->get().y();
+        if (!isHexVisible(cx, cy, view)) {
+            continue;
+        }
+        if (markerSprite) {
+            markerSprite->setPosition(sf::Vector2f(static_cast<float>(cx), static_cast<float>(cy)));
+            target.draw(*markerSprite);
+        } else {
+            _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, { centerHex },
+                sf::Color(80, 220, 110, 200));
+        }
     }
 }
 

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -102,6 +102,10 @@ public:
         const Map* map = nullptr;
         int currentElevation = 0;
 
+        // SID (MapScript::pid) of the spatial script to highlight as selected in the
+        // spatial-script overlay, or MapScript::NONE for no selection.
+        uint32_t selectedSpatialScriptSid = 0xFFFFFFFFu;
+
         // Exit-grid "Draw edge" live preview (MarkExits mode), grouped so RenderData stays small. When
         // `active`: `lineVertices`/`lineCursor` draw the polyline (vertex->vertex, last->cursor);
         // `hexes` are the prospective on-line hexes; `frmPids` (parallel) each hex's directional marker

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -41,6 +41,7 @@ public:
         bool showHexGrid = false;
         bool showLightOverlays = false;
         bool showExitGrids = false;
+        bool showSpatialScripts = false;
         // Merge touching selected objects of the same category into one union outline (true), or
         // outline every selected object individually so shared edges show too (false).
         bool mergeSelectionOutlines = true;
@@ -232,6 +233,16 @@ private:
         const sf::View& view,
         const RenderData& renderData,
         const Map* map);
+
+    /**
+     * @brief Editor-only "Show spatial scripts" overlay: for each spatial script on the current
+     * elevation, a translucent hex-distance radius disc plus the engine's green marker
+     * (art/intrface/msef001.frm) at its centre hex. Spatial scripts have no MapObject, so this is
+     * driven from the map's script list, not renderData.objects.
+     */
+    void renderSpatialScripts(sf::RenderTarget& target,
+        const sf::View& view,
+        const RenderData& renderData);
 
     /**
      * @brief Render the in-progress exit-grid "Draw edge" preview: the polyline plus each

--- a/src/resource/ResourcePaths.h
+++ b/src/resource/ResourcePaths.h
@@ -53,6 +53,10 @@ namespace ResourcePaths {
         // player-visible directional exitgrd*/ext2grd* art.
         constexpr std::string_view EXIT_GRID = "art/misc/exitgrid.frm";
 
+        // Spatial-script trigger marker — the same green hex the fallout2-ce mapper spawns for its
+        // 'h' toggle (interface art index 3). Drawn at each spatial script's centre hex.
+        constexpr std::string_view SPATIAL_SCRIPT = "art/intrface/msef001.frm";
+
         // Light source (special case)
         constexpr std::string_view LIGHT = "art/misc/light.frm";
 

--- a/src/ui/core/EditorSession.h
+++ b/src/ui/core/EditorSession.h
@@ -10,6 +10,7 @@
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
 #include "format/map/Map.h"
+#include "format/map/MapScript.h"
 #include "selection/SelectionManager.h"
 #include "util/UndoStack.h"
 
@@ -45,10 +46,17 @@ public:
         _floorSprites.clear();
         _roofSprites.clear();
         _wallBlockerOverlays.clear();
+        _selectedSpatialScriptSid = MapScript::NONE;
     }
 
     [[nodiscard]] VisibilitySettings& visibility() { return _visibility; }
     [[nodiscard]] const VisibilitySettings& visibility() const { return _visibility; }
+
+    // The SID (MapScript::pid) of the spatial script currently selected on the map / in the
+    // Scripts panel, or MapScript::NONE. Shared by the click hit-test, the panel row, and the
+    // renderer (which highlights the matching marker).
+    [[nodiscard]] uint32_t selectedSpatialScriptSid() const { return _selectedSpatialScriptSid; }
+    void setSelectedSpatialScriptSid(uint32_t sid) { _selectedSpatialScriptSid = sid; }
 
     [[nodiscard]] UndoStack& undoStack() { return _undoStack; }
     [[nodiscard]] const UndoStack& undoStack() const { return _undoStack; }
@@ -81,6 +89,8 @@ private:
     UndoStack _undoStack{ 100 };
 
     int _currentElevation = 0;
+
+    uint32_t _selectedSpatialScriptSid = MapScript::NONE;
 
     std::unique_ptr<selection::SelectionManager> _selectionManager;
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -887,12 +887,23 @@ void EditorWidget::bindInteractionCallbacks(InputHandler::Callbacks& callbacks) 
 
 void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
     callbacks.onPlayerPositionSelect = [this](sf::Vector2f worldPos) {
-        int hexPosition = _controller.viewport().worldPosToHexIndex(worldPos);
+        const int hexPosition = _controller.viewport().worldPosToHexIndex(worldPos);
+        Q_EMIT statusMessageClearRequested();
+
+        // Generic one-shot hex pick (beginHexPick): consume the callback and return to Select before
+        // invoking it, so the callback (which may reopen a dialog) sees a settled editor state.
+        if (_hexPickCallback) {
+            auto onFinished = std::exchange(_hexPickCallback, nullptr);
+            setMode(EditorMode::Select);
+            onFinished(hexPosition >= 0 ? std::optional<int>(hexPosition) : std::nullopt);
+            return;
+        }
+
+        // Legacy player-position pick: stays in the mode for repeated clicks until Escape.
         if (hexPosition >= 0) {
             Q_EMIT playerPositionSelected(hexPosition);
             spdlog::debug("EditorWidget: Player position selected at hex {}", hexPosition);
         }
-        Q_EMIT statusMessageClearRequested();
     };
 
     callbacks.onScrollBlockerRectangle = [this](sf::FloatRect area) {
@@ -964,6 +975,11 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
         } else if (_mode == EditorMode::PlaceObject) {
             setMode(EditorMode::Select);
             Q_EMIT statusMessageRequested("Object placement cancelled.");
+        } else if (_mode == EditorMode::SetPlayerPosition) {
+            // Cancels the player-position pick and any generic hex pick (beginHexPick); leaving the
+            // mode notifies a pending pick callback with no position (see setMode).
+            setMode(EditorMode::Select);
+            Q_EMIT statusMessageClearRequested();
         } else if (_tilePlacementManager->isTilePlacementMode()) {
             if (_mainWindow && _mainWindow->getTilePalettePanel()) {
                 _mainWindow->getTilePalettePanel()->deselectTile();
@@ -1343,7 +1359,16 @@ void EditorWidget::clearSelection() {
 }
 
 void EditorWidget::setMode(EditorMode mode, int tileIndex, bool isRoof) {
+    const EditorMode previousMode = _mode;
     _mode = mode;
+
+    // Leaving the hex-pick mode without a click (e.g. Escape) is a cancel: notify with no position.
+    // A successful pick clears _hexPickCallback before it calls setMode, so this won't double-fire.
+    if (previousMode == EditorMode::SetPlayerPosition && mode != EditorMode::SetPlayerPosition
+        && _hexPickCallback) {
+        auto onFinished = std::exchange(_hexPickCallback, nullptr);
+        onFinished(std::nullopt);
+    }
 
     // Single owner of mutual exclusion: deactivate every mode's state across all
     // components, then activate the target.
@@ -2261,6 +2286,17 @@ void EditorWidget::enterPlayerPositionSelectionMode() {
     Q_EMIT statusMessageRequested("Click on a hex to set the player starting position (Press Escape to cancel)");
 
     spdlog::debug("EditorWidget: Entered player position selection mode");
+}
+
+void EditorWidget::beginHexPick(std::function<void(std::optional<int>)> onFinished, const QString& prompt) {
+    if (!onFinished) {
+        return;
+    }
+    // setMode first (previousMode is whatever the caller was in), then arm the pick so the callback
+    // isn't mistaken for a stale one and cancelled by the setMode transition above.
+    setMode(EditorMode::SetPlayerPosition);
+    _hexPickCallback = std::move(onFinished);
+    Q_EMIT statusMessageRequested(prompt);
 }
 
 void EditorWidget::centerViewOnHex(uint32_t hexPosition) {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -1049,6 +1049,7 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     visibility.showHexGrid = _session.visibility().showHexGrid;
     visibility.showLightOverlays = _session.visibility().showLightOverlays;
     visibility.showExitGrids = _session.visibility().showExitGrids;
+    visibility.showSpatialScripts = _session.visibility().showSpatialScripts;
     visibility.mergeSelectionOutlines = _session.visibility().mergeSelectionOutlines;
 
     RenderingEngine::RenderData renderData;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -981,9 +981,11 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
     };
 
     callbacks.onDeleteObjects = [this]() {
-        // Delete removes the selected spatial script when one is selected; otherwise it deletes the
-        // selected objects. (Spatial selection is exclusive with object selection.)
-        if (_session.selectedSpatialScriptSid() != MapScript::NONE) {
+        // Delete removes the selected spatial script only while its overlay is visible (so it can't
+        // silently delete an invisible script); otherwise it deletes the selected objects. Spatial
+        // selection is exclusive with object selection.
+        if (_session.visibility().showSpatialScripts
+            && _session.selectedSpatialScriptSid() != MapScript::NONE) {
             deleteSpatialScript(_session.selectedSpatialScriptSid());
             return;
         }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -16,6 +16,8 @@
 #include <QSize>
 #include <QStringList>
 #include "editing/commands/ObjectCommandController.h"
+#include "format/map/MapScript.h"
+#include "util/BuiltTile.h"
 #include "rendering/MapSpriteLoader.h"
 #include "rendering/RenderingEngine.h"
 #include "ui/dragdrop/DragDropManager.h"
@@ -308,7 +310,83 @@ void EditorWidget::detachScript(const std::shared_ptr<MapObject>& object) {
 }
 
 void EditorWidget::addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius) {
-    _controller.commandController().addSpatialScript(programIndex, tile, elevation, radius);
+    if (_controller.commandController().addSpatialScript(programIndex, tile, elevation, radius)) {
+        Q_EMIT mapScriptsChanged();
+    }
+}
+
+void EditorWidget::editSpatialScript(uint32_t sid, uint32_t programIndex, int tile, int elevation, int radius) {
+    if (_controller.commandController().editSpatialScript(sid, programIndex, tile, elevation, radius)) {
+        Q_EMIT mapScriptsChanged();
+    }
+}
+
+void EditorWidget::deleteSpatialScript(uint32_t sid) {
+    if (_controller.commandController().removeSpatialScript(sid)) {
+        if (_session.selectedSpatialScriptSid() == sid) {
+            setSelectedSpatialScript(MapScript::NONE);
+        }
+        Q_EMIT mapScriptsChanged();
+    }
+}
+
+void EditorWidget::setSelectedSpatialScript(uint32_t sid) {
+    if (_session.selectedSpatialScriptSid() == sid) {
+        return; // no change; also breaks the map<->panel selection sync feedback loop
+    }
+    _session.setSelectedSpatialScriptSid(sid);
+    Q_EMIT spatialScriptSelectionChanged(sid);
+}
+
+std::optional<EditorWidget::SpatialScriptInfo> EditorWidget::spatialScriptInfo(uint32_t sid) const {
+    if (!_session.map()
+        || MapScript::sidSection(sid) != static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+        return std::nullopt;
+    }
+    constexpr int SPATIAL = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    for (const MapScript& s : _session.map()->getMapFile().map_scripts[SPATIAL]) {
+        if (s.pid == sid) {
+            return SpatialScriptInfo{ s.script_id,
+                static_cast<int>(built_tile::tileOf(s.timer)),
+                static_cast<int>(built_tile::elevationOf(s.timer)),
+                static_cast<int>(s.spatial_radius) };
+        }
+    }
+    return std::nullopt;
+}
+
+bool EditorWidget::trySelectSpatialScriptAt(sf::Vector2f worldPos) {
+    if (!_session.visibility().showSpatialScripts || !_session.map()) {
+        return false;
+    }
+    const int hex = _controller.viewport().worldPosToHexIndex(worldPos);
+    if (hex < 0) {
+        return false;
+    }
+    const auto elev = static_cast<uint32_t>(_session.currentElevation());
+    constexpr int SPATIAL = static_cast<int>(MapScript::ScriptType::SPATIAL);
+    for (const MapScript& s : _session.map()->getMapFile().map_scripts[SPATIAL]) {
+        if (built_tile::tileOf(s.timer) != static_cast<uint32_t>(hex)
+            || built_tile::elevationOf(s.timer) != elev) {
+            continue;
+        }
+        // A second quick click on the same marker opens its editor; a single click just selects.
+        const bool doubleClick = s.pid == _lastSpatialClickSid
+            && _spatialClickClock.getElapsedTime().asSeconds() < kSpatialDoubleClickSeconds;
+        _lastSpatialClickSid = s.pid;
+        _spatialClickClock.restart();
+
+        _session.selectionManager()->clearSelection(); // spatial selection is exclusive with objects/tiles
+        setSelectedSpatialScript(s.pid);
+        if (doubleClick) {
+            Q_EMIT spatialScriptEditActivated(s.pid);
+        }
+        return true;
+    }
+    // Clicked away from any marker: drop the spatial selection and let object selection proceed.
+    _lastSpatialClickSid = MapScript::NONE;
+    setSelectedSpatialScript(MapScript::NONE);
+    return false;
 }
 
 EditorWidget::~EditorWidget() {
@@ -723,6 +801,12 @@ void EditorWidget::setupInputCallbacks() {
 void EditorWidget::bindSelectionCallbacks(InputHandler::Callbacks& callbacks) {
     // Mouse events
     callbacks.onSelectionClick = [this](sf::Vector2f worldPos, InputHandler::SelectionModifier modifier) {
+        // A plain click on a visible spatial-script marker selects (or, on a quick second click,
+        // edits) that script instead of the object/tile underneath. Modified clicks (add/toggle/
+        // range) stay object-selection operations and leave the spatial selection untouched.
+        if (modifier == InputHandler::SelectionModifier::NONE && trySelectSpatialScriptAt(worldPos)) {
+            return;
+        }
         SelectionModifier selectionModifier;
         switch (modifier) {
             case InputHandler::SelectionModifier::ADD:
@@ -897,6 +981,12 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
     };
 
     callbacks.onDeleteObjects = [this]() {
+        // Delete removes the selected spatial script when one is selected; otherwise it deletes the
+        // selected objects. (Spatial selection is exclusive with object selection.)
+        if (_session.selectedSpatialScriptSid() != MapScript::NONE) {
+            deleteSpatialScript(_session.selectedSpatialScriptSid());
+            return;
+        }
         deleteSelectedObjects();
     };
 
@@ -1083,6 +1173,7 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     renderData.playerPositionHex = _session.map() ? static_cast<int>(_session.map()->getMapFile().header.player_default_position) : -1;
     renderData.map = _session.map();
     renderData.currentElevation = _session.currentElevation();
+    renderData.selectedSpatialScriptSid = _session.selectedSpatialScriptSid();
 
     // Exit-grid "Draw edge" live preview (MarkExits mode).
     renderData.exitGridPreview.active = _exitGridLineActive;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -886,25 +886,7 @@ void EditorWidget::bindInteractionCallbacks(InputHandler::Callbacks& callbacks) 
 }
 
 void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
-    callbacks.onPlayerPositionSelect = [this](sf::Vector2f worldPos) {
-        const int hexPosition = _controller.viewport().worldPosToHexIndex(worldPos);
-        Q_EMIT statusMessageClearRequested();
-
-        // Generic one-shot hex pick (beginHexPick): consume the callback and return to Select before
-        // invoking it, so the callback (which may reopen a dialog) sees a settled editor state.
-        if (_hexPickCallback) {
-            auto onFinished = std::exchange(_hexPickCallback, nullptr);
-            setMode(EditorMode::Select);
-            onFinished(hexPosition >= 0 ? std::optional<int>(hexPosition) : std::nullopt);
-            return;
-        }
-
-        // Legacy player-position pick: stays in the mode for repeated clicks until Escape.
-        if (hexPosition >= 0) {
-            Q_EMIT playerPositionSelected(hexPosition);
-            spdlog::debug("EditorWidget: Player position selected at hex {}", hexPosition);
-        }
-    };
+    callbacks.onPlayerPositionSelect = [this](sf::Vector2f worldPos) { handlePositionPickClick(worldPos); };
 
     callbacks.onScrollBlockerRectangle = [this](sf::FloatRect area) {
         auto borderHexes = calculateRectangleBorderHexes(area);
@@ -2286,6 +2268,26 @@ void EditorWidget::enterPlayerPositionSelectionMode() {
     Q_EMIT statusMessageRequested("Click on a hex to set the player starting position (Press Escape to cancel)");
 
     spdlog::debug("EditorWidget: Entered player position selection mode");
+}
+
+void EditorWidget::handlePositionPickClick(sf::Vector2f worldPos) {
+    const int hexPosition = _controller.viewport().worldPosToHexIndex(worldPos);
+    Q_EMIT statusMessageClearRequested();
+
+    // Generic one-shot hex pick (beginHexPick): consume the callback and return to Select before
+    // invoking it, so the callback (which may reopen a dialog) sees a settled editor state.
+    if (_hexPickCallback) {
+        auto onFinished = std::exchange(_hexPickCallback, nullptr);
+        setMode(EditorMode::Select);
+        onFinished(hexPosition >= 0 ? std::optional<int>(hexPosition) : std::nullopt);
+        return;
+    }
+
+    // Legacy player-position pick: stays in the mode for repeated clicks until Escape.
+    if (hexPosition >= 0) {
+        Q_EMIT playerPositionSelected(hexPosition);
+        spdlog::debug("EditorWidget: Player position selected at hex {}", hexPosition);
+    }
 }
 
 void EditorWidget::beginHexPick(std::function<void(std::optional<int>)> onFinished, const QString& prompt) {

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -339,8 +339,7 @@ void EditorWidget::setSelectedSpatialScript(uint32_t sid) {
 }
 
 std::optional<EditorWidget::SpatialScriptInfo> EditorWidget::spatialScriptInfo(uint32_t sid) const {
-    if (!_session.map()
-        || MapScript::sidSection(sid) != static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+    if (!_session.map() || MapScript::fromPid(sid) != MapScript::ScriptType::SPATIAL) {
         return std::nullopt;
     }
     constexpr int SPATIAL = static_cast<int>(MapScript::ScriptType::SPATIAL);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -96,7 +96,14 @@ public:
     void setShowHexGrid(bool show) { _session.visibility().showHexGrid = show; }
     void setShowLightOverlays(bool show);
     void setShowExitGrids(bool show) { _session.visibility().showExitGrids = show; }
-    void setShowSpatialScripts(bool show) { _session.visibility().showSpatialScripts = show; }
+    void setShowSpatialScripts(bool show) {
+        _session.visibility().showSpatialScripts = show;
+        // Hiding the overlay drops any spatial-script selection: it can no longer be seen, and a
+        // lingering selection would let the map Delete key remove an invisible script.
+        if (!show) {
+            setSelectedSpatialScript(MapScript::NONE);
+        }
+    }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
     // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -96,6 +96,7 @@ public:
     void setShowHexGrid(bool show) { _session.visibility().showHexGrid = show; }
     void setShowLightOverlays(bool show);
     void setShowExitGrids(bool show) { _session.visibility().showExitGrids = show; }
+    void setShowSpatialScripts(bool show) { _session.visibility().showSpatialScripts = show; }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
     // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -301,8 +301,36 @@ public:
     void attachScript(const std::shared_ptr<MapObject>& object, int scriptType, uint32_t programIndex);
     void detachScript(const std::shared_ptr<MapObject>& object);
     void addSpatialScript(uint32_t programIndex, int tile, int elevation, int radius);
+    // Edit / delete an existing spatial script by SID (undoable). Both refresh the script panels via
+    // mapScriptsChanged; delete also clears the selection if it pointed at the removed script.
+    void editSpatialScript(uint32_t sid, uint32_t programIndex, int tile, int elevation, int radius);
+    void deleteSpatialScript(uint32_t sid);
+
+    // Shared "selected spatial script" state (map click <-> Scripts panel). Setting it emits
+    // spatialScriptSelectionChanged so the panel can mirror the row; MapScript::NONE clears it.
+    void setSelectedSpatialScript(uint32_t sid);
+    [[nodiscard]] uint32_t selectedSpatialScript() const { return _session.selectedSpatialScriptSid(); }
+
+    // Current field values of the spatial script with this SID (for pre-filling an edit dialog),
+    // or nullopt if none matches. tile/elevation are the decoded built_tile.
+    struct SpatialScriptInfo {
+        uint32_t programIndex;
+        int tile;
+        int elevation;
+        int radius;
+    };
+    [[nodiscard]] std::optional<SpatialScriptInfo> spatialScriptInfo(uint32_t sid) const;
 
 signals:
+    /// The map-side spatial-script selection changed (marker click or clear). MainWindow mirrors it
+    /// onto the Scripts panel row. Carries MapScript::NONE when nothing is selected.
+    void spatialScriptSelectionChanged(uint32_t sid);
+    /// The user double-clicked a spatial marker on the map: open its editor (same as the panel's
+    /// edit request). MainWindow owns the dialog.
+    void spatialScriptEditActivated(uint32_t sid);
+    /// A spatial script was added / edited / deleted, so the script panels must repopulate.
+    void mapScriptsChanged();
+
     void selectionChanged(const selection::SelectionState& selection, int elevation);
     void mapLoadRequested(const std::string& mapPath);
     void hexHoverChanged(int hexIndex);
@@ -352,6 +380,12 @@ private:
         const selection::SelectedItem& item,
         const std::unordered_map<const MapObject*, std::shared_ptr<Object>>& objectsByMapObject,
         const std::optional<std::pair<int, int>>& tileDelta) const;
+
+    // If the spatial-script overlay is visible and a marker sits on the clicked hex (current
+    // elevation), select that script (clearing any object/tile selection) and return true. A second
+    // quick click on the same marker also fires spatialScriptEditActivated. A miss clears the spatial
+    // selection and returns false so normal object selection proceeds.
+    bool trySelectSpatialScriptAt(sf::Vector2f worldPos);
 
     // Object management
     void deleteSelectedObjects();
@@ -463,6 +497,12 @@ private:
     const ObjectInfo* _previewObjectInfo = nullptr; // Object info from palette
 
     int _currentHoverHex = -1;
+
+    // Map-side double-click detection for spatial markers: a second click on the same SID within
+    // kSpatialDoubleClickSeconds opens its editor. Self-contained (no InputHandler timing plumbing).
+    sf::Clock _spatialClickClock;
+    uint32_t _lastSpatialClickSid = 0xFFFFFFFFu; // MapScript::NONE
+    static constexpr float kSpatialDoubleClickSeconds = 0.4f;
 
     // Edge scrolling: auto-pan when the cursor rests near a viewport edge (see setEdgeScrollEnabled).
     // Default on to match both reference mappers; the View menu / Settings persist the user's choice.

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -131,6 +131,12 @@ public:
     void enterPlayerPositionSelectionMode();
     void centerViewOnPlayerPosition();
 
+    // Enter a one-shot "click a hex on the map" mode: the next left-click passes its hex index to
+    // `onFinished`, then returns to Select; Escape (or leaving the mode) calls it with std::nullopt.
+    // Reuses the player-position pick plumbing so callers (e.g. the Spatial Script dialog) don't
+    // duplicate it. The caller stays responsible for any UI (e.g. hiding a non-modal dialog).
+    void beginHexPick(std::function<void(std::optional<int>)> onFinished, const QString& prompt);
+
     // Find the object that owns the script with the given SID (its `map_scripts_pid`), switch to its
     // elevation, select it and center the view on it. Returns false (leaving the current selection
     // untouched) when no object on the map owns that script. Used by the Scripts panel's double-click.
@@ -554,6 +560,10 @@ private:
 
     // Player position selection state
     bool _playerPositionSelectionMode = false;
+
+    // When set, the SetPlayerPosition mode is being used as a generic one-shot hex picker (see
+    // beginHexPick): the next click routes here instead of emitting playerPositionSelected.
+    std::function<void(std::optional<int>)> _hexPickCallback;
 
     // Exit-grid "Draw edge" preview state (MarkExits mode). _exitGridLineActive gates the renderer;
     // the vertices/cursor draw the polyline; the hexes are the prospective on-line hexes (recomputed

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -400,6 +400,10 @@ private:
     // selection and returns false so normal object selection proceeds.
     bool trySelectSpatialScriptAt(sf::Vector2f worldPos);
 
+    // Handles a click in SetPlayerPosition mode: routes to an armed beginHexPick callback (one-shot)
+    // or, failing that, emits playerPositionSelected (legacy player-start pick).
+    void handlePositionPickClick(sf::Vector2f worldPos);
+
     // Object management
     void deleteSelectedObjects();
     void registerTileEdit(const QString& description, const std::vector<TileChange>& changes) override;

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -1691,7 +1691,7 @@ void MainWindow::openSpatialScriptDialog(std::optional<uint32_t> editSid) {
 
     // Editing needs the target script to still exist.
     std::optional<EditorWidget::SpatialScriptInfo> info;
-    if (editSid) {
+    if (editSid.has_value()) {
         info = _currentEditorWidget->spatialScriptInfo(*editSid);
         if (!info) {
             showStatusMessage("Spatial script no longer exists");
@@ -1736,7 +1736,7 @@ void MainWindow::pickSpatialScriptPosition() {
             if (!_spatialScriptDialog) {
                 return; // dialog was closed while picking
             }
-            if (hex && _currentEditorWidget) {
+            if (hex.has_value() && _currentEditorWidget) {
                 _spatialScriptDialog->setTile(*hex);
                 // The clicked hex lives on the current elevation, so match it.
                 _spatialScriptDialog->setElevation(_currentEditorWidget->getCurrentElevation());
@@ -1752,7 +1752,7 @@ void MainWindow::applySpatialScriptDialog() {
     if (!_currentEditorWidget || !_spatialScriptDialog) {
         return;
     }
-    SpatialScriptDialog* dialog = _spatialScriptDialog;
+    const SpatialScriptDialog* dialog = _spatialScriptDialog;
     if (dialog->programIndex() < 0) {
         return; // OK is disabled without a chosen script, but guard anyway
     }

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -493,7 +493,7 @@ void MainWindow::setupMenuBar() {
         QKeySequence shortcut;
     };
 
-    const std::array<ViewToggleSpec, 9> viewToggleSpecs = { {
+    const std::array<ViewToggleSpec, 10> viewToggleSpecs = { {
         { &_showObjectsAction, ":/icons/actions/view-objects.svg", "Show &Objects", UI::DEFAULT_SHOW_OBJECTS, &MainWindow::showObjectsToggled, {}, {} },
         { &_showCrittersAction, ":/icons/actions/view-critters.svg", "Show &Critters", UI::DEFAULT_SHOW_CRITTERS, &MainWindow::showCrittersToggled, {}, {} },
         { &_showWallsAction, ":/icons/actions/view-walls.svg", "Show &Walls", UI::DEFAULT_SHOW_WALLS, &MainWindow::showWallsToggled, {}, {} },
@@ -503,6 +503,7 @@ void MainWindow::setupMenuBar() {
         { &_showHexGridAction, ":/icons/actions/view-grid.svg", "Show &Hex Grid", UI::DEFAULT_SHOW_HEX_GRID, &MainWindow::showHexGridToggled, {}, {} },
         { &_showLightOverlaysAction, ":/icons/actions/view-light.svg", "Show &Light Overlays", false, &MainWindow::showLightOverlaysToggled, {}, {} },
         { &_showExitGridsAction, ":/icons/actions/view-exits.svg", "Show &Exit Grids", false, &MainWindow::showExitGridsToggled, "Show exit grid markers", QKeySequence("Ctrl+E") },
+        { &_showSpatialScriptsAction, ":/icons/actions/target-arrow.svg", "Show Spatial &Scripts", false, &MainWindow::showSpatialScriptsToggled, "Show spatial-script trigger markers and their radius", {} },
     } };
 
     for (const ViewToggleSpec& spec : viewToggleSpecs) {
@@ -1017,6 +1018,10 @@ void MainWindow::setupDockWidgets() {
     connect(this, &MainWindow::showExitGridsToggled, this, [this](bool enabled) {
         if (_currentEditorWidget)
             _currentEditorWidget->setShowExitGrids(enabled);
+    });
+    connect(this, &MainWindow::showSpatialScriptsToggled, this, [this](bool enabled) {
+        if (_currentEditorWidget)
+            _currentEditorWidget->setShowSpatialScripts(enabled);
     });
     connect(this, &MainWindow::elevationChanged, this, [this](int elevation) {
         if (_currentEditorWidget)
@@ -1686,6 +1691,7 @@ void MainWindow::syncMenuStateToEditorWidget() {
     _currentEditorWidget->setShowHexGrid(_showHexGridAction->isChecked());
     _currentEditorWidget->setShowLightOverlays(_showLightOverlaysAction->isChecked());
     _currentEditorWidget->setShowExitGrids(_showExitGridsAction->isChecked());
+    _currentEditorWidget->setShowSpatialScripts(_showSpatialScriptsAction->isChecked());
     _currentEditorWidget->setMergeSelectionOutlines(_mergeOutlinesAction->isChecked());
     _currentEditorWidget->setEdgeScrollEnabled(_edgeScrollAction->isChecked());
     updateUndoRedoActions();

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -1,6 +1,7 @@
 #define QT_NO_EMIT
 #include "MainWindow.h"
 #include "EditorWidget.h"
+#include "format/map/MapScript.h"
 #include "ui/core/EditorHints.h"
 #include "ui/widgets/LoadingWidget.h"
 #include "ui/widgets/WelcomeWidget.h"
@@ -1554,10 +1555,7 @@ void MainWindow::connectPanelSignals() {
                     _currentEditorWidget->copyElevation(from, to);
             });
         connect(_mapInfoPanel, &MapInfoPanel::addSpatialScriptRequested,
-            this, [this](int programIndex, int tile, int elevation, int radius) {
-                if (_currentEditorWidget)
-                    _currentEditorWidget->addSpatialScript(static_cast<uint32_t>(programIndex), tile, elevation, radius);
-            });
+            this, [this]() { openSpatialScriptDialog(std::nullopt); });
 
         // Header edits in the Info panel write straight to the map (no undo command), so flag the map
         // modified here. These also fire while the panel is being populated from a freshly loaded map,
@@ -1600,7 +1598,7 @@ void MainWindow::connectPanelSignals() {
         });
         // Edit / delete requested from the panel (context menu or double-click).
         connect(_scriptsPanel, &ScriptsPanel::spatialScriptEditRequested, this,
-            [this](uint32_t sid) { openSpatialScriptEditor(sid); });
+            [this](uint32_t sid) { openSpatialScriptDialog(sid); });
         connect(_scriptsPanel, &ScriptsPanel::spatialScriptDeleteRequested, this, [this](uint32_t sid) {
             if (_currentEditorWidget) {
                 _currentEditorWidget->deleteSpatialScript(sid);
@@ -1668,7 +1666,7 @@ void MainWindow::connectToEditorWidget() {
         }
     });
     connect(_currentEditorWidget, &EditorWidget::spatialScriptEditActivated, this,
-        [this](uint32_t sid) { openSpatialScriptEditor(sid); });
+        [this](uint32_t sid) { openSpatialScriptDialog(sid); });
     connect(_currentEditorWidget, &EditorWidget::mapScriptsChanged, this,
         [this]() { refreshScriptsPanel(); });
 
@@ -1686,28 +1684,85 @@ void MainWindow::connectToEditorWidget() {
     spdlog::debug("Connected EditorWidget instance signals");
 }
 
-void MainWindow::openSpatialScriptEditor(uint32_t sid) {
+void MainWindow::openSpatialScriptDialog(std::optional<uint32_t> editSid) {
     if (!_currentEditorWidget) {
         return;
     }
-    const auto info = _currentEditorWidget->spatialScriptInfo(sid);
-    if (!info) {
-        showStatusMessage("Spatial script no longer exists");
+
+    // Editing needs the target script to still exist.
+    std::optional<EditorWidget::SpatialScriptInfo> info;
+    if (editSid) {
+        info = _currentEditorWidget->spatialScriptInfo(*editSid);
+        if (!info) {
+            showStatusMessage("Spatial script no longer exists");
+            return;
+        }
+    }
+
+    // One dialog at a time: re-focus an open one rather than stacking a second.
+    if (_spatialScriptDialog) {
+        _spatialScriptDialog->raise();
+        _spatialScriptDialog->activateWindow();
         return;
     }
 
-    // Reuse the Add Spatial Script dialog, pre-filled with the script's current values.
-    SpatialScriptDialog dialog(ScriptSelectorDialog::buildEntries(*_resourcesShared), this);
-    dialog.setWindowTitle("Edit Spatial Script");
-    dialog.setProgramIndex(static_cast<int>(info->programIndex));
-    dialog.setTile(info->tile);
-    dialog.setElevation(info->elevation);
-    dialog.setRadius(info->radius);
-    if (dialog.exec() != QDialog::Accepted) {
+    // Non-modal (like the player-position pick) so the map stays clickable for "Pick on map".
+    auto* dialog = new SpatialScriptDialog(ScriptSelectorDialog::buildEntries(*_resourcesShared), this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    _spatialScriptDialog = dialog;
+    _editingSpatialSid = editSid.value_or(MapScript::NONE);
+
+    if (info) {
+        dialog->setWindowTitle("Edit Spatial Script");
+        dialog->setProgramIndex(static_cast<int>(info->programIndex));
+        dialog->setTile(info->tile);
+        dialog->setElevation(info->elevation);
+        dialog->setRadius(info->radius);
+    }
+
+    connect(dialog, &SpatialScriptDialog::pickPositionRequested, this, &MainWindow::pickSpatialScriptPosition);
+    connect(dialog, &QDialog::accepted, this, &MainWindow::applySpatialScriptDialog);
+    connect(dialog, &QObject::destroyed, this, [this]() { _spatialScriptDialog = nullptr; });
+    dialog->show();
+}
+
+void MainWindow::pickSpatialScriptPosition() {
+    if (!_currentEditorWidget || !_spatialScriptDialog) {
         return;
     }
-    _currentEditorWidget->editSpatialScript(sid, static_cast<uint32_t>(dialog.programIndex()),
-        dialog.tile(), dialog.elevation(), dialog.radius());
+    _spatialScriptDialog->hide(); // step aside; the map is clickable because the dialog is non-modal
+    _currentEditorWidget->beginHexPick(
+        [this](std::optional<int> hex) {
+            if (!_spatialScriptDialog) {
+                return; // dialog was closed while picking
+            }
+            if (hex && _currentEditorWidget) {
+                _spatialScriptDialog->setTile(*hex);
+                // The clicked hex lives on the current elevation, so match it.
+                _spatialScriptDialog->setElevation(_currentEditorWidget->getCurrentElevation());
+            }
+            _spatialScriptDialog->show();
+            _spatialScriptDialog->raise();
+            _spatialScriptDialog->activateWindow();
+        },
+        "Click a hex for the spatial-script position (Esc to cancel)");
+}
+
+void MainWindow::applySpatialScriptDialog() {
+    if (!_currentEditorWidget || !_spatialScriptDialog) {
+        return;
+    }
+    SpatialScriptDialog* dialog = _spatialScriptDialog;
+    if (dialog->programIndex() < 0) {
+        return; // OK is disabled without a chosen script, but guard anyway
+    }
+    if (_editingSpatialSid == MapScript::NONE) {
+        _currentEditorWidget->addSpatialScript(static_cast<uint32_t>(dialog->programIndex()),
+            dialog->tile(), dialog->elevation(), dialog->radius());
+    } else {
+        _currentEditorWidget->editSpatialScript(_editingSpatialSid,
+            static_cast<uint32_t>(dialog->programIndex()), dialog->tile(), dialog->elevation(), dialog->radius());
+    }
 }
 
 void MainWindow::refreshScriptsPanel() {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -20,6 +20,8 @@
 #include "ui/dialogs/SettingsDialog.h"
 #include "ui/dialogs/AboutDialog.h"
 #include "ui/dialogs/FillDialog.h"
+#include "ui/dialogs/SpatialScriptDialog.h"
+#include "ui/dialogs/ScriptSelectorDialog.h"
 #include "ui/dialogs/MapBrowserDialog.h"
 #include "ui/dialogs/PatternBrowserDialog.h"
 #include "ui/UIConstants.h"
@@ -464,6 +466,7 @@ void MainWindow::setupMenuBar() {
             updateUndoRedoActions();
             if (_selectionPanel)
                 _selectionPanel->refresh();
+            refreshScriptsPanel(); // an undone spatial add/edit/delete must re-appear in the panel
         }
     });
 
@@ -476,6 +479,7 @@ void MainWindow::setupMenuBar() {
             updateUndoRedoActions();
             if (_selectionPanel)
                 _selectionPanel->refresh();
+            refreshScriptsPanel(); // keep the panel in step with a redone spatial add/edit/delete
         }
     });
 
@@ -1587,6 +1591,21 @@ void MainWindow::connectPanelSignals() {
                     showStatusMessage("Script has no object on the map");
                 }
             });
+
+        // Selecting a spatial-script row drives the shared selection (highlights its marker on the map).
+        connect(_scriptsPanel, &ScriptsPanel::spatialScriptSelected, this, [this](uint32_t sid) {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->setSelectedSpatialScript(sid);
+            }
+        });
+        // Edit / delete requested from the panel (context menu or double-click).
+        connect(_scriptsPanel, &ScriptsPanel::spatialScriptEditRequested, this,
+            [this](uint32_t sid) { openSpatialScriptEditor(sid); });
+        connect(_scriptsPanel, &ScriptsPanel::spatialScriptDeleteRequested, this, [this](uint32_t sid) {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->deleteSpatialScript(sid);
+            }
+        });
     }
 }
 
@@ -1641,6 +1660,18 @@ void MainWindow::connectToEditorWidget() {
         handleMapLoadRequest(mapPath, true);
     });
 
+    // Spatial-script selection/editing sync (map <-> Scripts panel). The panel mirrors the map-side
+    // selection; a map double-click opens the editor; add/edit/delete repopulate the panel.
+    connect(_currentEditorWidget, &EditorWidget::spatialScriptSelectionChanged, this, [this](uint32_t sid) {
+        if (_scriptsPanel) {
+            _scriptsPanel->selectSpatialScriptRow(sid);
+        }
+    });
+    connect(_currentEditorWidget, &EditorWidget::spatialScriptEditActivated, this,
+        [this](uint32_t sid) { openSpatialScriptEditor(sid); });
+    connect(_currentEditorWidget, &EditorWidget::mapScriptsChanged, this,
+        [this]() { refreshScriptsPanel(); });
+
     if (_mapInfoPanel) {
         connect(_currentEditorWidget, &EditorWidget::playerPositionSelected,
             this, [this](int hexPosition) {
@@ -1653,6 +1684,38 @@ void MainWindow::connectToEditorWidget() {
     applySelectionColorsToEditor();
 
     spdlog::debug("Connected EditorWidget instance signals");
+}
+
+void MainWindow::openSpatialScriptEditor(uint32_t sid) {
+    if (!_currentEditorWidget) {
+        return;
+    }
+    const auto info = _currentEditorWidget->spatialScriptInfo(sid);
+    if (!info) {
+        showStatusMessage("Spatial script no longer exists");
+        return;
+    }
+
+    // Reuse the Add Spatial Script dialog, pre-filled with the script's current values.
+    SpatialScriptDialog dialog(ScriptSelectorDialog::buildEntries(*_resourcesShared), this);
+    dialog.setWindowTitle("Edit Spatial Script");
+    dialog.setProgramIndex(static_cast<int>(info->programIndex));
+    dialog.setTile(info->tile);
+    dialog.setElevation(info->elevation);
+    dialog.setRadius(info->radius);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    _currentEditorWidget->editSpatialScript(sid, static_cast<uint32_t>(dialog.programIndex()),
+        dialog.tile(), dialog.elevation(), dialog.radius());
+}
+
+void MainWindow::refreshScriptsPanel() {
+    if (_scriptsPanel && _currentEditorWidget) {
+        _scriptsPanel->setMap(_currentEditorWidget->getMap());
+        // populate() drops the selection; re-assert the shared spatial selection so the row stays lit.
+        _scriptsPanel->selectSpatialScriptRow(_currentEditorWidget->selectedSpatialScript());
+    }
 }
 
 void MainWindow::applySelectionColorsToEditor() {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -181,6 +181,12 @@ private:
     void applyDefaultPanelDockLayout();
     void connectFileBrowserSignals();
     void connectPanelSignals();
+    // Open the (pre-filled) Spatial Script dialog to edit the spatial script with this SID, applying
+    // an undoable edit on accept. Shared by the Scripts-panel and map double-click edit requests.
+    void openSpatialScriptEditor(uint32_t sid);
+    // Rebuild the Scripts panel from the current map and re-assert the shared spatial selection.
+    // Called after a spatial-script add/edit/delete and after undo/redo.
+    void refreshScriptsPanel();
     void replaceDockPanelWidget(QDockWidget* dock, QWidget* panel, QSizePolicy::Policy verticalPolicy);
     void rebuildResourcePanels();
     void rebuildGameResourcesFromSettings();

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -103,6 +103,7 @@ signals:
     void showHexGridToggled(bool enabled);
     void showLightOverlaysToggled(bool enabled);
     void showExitGridsToggled(bool enabled);
+    void showSpatialScriptsToggled(bool enabled);
     void elevationChanged(int elevation);
     void selectionModeRequested();
     void rotateObjectRequested();
@@ -296,6 +297,7 @@ private:
     QAction* _showHexGridAction;
     QAction* _showLightOverlaysAction;
     QAction* _showExitGridsAction;
+    QAction* _showSpatialScriptsAction;
     QAction* _mergeOutlinesAction;
     QAction* _edgeScrollAction;
 

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -12,7 +12,9 @@
 #include <QLabel>
 #include <QSettings>
 #include <QMenu>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <filesystem>
 #include <unordered_map>
 #include <utility>
@@ -45,6 +47,7 @@ class TilePalettePanel;
 class ObjectPalettePanel;
 class FileBrowserPanel;
 class ScriptConsoleWidget;
+class SpatialScriptDialog;
 class Map;
 
 class MainWindow : public QMainWindow {
@@ -181,9 +184,15 @@ private:
     void applyDefaultPanelDockLayout();
     void connectFileBrowserSignals();
     void connectPanelSignals();
-    // Open the (pre-filled) Spatial Script dialog to edit the spatial script with this SID, applying
-    // an undoable edit on accept. Shared by the Scripts-panel and map double-click edit requests.
-    void openSpatialScriptEditor(uint32_t sid);
+    // Open the (non-modal) Spatial Script dialog: editSid empty = add a new script, set = edit that
+    // one pre-filled. On accept it applies an undoable add/edit. Shared by the Add button, the
+    // Scripts-panel edit request, and the map double-click.
+    void openSpatialScriptDialog(std::optional<uint32_t> editSid);
+    // "Pick on map" from the open dialog: hide it, let the user click a hex (beginHexPick), then feed
+    // the hex + its elevation back and re-show the dialog.
+    void pickSpatialScriptPosition();
+    // Apply the open dialog's values (add or edit, per _editingSpatialSid).
+    void applySpatialScriptDialog();
     // Rebuild the Scripts panel from the current map and re-assert the shared spatial selection.
     // Called after a spatial-script add/edit/delete and after undo/redo.
     void refreshScriptsPanel();
@@ -268,6 +277,11 @@ private:
     SelectionPanel* _selectionPanel;
     MapInfoPanel* _mapInfoPanel;
     ScriptsPanel* _scriptsPanel;
+
+    // The open non-modal Spatial Script dialog (add or edit), or null. _editingSpatialSid is the SID
+    // being edited, or MapScript::NONE (0xFFFFFFFF) when adding.
+    SpatialScriptDialog* _spatialScriptDialog = nullptr;
+    uint32_t _editingSpatialSid = 0xFFFFFFFFu;
     TilePalettePanel* _tilePalettePanel;
     ObjectPalettePanel* _objectPalettePanel;
     FileBrowserPanel* _fileBrowserPanel;

--- a/src/ui/core/VisibilitySettings.h
+++ b/src/ui/core/VisibilitySettings.h
@@ -22,6 +22,7 @@ struct VisibilitySettings {
     bool showHexGrid = UI::DEFAULT_SHOW_HEX_GRID;
     bool showLightOverlays = false;
     bool showExitGrids = false;
+    bool showSpatialScripts = false;
     // Merge touching same-category selected objects into one union outline (vs. one per object).
     bool mergeSelectionOutlines = true;
 };

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -33,7 +33,7 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<ScriptSelectorDialog:
     _tileSpin->setRange(0, HexagonGrid::POSITION_COUNT - 1);
     auto* tileRow = new QHBoxLayout();
     tileRow->addWidget(_tileSpin, 1);
-    auto* pickButton = new QPushButton("Pick on map...");
+    auto* pickButton = new QPushButton("Pick on map...", this);
     pickButton->setToolTip("Click a hex on the map to set the position");
     tileRow->addWidget(pickButton);
     formLayout->addRow("Hex tile:", tileRow);

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -12,6 +12,7 @@
 #include <QVBoxLayout>
 
 #include "editor/HexagonGrid.h"
+#include "ui/IconHelper.h"
 
 namespace geck {
 
@@ -34,6 +35,7 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<ScriptSelectorDialog:
     auto* tileRow = new QHBoxLayout();
     tileRow->addWidget(_tileSpin, 1);
     auto* pickButton = new QPushButton("Pick on map...", this);
+    pickButton->setIcon(createIcon(":/icons/actions/target-arrow.svg"));
     pickButton->setToolTip("Click a hex on the map to set the position");
     tileRow->addWidget(pickButton);
     formLayout->addRow("Hex tile:", tileRow);

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -62,6 +62,10 @@ void SpatialScriptDialog::onChooseScript() {
     if (index < 0) {
         return;
     }
+    selectProgram(index);
+}
+
+void SpatialScriptDialog::selectProgram(int index) {
     _programIndex = index;
     if (static_cast<size_t>(index) < _scripts.size()) {
         const ScriptSelectorDialog::Entry& entry = _scripts[static_cast<size_t>(index)];
@@ -73,8 +77,25 @@ void SpatialScriptDialog::onChooseScript() {
     } else {
         _scriptLabel->setText(QString("Script #%1").arg(index));
     }
-    _okButton->setEnabled(true);
+    _okButton->setEnabled(index >= 0);
 }
+
+void SpatialScriptDialog::setProgramIndex(int index) {
+    if (index >= 0) {
+        selectProgram(index);
+    }
+}
+
+void SpatialScriptDialog::setTile(int tile) { _tileSpin->setValue(tile); }
+
+void SpatialScriptDialog::setElevation(int elevation) {
+    const int comboIndex = _elevationCombo->findData(elevation);
+    if (comboIndex >= 0) {
+        _elevationCombo->setCurrentIndex(comboIndex);
+    }
+}
+
+void SpatialScriptDialog::setRadius(int radius) { _radiusSpin->setValue(radius); }
 
 int SpatialScriptDialog::tile() const { return _tileSpin->value(); }
 int SpatialScriptDialog::elevation() const { return _elevationCombo->currentData().toInt(); }

--- a/src/ui/dialogs/SpatialScriptDialog.cpp
+++ b/src/ui/dialogs/SpatialScriptDialog.cpp
@@ -31,7 +31,12 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<ScriptSelectorDialog:
 
     _tileSpin = new QSpinBox(this);
     _tileSpin->setRange(0, HexagonGrid::POSITION_COUNT - 1);
-    formLayout->addRow("Hex tile:", _tileSpin);
+    auto* tileRow = new QHBoxLayout();
+    tileRow->addWidget(_tileSpin, 1);
+    auto* pickButton = new QPushButton("Pick on map...");
+    pickButton->setToolTip("Click a hex on the map to set the position");
+    tileRow->addWidget(pickButton);
+    formLayout->addRow("Hex tile:", tileRow);
 
     _elevationCombo = new QComboBox(this);
     _elevationCombo->addItem("Elevation 1", 0);
@@ -50,6 +55,7 @@ SpatialScriptDialog::SpatialScriptDialog(const std::vector<ScriptSelectorDialog:
     _okButton = buttonBox->button(QDialogButtonBox::Ok);
     _okButton->setEnabled(false); // need a script first
     connect(chooseButton, &QPushButton::clicked, this, &SpatialScriptDialog::onChooseScript);
+    connect(pickButton, &QPushButton::clicked, this, &SpatialScriptDialog::pickPositionRequested);
     mainLayout->addWidget(buttonBox);
 }
 

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -27,12 +27,21 @@ public:
     int elevation() const;
     int radius() const;
 
+    // Pre-populate the fields so the dialog can edit an existing spatial script. setProgramIndex
+    // also updates the script label and enables OK (a chosen script is what OK requires).
+    void setProgramIndex(int index);
+    void setTile(int tile);
+    void setElevation(int elevation);
+    void setRadius(int radius);
+
     static constexpr int MAX_RADIUS = 50; // engine win_get_num_i range in map_scr_add_spatial
 
 private slots:
     void onChooseScript();
 
 private:
+    // Sets _programIndex, refreshes the script label from _scripts, and enables OK.
+    void selectProgram(int index);
     std::vector<ScriptSelectorDialog::Entry> _scripts;
     int _programIndex = -1;
 

--- a/src/ui/dialogs/SpatialScriptDialog.h
+++ b/src/ui/dialogs/SpatialScriptDialog.h
@@ -36,6 +36,11 @@ public:
 
     static constexpr int MAX_RADIUS = 50; // engine win_get_num_i range in map_scr_add_spatial
 
+signals:
+    /// The user clicked "Pick on map"; the host should let them click a hex and feed it back via
+    /// setTile()/setElevation(). The dialog is non-modal so the map stays interactive.
+    void pickPositionRequested();
+
 private slots:
     void onChooseScript();
 

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -29,8 +29,6 @@
 #include "resource/ScriptNames.h"
 #include "util/Coordinates.h"
 #include "ui/IconHelper.h"
-#include "ui/dialogs/ScriptSelectorDialog.h"
-#include "ui/dialogs/SpatialScriptDialog.h"
 #include "ui/widgets/IntCellDelegate.h"
 
 namespace geck {
@@ -920,21 +918,8 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
     if (!_map) {
         return;
     }
-
-    auto* scriptsLst = _resources.repository().load<Lst>(std::string(ResourcePaths::Lst::SCRIPTS));
-    if (!scriptsLst) {
-        QMessageBox::warning(this, "Add Spatial Script", "Could not load scripts.lst.");
-        return;
-    }
-
-    SpatialScriptDialog dialog(ScriptSelectorDialog::buildEntries(_resources), this);
-    if (dialog.exec() != QDialog::Accepted || dialog.programIndex() < 0) {
-        return;
-    }
-
-    // Direct (synchronous) connection: the script is created before this returns.
-    Q_EMIT addSpatialScriptRequested(dialog.programIndex(), dialog.tile(),
-        dialog.elevation(), dialog.radius());
+    // The dialog (with its map-pick flow) is owned by MainWindow, which brokers the map click.
+    Q_EMIT addSpatialScriptRequested();
 }
 
 void MapInfoPanel::onGlobalVarChanged(QTreeWidgetItem* item, int column) {

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -156,11 +156,11 @@ void MapInfoPanel::setupUI() {
     _playerPositionSpin = new QSpinBox();
     _playerPositionSpin->setRange(0, HexPosition::MAX_VALUE); // Max hex position
     _setPositionButton = new QPushButton();
-    _setPositionButton->setIcon(createIcon(":/icons/actions/map-pin.svg"));
+    _setPositionButton->setIcon(createIcon(":/icons/actions/target-arrow.svg"));
     _setPositionButton->setMaximumWidth(ui::constants::sizes::NAV_BUTTON);
     _setPositionButton->setToolTip("Click to select position on map");
     _centerViewButton = new QPushButton();
-    _centerViewButton->setIcon(createIcon(":/icons/actions/target-arrow.svg"));
+    _centerViewButton->setIcon(createIcon(":/icons/actions/map-pin.svg"));
     _centerViewButton->setMaximumWidth(ui::constants::sizes::NAV_BUTTON);
     _centerViewButton->setToolTip("Center view on player position");
     positionLayout->addWidget(_playerPositionSpin);

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -72,7 +72,7 @@ signals:
     /// are undoable. The confirmation dialog lives here in the panel.
     void clearElevationRequested(int elevation);
     void copyElevationRequested(int fromElevation, int toElevation);
-    void addSpatialScriptRequested(int programIndex, int tile, int elevation, int radius);
+    void addSpatialScriptRequested();
 
 private slots:
     void onFieldChanged();

--- a/src/ui/panels/ScriptsPanel.cpp
+++ b/src/ui/panels/ScriptsPanel.cpp
@@ -209,14 +209,15 @@ void ScriptsPanel::onCellDoubleClicked(int row) {
         return;
     }
 
-    // Double-clicking a spatial row edits it (it has no owning object to reveal); everything else
-    // navigates to its owning object.
-    if (MapScript::sidSection(sid) == static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+    // Double-clicking a spatial row edits it. Only object-owned script types (ITEM / CRITTER) can be
+    // navigated to; SYSTEM and TIMER scripts are ownerless, so a double-click there does nothing.
+    const int section = MapScript::sidSection(sid);
+    if (section == static_cast<int>(MapScript::ScriptType::SPATIAL)) {
         Q_EMIT spatialScriptEditRequested(sid);
-        return;
+    } else if (section == static_cast<int>(MapScript::ScriptType::ITEM)
+        || section == static_cast<int>(MapScript::ScriptType::CRITTER)) {
+        Q_EMIT scriptObjectActivated(static_cast<int>(sid));
     }
-
-    Q_EMIT scriptObjectActivated(static_cast<int>(sid));
 }
 
 void ScriptsPanel::onTableContextMenu(const QPoint& pos) {

--- a/src/ui/panels/ScriptsPanel.cpp
+++ b/src/ui/panels/ScriptsPanel.cpp
@@ -211,11 +211,10 @@ void ScriptsPanel::onCellDoubleClicked(int row) {
 
     // Double-clicking a spatial row edits it. Only object-owned script types (ITEM / CRITTER) can be
     // navigated to; SYSTEM and TIMER scripts are ownerless, so a double-click there does nothing.
-    const int section = MapScript::sidSection(sid);
-    if (section == static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+    const MapScript::ScriptType type = MapScript::fromPid(sid);
+    if (type == MapScript::ScriptType::SPATIAL) {
         Q_EMIT spatialScriptEditRequested(sid);
-    } else if (section == static_cast<int>(MapScript::ScriptType::ITEM)
-        || section == static_cast<int>(MapScript::ScriptType::CRITTER)) {
+    } else if (type == MapScript::ScriptType::ITEM || type == MapScript::ScriptType::CRITTER) {
         Q_EMIT scriptObjectActivated(static_cast<int>(sid));
     }
 }
@@ -223,16 +222,15 @@ void ScriptsPanel::onCellDoubleClicked(int row) {
 void ScriptsPanel::onTableContextMenu(const QPoint& pos) {
     const int row = _table->indexAt(pos).row();
     const uint32_t sid = sidOfRow(row);
-    if (sid == MapScript::NONE
-        || MapScript::sidSection(sid) != static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+    if (MapScript::fromPid(sid) != MapScript::ScriptType::SPATIAL) {
         return; // Edit/Delete are spatial-only (other scripts live on their owning object).
     }
 
     _table->selectRow(row); // right-click also selects, syncing the map highlight
 
     QMenu menu(this);
-    QAction* editAction = menu.addAction(tr("Edit Spatial Script..."));
-    QAction* deleteAction = menu.addAction(tr("Delete Spatial Script"));
+    const QAction* editAction = menu.addAction(tr("Edit Spatial Script..."));
+    const QAction* deleteAction = menu.addAction(tr("Delete Spatial Script"));
     const QAction* chosen = menu.exec(_table->viewport()->mapToGlobal(pos));
     if (chosen == editAction) {
         Q_EMIT spatialScriptEditRequested(sid);
@@ -295,8 +293,7 @@ void ScriptsPanel::onScriptSelectionChanged() {
     // Mirror the shared spatial selection: a spatial row selects that script on the map, anything
     // else clears it. Suppressed while a rebuild or a map-driven sync is churning the selection.
     if (!_suppressSpatialSelectionSignal) {
-        const bool spatial = sid != MapScript::NONE
-            && MapScript::sidSection(sid) == static_cast<int>(MapScript::ScriptType::SPATIAL);
+        const bool spatial = MapScript::fromPid(sid) == MapScript::ScriptType::SPATIAL;
         Q_EMIT spatialScriptSelected(spatial ? sid : MapScript::NONE);
     }
 

--- a/src/ui/panels/ScriptsPanel.cpp
+++ b/src/ui/panels/ScriptsPanel.cpp
@@ -10,6 +10,7 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMenu>
 #include <QSplitter>
 #include <QTableWidget>
 #include <QVBoxLayout>
@@ -81,10 +82,13 @@ ScriptsPanel::ScriptsPanel(resource::GameResources& resources, QWidget* parent)
     splitter->setStretchFactor(1, 1);
     mainLayout->addWidget(splitter);
 
+    _table->setContextMenuPolicy(Qt::CustomContextMenu);
+
     connect(_filterEdit, &QLineEdit::textChanged, this, &ScriptsPanel::applyFilter);
     connect(_table, &QTableWidget::cellDoubleClicked, this,
         [this](int row, int /*column*/) { onCellDoubleClicked(row); });
     connect(_table, &QTableWidget::itemSelectionChanged, this, &ScriptsPanel::onScriptSelectionChanged);
+    connect(_table, &QTableWidget::customContextMenuRequested, this, &ScriptsPanel::onTableContextMenu);
 }
 
 void ScriptsPanel::setMap(Map* map) {
@@ -93,6 +97,11 @@ void ScriptsPanel::setMap(Map* map) {
 }
 
 void ScriptsPanel::populate() {
+    // Clearing/refilling the table churns the selection, which would otherwise fire
+    // spatialScriptSelected(NONE) and clobber the map-side selection. Suppress those emits here;
+    // MainWindow re-asserts the selection after an edit if it should survive.
+    _suppressSpatialSelectionSignal = true;
+
     // Sorting must be off while inserting, or rows shuffle mid-build and setItem targets the wrong cell.
     _table->setSortingEnabled(false);
     _table->setRowCount(0);
@@ -100,6 +109,7 @@ void ScriptsPanel::populate() {
 
     if (_map == nullptr) {
         _table->setSortingEnabled(true);
+        _suppressSpatialSelectionSignal = false;
         return;
     }
 
@@ -139,6 +149,8 @@ void ScriptsPanel::populate() {
     _table->setSortingEnabled(true);
 
     applyFilter(); // a re-populate (map switch) must honour the filter still shown in the box
+
+    _suppressSpatialSelectionSignal = false;
 }
 
 void ScriptsPanel::addRow(const QString& section, int programIndex, qulonglong rowSid, qulonglong ownerOid,
@@ -190,19 +202,73 @@ void ScriptsPanel::applyFilter() {
 }
 
 void ScriptsPanel::onCellDoubleClicked(int row) {
-    const QTableWidgetItem* idItem = _table->item(row, COL_SCRIPT_ID);
-    if (idItem == nullptr) {
-        return;
-    }
-
-    // The owning script's SID is stashed in UserRole; NONE marks an ownerless row (spatial / timer /
-    // system scripts and the map's own header script), which has no object to navigate to.
-    const auto sid = static_cast<uint32_t>(idItem->data(Qt::UserRole).toULongLong());
+    // The row's SID is stashed in UserRole; NONE marks an ownerless row (the map's own header
+    // script), which has neither an object to navigate to nor an editable record.
+    const uint32_t sid = sidOfRow(row);
     if (sid == MapScript::NONE) {
         return;
     }
 
+    // Double-clicking a spatial row edits it (it has no owning object to reveal); everything else
+    // navigates to its owning object.
+    if (MapScript::sidSection(sid) == static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+        Q_EMIT spatialScriptEditRequested(sid);
+        return;
+    }
+
     Q_EMIT scriptObjectActivated(static_cast<int>(sid));
+}
+
+void ScriptsPanel::onTableContextMenu(const QPoint& pos) {
+    const int row = _table->indexAt(pos).row();
+    const uint32_t sid = sidOfRow(row);
+    if (sid == MapScript::NONE
+        || MapScript::sidSection(sid) != static_cast<int>(MapScript::ScriptType::SPATIAL)) {
+        return; // Edit/Delete are spatial-only (other scripts live on their owning object).
+    }
+
+    _table->selectRow(row); // right-click also selects, syncing the map highlight
+
+    QMenu menu(this);
+    QAction* editAction = menu.addAction(tr("Edit Spatial Script..."));
+    QAction* deleteAction = menu.addAction(tr("Delete Spatial Script"));
+    const QAction* chosen = menu.exec(_table->viewport()->mapToGlobal(pos));
+    if (chosen == editAction) {
+        Q_EMIT spatialScriptEditRequested(sid);
+    } else if (chosen == deleteAction) {
+        Q_EMIT spatialScriptDeleteRequested(sid);
+    }
+}
+
+uint32_t ScriptsPanel::sidOfRow(int row) const {
+    if (row < 0) {
+        return MapScript::NONE;
+    }
+    const QTableWidgetItem* idItem = _table->item(row, COL_SCRIPT_ID);
+    return idItem == nullptr ? MapScript::NONE
+                             : static_cast<uint32_t>(idItem->data(Qt::UserRole).toULongLong());
+}
+
+void ScriptsPanel::selectSpatialScriptRow(uint32_t sid) {
+    _suppressSpatialSelectionSignal = true;
+    if (sid == MapScript::NONE) {
+        _table->clearSelection();
+    } else {
+        int targetRow = -1;
+        for (int row = 0; row < _table->rowCount(); ++row) {
+            if (sidOfRow(row) == sid) {
+                targetRow = row;
+                break;
+            }
+        }
+        if (targetRow >= 0) {
+            _table->selectRow(targetRow);
+            _table->scrollToItem(_table->item(targetRow, COL_SCRIPT_ID));
+        } else {
+            _table->clearSelection();
+        }
+    }
+    _suppressSpatialSelectionSignal = false;
 }
 
 const MapScript* ScriptsPanel::scriptByPid(qulonglong sid) const {
@@ -223,17 +289,19 @@ void ScriptsPanel::onScriptSelectionChanged() {
     _localVarsTable->setRowCount(0);
 
     const int row = _table->currentRow();
-    if (row < 0) {
-        return;
-    }
-    const QTableWidgetItem* idItem = _table->item(row, COL_SCRIPT_ID);
-    if (idItem == nullptr) {
-        return;
+    const uint32_t sid = _table->selectionModel()->hasSelection() ? sidOfRow(row) : MapScript::NONE;
+
+    // Mirror the shared spatial selection: a spatial row selects that script on the map, anything
+    // else clears it. Suppressed while a rebuild or a map-driven sync is churning the selection.
+    if (!_suppressSpatialSelectionSignal) {
+        const bool spatial = sid != MapScript::NONE
+            && MapScript::sidSection(sid) == static_cast<int>(MapScript::ScriptType::SPATIAL);
+        Q_EMIT spatialScriptSelected(spatial ? sid : MapScript::NONE);
     }
 
     // Resolve the selected row back to its MapScript and show its slice of map_local_vars
     // (local_var_offset .. +local_var_count). Ownerless rows (the map-header row) resolve to nullptr.
-    const MapScript* script = scriptByPid(idItem->data(Qt::UserRole).toULongLong());
+    const MapScript* script = scriptByPid(sid);
     if (script == nullptr || script->local_var_offset == MapScript::NONE) {
         return;
     }

--- a/src/ui/panels/ScriptsPanel.h
+++ b/src/ui/panels/ScriptsPanel.h
@@ -2,6 +2,8 @@
 
 #include <QWidget>
 
+#include <cstdint>
+
 class QTableWidget;
 class QLineEdit;
 
@@ -28,16 +30,30 @@ public:
     /// Repopulate the table from `map`, or clear it when `map` is null.
     void setMap(Map* map);
 
+    /// Select the row for the spatial script with this SID (or clear the selection when it is
+    /// MapScript::NONE / not found). Used to mirror a map-side selection. Does not re-emit
+    /// spatialScriptSelected, so it is safe to call in response to that signal.
+    void selectSpatialScriptRow(uint32_t sid);
+
 signals:
     /// Emitted when the user double-clicks a row owned by a map object. `sid` is the
     /// script's SID (its owning object's `map_scripts_pid`). Ownerless rows (spatial /
     /// timer / system scripts and the map's own header script) emit nothing.
     void scriptObjectActivated(int sid);
 
+    /// A spatial-script row became the current selection (or MapScript::NONE when the current
+    /// row is not a spatial script). Drives the shared map/panel selection.
+    void spatialScriptSelected(uint32_t sid);
+    /// The user asked to edit / delete the spatial script with this SID (context menu or
+    /// double-click). Handled by MainWindow, which owns the dialog and command controller.
+    void spatialScriptEditRequested(uint32_t sid);
+    void spatialScriptDeleteRequested(uint32_t sid);
+
 private slots:
-    void applyFilter();                // hide rows that don't match _filterEdit; re-applied after every populate()
-    void onCellDoubleClicked(int row); // resolve the row's owning SID and emit scriptObjectActivated
-    void onScriptSelectionChanged();   // show the selected script's local variables
+    void applyFilter();                         // hide rows that don't match _filterEdit; re-applied after every populate()
+    void onCellDoubleClicked(int row);          // resolve the row's owning SID and emit scriptObjectActivated
+    void onScriptSelectionChanged();            // show the selected script's local variables + sync spatial selection
+    void onTableContextMenu(const QPoint& pos); // Edit/Delete menu for a spatial-script row
 
 private:
     void populate();
@@ -47,6 +63,8 @@ private:
         const QString& detail, const Lst* lst);
     // The map's script with this SID (its `pid`), or nullptr (e.g. the ownerless map-header row's NONE).
     const MapScript* scriptByPid(qulonglong sid) const;
+    // The SID stashed in row's Script-ID cell, or MapScript::NONE if the row/cell is missing.
+    uint32_t sidOfRow(int row) const;
 
     resource::GameResources& _resources;
     Map* _map = nullptr;
@@ -54,6 +72,10 @@ private:
     QLineEdit* _filterEdit;
     QTableWidget* _table;
     QTableWidget* _localVarsTable; // local variables (LVARs) of the currently selected script
+
+    // Guards selectSpatialScriptRow() against re-emitting spatialScriptSelected (feedback loop when
+    // the map-side selection drives the panel row and vice versa).
+    bool _suppressSpatialSelectionSignal = false;
 };
 
 } // namespace geck

--- a/tests/general/test_hex_geometry.cpp
+++ b/tests/general/test_hex_geometry.cpp
@@ -1,12 +1,20 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <cstdlib>
+#include <unordered_set>
 
 #include "editor/HexGeometry.h"
 
 using namespace geck::hexgrid;
 
 namespace {
+
+// Hex-step distance via the cube model, i.e. the engine's tileDistanceBetween.
+int cubeDistance(int a, int b) {
+    const Cube d = cubeOfPosition(a) - cubeOfPosition(b);
+    return (std::abs(d.x) + std::abs(d.y) + std::abs(d.z)) / 2;
+}
 
 // Unit cube vectors for the six Fallout 2 hex directions (derived so the even-q
 // offset<->cube conversion reproduces the engine's neighbour deltas).
@@ -98,4 +106,52 @@ TEST_CASE("translate reports positions that fall off the grid", "[hex_geometry]"
     const int toAnchor = 0 * WIDTH + 0;   // top-left corner
     const int authored = 98 * WIDTH + 98; // up-left of the authoring anchor
     CHECK_FALSE(translate(authored, fromAnchor, toAnchor).has_value());
+}
+
+TEST_CASE("hexesWithinRadius is the centre only at radius 0", "[hex_geometry]") {
+    const int center = 100 * WIDTH + 100;
+    const auto disc = hexesWithinRadius(center, 0);
+    REQUIRE(disc.size() == 1);
+    CHECK(disc[0] == center);
+}
+
+TEST_CASE("hexesWithinRadius yields the full disc away from edges", "[hex_geometry]") {
+    const int center = 100 * WIDTH + 100; // well interior for these radii
+    for (int radius = 1; radius <= 6; ++radius) {
+        INFO("radius " << radius);
+        const auto disc = hexesWithinRadius(center, radius);
+
+        // A complete hex disc has 3*R*(R+1) + 1 cells.
+        CHECK(disc.size() == static_cast<size_t>(3 * radius * (radius + 1) + 1));
+
+        const std::unordered_set<int> members(disc.begin(), disc.end());
+        CHECK(members.size() == disc.size()); // no duplicates
+        CHECK(members.contains(center));      // centre included
+
+        // Every returned hex is within the radius; no hex just outside it is included.
+        for (int h : disc) {
+            CHECK(cubeDistance(center, h) <= radius);
+        }
+        for (int d = 0; d < 6; ++d) {
+            CHECK(members.contains(stepInDirection(center, d))); // all 6 immediate neighbours present
+        }
+    }
+}
+
+TEST_CASE("hexesWithinRadius clips at the grid edge and stays in bounds", "[hex_geometry]") {
+    const int corner = 0; // top-left; most of a disc here is off-grid
+    const auto disc = hexesWithinRadius(corner, 3);
+
+    // Clipped, so fewer than a full disc, but non-empty and every hex is on-grid.
+    CHECK(disc.size() < static_cast<size_t>(3 * 3 * 4 + 1));
+    CHECK_FALSE(disc.empty());
+    for (int h : disc) {
+        CHECK(h >= 0);
+        CHECK(h < WIDTH * HEIGHT);
+        CHECK(cubeDistance(corner, h) <= 3);
+    }
+}
+
+TEST_CASE("hexesWithinRadius is empty for a negative radius", "[hex_geometry]") {
+    CHECK(hexesWithinRadius(100 * WIDTH + 100, -1).empty());
 }

--- a/tests/general/test_object_command_controller.cpp
+++ b/tests/general/test_object_command_controller.cpp
@@ -10,6 +10,7 @@
 #include "format/map/MapObject.h"
 #include "format/map/MapScript.h"
 #include "editing/commands/ObjectCommandController.h"
+#include "util/BuiltTile.h"
 
 #include "support/ControllerFixture.h"
 
@@ -19,6 +20,7 @@ using geck::test::ControllerFixture;
 namespace {
 
 constexpr int ITEM_SECTION = static_cast<int>(MapScript::ScriptType::ITEM);
+constexpr int SPATIAL_SECTION = static_cast<int>(MapScript::ScriptType::SPATIAL);
 
 // Adds an object on `elevation` carrying an attached ITEM script and returns it.
 std::shared_ptr<MapObject> addScriptedObject(ControllerFixture& fx, int elevation, uint32_t oid, uint32_t scriptIndex) {
@@ -188,6 +190,85 @@ TEST_CASE("attachScript and detachScript are undoable", "[undo][controller]") {
     REQUIRE(fx.undoStack.undo());
     CHECK(fx.mapFile().map_scripts[ITEM_SECTION].size() == 1);
     CHECK(obj->map_scripts_pid == expectedSid);
+}
+
+TEST_CASE("editSpatialScript edits in place, keeps the SID, and is undoable", "[undo][controller][spatial]") {
+    ControllerFixture fx;
+    REQUIRE(fx.mapFile().map_scripts[SPATIAL_SECTION].empty());
+
+    // First spatial script in an empty section gets index 0, so the SID is deterministic.
+    const uint32_t sid = MapScript::makeSid(MapScript::ScriptType::SPATIAL, 0);
+    REQUIRE(fx.controller.addSpatialScript(/*programIndex*/ 7, /*tile*/ 100, /*elevation*/ 1, /*radius*/ 3));
+    REQUIRE(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 1);
+
+    const MapScript* found = fx.controller.findSpatialScript(sid);
+    REQUIRE(found != nullptr);
+    CHECK(found->script_id == 7u);
+    CHECK(found->spatial_radius == 3u);
+    CHECK(built_tile::tileOf(found->timer) == 100u);
+    CHECK(built_tile::elevationOf(found->timer) == 1u);
+
+    // Edit in place: new program index, position and radius; the SID must not change.
+    REQUIRE(fx.controller.editSpatialScript(sid, /*programIndex*/ 9, /*tile*/ 250, /*elevation*/ 2, /*radius*/ 6));
+    REQUIRE(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 1);
+    const MapScript* edited = fx.controller.findSpatialScript(sid);
+    REQUIRE(edited != nullptr);
+    CHECK(edited->pid == sid);
+    CHECK(edited->script_id == 9u);
+    CHECK(edited->spatial_radius == 6u);
+    CHECK(built_tile::tileOf(edited->timer) == 250u);
+    CHECK(built_tile::elevationOf(edited->timer) == 2u);
+
+    // Undo restores the original values (still one script, same SID).
+    REQUIRE(fx.undoStack.undo());
+    const MapScript* reverted = fx.controller.findSpatialScript(sid);
+    REQUIRE(reverted != nullptr);
+    CHECK(reverted->script_id == 7u);
+    CHECK(reverted->spatial_radius == 3u);
+    CHECK(built_tile::tileOf(reverted->timer) == 100u);
+
+    // Redo re-applies the edit.
+    REQUIRE(fx.undoStack.redo());
+    const MapScript* redone = fx.controller.findSpatialScript(sid);
+    REQUIRE(redone != nullptr);
+    CHECK(redone->spatial_radius == 6u);
+    CHECK(built_tile::tileOf(redone->timer) == 250u);
+}
+
+TEST_CASE("removeSpatialScript deletes by SID and undo restores it", "[undo][controller][spatial]") {
+    ControllerFixture fx;
+    REQUIRE(fx.controller.addSpatialScript(/*programIndex*/ 5, /*tile*/ 42, /*elevation*/ 0, /*radius*/ 2));
+    REQUIRE(fx.controller.addSpatialScript(/*programIndex*/ 6, /*tile*/ 99, /*elevation*/ 0, /*radius*/ 4));
+    REQUIRE(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 2);
+
+    const uint32_t firstSid = MapScript::makeSid(MapScript::ScriptType::SPATIAL, 0);
+    REQUIRE(fx.controller.findSpatialScript(firstSid) != nullptr);
+
+    REQUIRE(fx.controller.removeSpatialScript(firstSid));
+    CHECK(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 1);
+    CHECK(fx.controller.findSpatialScript(firstSid) == nullptr);
+
+    REQUIRE(fx.undoStack.undo());
+    CHECK(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 2);
+    const MapScript* restored = fx.controller.findSpatialScript(firstSid);
+    REQUIRE(restored != nullptr);
+    CHECK(restored->script_id == 5u);
+    CHECK(restored->spatial_radius == 2u);
+
+    REQUIRE(fx.undoStack.redo());
+    CHECK(fx.mapFile().map_scripts[SPATIAL_SECTION].size() == 1);
+    CHECK(fx.controller.findSpatialScript(firstSid) == nullptr);
+}
+
+TEST_CASE("editSpatialScript and removeSpatialScript reject unknown SIDs", "[undo][controller][spatial]") {
+    ControllerFixture fx;
+    const uint32_t missing = MapScript::makeSid(MapScript::ScriptType::SPATIAL, 3);
+    CHECK_FALSE(fx.controller.removeSpatialScript(missing));
+    CHECK_FALSE(fx.controller.editSpatialScript(missing, 1, 0, 0, 1));
+    // A non-spatial SID must be rejected outright.
+    const uint32_t itemSid = MapScript::makeSid(MapScript::ScriptType::ITEM, 0);
+    CHECK_FALSE(fx.controller.removeSpatialScript(itemSid));
+    CHECK(fx.controller.findSpatialScript(itemSid) == nullptr);
 }
 
 TEST_CASE("registerInventoryEdit restores inventory snapshots", "[undo][controller]") {


### PR DESCRIPTION
Spatial scripts (hex trigger zones with a position + radius) could be *created* but were otherwise **invisible and untouchable** once placed. This PR makes them a first-class, editable map element: a read-only overlay to see them, plus a shared map/panel selection with undoable edit and delete. Closes the feature-gap audit item #2 and Known-limitation #3.

*(Supersedes #101, which was the read-only overlay on its own; its commits are included here.)*

## 1. Visualize (the overlay)

`View › Show Spatial Scripts` draws, for each spatial script on the current elevation:
- the engine's own green marker (`art/intrface/msef001.frm`) centred on the script's hex, and
- a translucent **hex-distance** radius disc.

Grounded in fallout2-ce before coding: the marker art (`mp_scrpt.cc`), that the packed `built_tile` position is a **hex** index (not a floor tile — the CLAUDE.md trap) with elevation in the high bits, and that the trigger radius is `tileDistanceBetween(centre, hex) <= radius`. The disc uses a new headless `hexgrid::hexesWithinRadius` that reproduces that metric (unit-tested against distance / count / edge-clipping / the six neighbours). Rendered as a viewport-culled layer in `RenderingEngine::renderSpatialScripts`, modelled on the exit-grid overlay; the marker load is guarded so missing art degrades to a plain hex.

## 2. Select / edit / delete (shared map + panel)

| | Map | Scripts panel |
|---|---|---|
| **Select** | click a marker (overlay visible) → turns **amber** | select its row |
| **Edit** | double-click the marker | double-click row / right-click → Edit |
| **Delete** | `Delete` / `Backspace` | right-click → Delete |

Both surfaces write one shared `EditorSession::selectedSpatialScriptSid`, keyed on the script's **SID (`pid`)**; the selected marker + disc render amber and the panel row mirrors the map (a suppression flag breaks the sync feedback loop). Map selection is gated on the overlay being visible and is exclusive with object/tile selection; hiding the overlay clears it (so `Delete` can never remove an invisible script).

- **`ScriptEditService`** gains `editSpatialScript` (in place, so the SID + live selection survive) and `removeSpatialScript`, both undoable via the existing `snapshot`+`recordScriptEdit` path, plus a `findSpatialScript` reader — exposed through `ObjectCommandController` → `EditorWidget`.
- **`SpatialScriptDialog`** gets setters so the Add dialog doubles as a pre-filled Edit dialog.
- **`MainWindow`** wires the two surfaces together, owns the edit dialog, and refreshes the panel after add/edit/delete and undo/redo.

## Testing

- **`test_hex_geometry.cpp`** — `hexesWithinRadius` (radius 0, full-disc count `3R(R+1)+1`, membership ≤ R, six neighbours, edge-clipping, negative radius).
- **`test_object_command_controller.cpp`** — `[spatial]` cases: edit-in-place keeps the SID + undo/redo round-trips; delete-by-SID + undo restores; unknown / non-spatial SIDs rejected.
- Full suite **369/369**; all targets build clean (Linux/Windows/macOS × Debug/Release green).
- **Visually verified** both the overlay and the amber selection highlight by rendering Toxic Caves through the real `RenderingEngine` (correct hex + elevation; selected = amber, others = green).

## Review fixes already applied
- Map `Delete` only removes a spatial script while its overlay is visible; hiding clears the selection.
- Scripts-panel double-click navigates to an object only for owner-bearing types (Item/Critter); System/Timer rows are ownerless and do nothing.

## Follow-up (out of scope)
- MapInfoPanel's script *counts* aren't force-refreshed on add/edit/delete (same as the pre-existing Add flow); the Scripts panel (detail view) is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)