### PR TITLE
Persist panel layout reliably and widen default dock columns

### DIFF
--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -121,14 +121,6 @@ QJsonObject Settings::toJson() const {
         ui["floatingDockGeometries"] = floatingDocks;
     }
 
-    if (!_panelVisibilityPreferences.isEmpty()) {
-        QJsonObject panelVisibility;
-        for (auto it = _panelVisibilityPreferences.begin(); it != _panelVisibilityPreferences.end(); ++it) {
-            panelVisibility[it.key()] = it.value();
-        }
-        ui["panelVisibility"] = panelVisibility;
-    }
-
     json["ui"] = ui;
 
     QJsonObject textEditor;
@@ -199,14 +191,6 @@ void Settings::fromJson(const QJsonObject& json) {
             QJsonObject floatingDocks = ui["floatingDockGeometries"].toObject();
             for (auto it = floatingDocks.begin(); it != floatingDocks.end(); ++it) {
                 _floatingDockGeometries[it.key()] = QByteArray::fromBase64(it.value().toString().toLatin1());
-            }
-        }
-
-        if (ui.contains("panelVisibility")) {
-            QJsonObject panelVisibility = ui["panelVisibility"].toObject();
-            _panelVisibilityPreferences.clear();
-            for (auto it = panelVisibility.begin(); it != panelVisibility.end(); ++it) {
-                _panelVisibilityPreferences[it.key()] = it.value().toBool(true);
             }
         }
     }
@@ -348,18 +332,6 @@ QByteArray Settings::getDockState() const {
 
 void Settings::setDockState(const QByteArray& state) {
     _dockState = state;
-}
-
-std::optional<bool> Settings::getPanelVisibilityPreference(const QString& panelName) const {
-    auto it = _panelVisibilityPreferences.find(panelName);
-    if (it != _panelVisibilityPreferences.end()) {
-        return it.value();
-    }
-    return std::nullopt;
-}
-
-void Settings::setPanelVisibilityPreference(const QString& panelName, bool visible) {
-    _panelVisibilityPreferences[panelName] = visible;
 }
 
 QByteArray Settings::getFloatingDockGeometry(const QString& dockName) const {

--- a/src/ui/Settings.h
+++ b/src/ui/Settings.h
@@ -10,7 +10,6 @@
 #include <QByteArray>
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace geck {
@@ -49,10 +48,6 @@ public:
 
     QByteArray getDockState() const;
     void setDockState(const QByteArray& state);
-
-    // Panel visibility preferences
-    std::optional<bool> getPanelVisibilityPreference(const QString& panelName) const;
-    void setPanelVisibilityPreference(const QString& panelName, bool visible);
 
     // Window state (normal/maximized)
     bool getWindowMaximized() const;
@@ -129,7 +124,6 @@ private:
     bool _mergeSelectionOutlines = true; // Default: merge touching same-category outlines
     bool _edgeScrollEnabled = true;      // Default: auto-scroll when the cursor rests near an edge
     QMap<QString, QByteArray> _floatingDockGeometries;
-    QMap<QString, bool> _panelVisibilityPreferences;
     QString _version;
 
     // Text editor configuration

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -126,8 +126,8 @@ MainWindow::MainWindow(std::shared_ptr<resource::GameResources> resources, std::
 
     restoreDockWidgetState();
 
-    // Capture the restored visibility, then hide panels until a map is loaded
-    snapshotPanelVisibility();
+    // restoreDockWidgetState() seeded _restoredDockState with the working layout; hide the panels
+    // until a map is loaded (welcome screen). showPanelsForMap() re-applies the layout on map open.
     hidePanelsForNoMap();
 
     // Reflect actual visibility once restoration settles
@@ -168,9 +168,8 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
 
     if (_currentEditorWidget->getMap()) {
         updateMapInfo(_currentEditorWidget->getMap());
-        restorePanelVisibilitySnapshot();
+        showPanelsForMap();
     } else {
-        snapshotPanelVisibility();
         hidePanelsForNoMap();
     }
 
@@ -307,14 +306,14 @@ QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* doc
     QAction* action = actionRef;
 
     connect(action, &QAction::toggled, this, [this, dock, showDock](bool visible) {
-        if (_suppressPanelPreferenceUpdates) {
+        if (_suppressDockStateSave) {
             return;
         }
 
         spdlog::debug("{} action toggled: {}", dock->windowTitle().toStdString(), visible);
+        // showDock() flips the dock, which fires QDockWidget::visibilityChanged below; that handler
+        // persists the new layout, so there's nothing to save here.
         showDock(dock, visible);
-        snapshotPanelVisibility();
-        persistPanelPreference(dock, visible);
     });
 
     connect(dock, &QDockWidget::visibilityChanged, this, [this, dock, action](bool visible) {
@@ -328,9 +327,11 @@ QAction* MainWindow::addPanelToggleAction(const QString& label, QDockWidget* doc
             QSignalBlocker blocker(*action);
             action->setChecked(dockVisible);
         }
-        if (!_suppressPanelPreferenceUpdates) {
-            snapshotPanelVisibility();
-            persistPanelPreference(dock, dockVisible);
+        // A genuine user show/hide updates the persisted dock layout immediately, so it survives even
+        // a non-clean exit (e.g. the app being killed to recompile). saveDockWidgetState() is a no-op
+        // while re-laying-out programmatically or when no map is open.
+        if (!_suppressDockStateSave) {
+            saveDockWidgetState();
         }
     });
 
@@ -398,6 +399,12 @@ void MainWindow::applyDefaultPanelDockLayout() {
     if (_tilePaletteDock) {
         _tilePaletteDock->raise();
     }
+
+    // Give each dock column enough width to show its panel content (e.g. the Map Info form) without a
+    // horizontal scrollbar. Only applied to the default layout; a restored layout keeps the user's own
+    // widths, so this never fights a manual resize.
+    const int preferredWidth = ui::constants::sizes::PANEL_PREFERRED_WIDTH;
+    resizeDocks({ _mapInfoDock, _tilePaletteDock }, { preferredWidth, preferredWidth }, Qt::Horizontal);
 }
 
 void MainWindow::setupMenuBar() {
@@ -1298,8 +1305,10 @@ void MainWindow::closeEvent(QCloseEvent* event) {
         event->ignore(); // user cancelled the quit to keep their unsaved map
         return;
     }
-    _suppressPanelPreferenceUpdates = true;
-    _suppressPanelSnapshotUpdates = true;
+    // Persist the layout on a normal quit; the destructor runs too late/unreliably (skipped entirely
+    // when the process is killed). saveDockWidgetState() no-ops when no map is open (welcome screen).
+    saveDockWidgetState();
+    _suppressDockStateSave = true; // teardown: closing docks must not rewrite the saved layout
     stopGameLoop();
     event->accept();
 }
@@ -1950,8 +1959,17 @@ void MainWindow::setupPanelsMenu() {
 }
 
 void MainWindow::saveDockWidgetState() {
+    // The saved dock state is the user's working layout with a map open. While no map is open the
+    // panels are transiently hidden (welcome screen) and _suppressDockStateSave guards programmatic
+    // relayout, so in both cases we must not overwrite the saved layout with a transient one.
+    if (_suppressDockStateSave || !_currentEditorWidget || !_currentEditorWidget->getMap()) {
+        return;
+    }
+
     auto& settings = *_settings;
-    settings.setDockState(saveState());
+    const QByteArray state = saveState();
+    _restoredDockState = state; // re-shown verbatim by showPanelsForMap() when the next map opens
+    settings.setDockState(state);
     settings.setWindowGeometry(saveGeometry());
     settings.setWindowMaximized(isMaximized());
 
@@ -1981,6 +1999,7 @@ void MainWindow::restoreDockWidgetState() {
     QByteArray state = settings.getDockState();
     if (!state.isEmpty()) {
         restoreState(state);
+        _restoredDockState = state; // the layout to re-show once a map opens (see showPanelsForMap)
 
         // Restore individual floating dock widget geometries after a short delay
         // This ensures the dock widgets are fully initialized first
@@ -2004,6 +2023,7 @@ void MainWindow::restoreDockWidgetState() {
         spdlog::debug("Restored dock widget state and window geometry");
     } else {
         restoreDefaultLayout();
+        _restoredDockState = saveState(); // no saved layout: remember the default to re-show on map open
         spdlog::debug("No saved state found, using default dock widget layout");
     }
 }
@@ -2020,8 +2040,8 @@ void MainWindow::setDockVisibility(QDockWidget* dock, QAction* action, bool visi
         return;
     }
 
-    const bool previousPreferenceSuppression = _suppressPanelPreferenceUpdates;
-    _suppressPanelPreferenceUpdates = true;
+    const bool previousSuppression = _suppressDockStateSave;
+    _suppressDockStateSave = true; // programmatic show/hide is not a user layout change
 
     if (action) {
         QSignalBlocker blocker(*action);
@@ -2030,87 +2050,25 @@ void MainWindow::setDockVisibility(QDockWidget* dock, QAction* action, bool visi
 
     dock->setVisible(visible);
 
-    _suppressPanelPreferenceUpdates = previousPreferenceSuppression;
+    _suppressDockStateSave = previousSuppression;
 }
 
-void MainWindow::persistPanelPreference(QDockWidget* dock, bool visible) {
-    if (_suppressPanelPreferenceUpdates || !dock) {
-        return;
+void MainWindow::showPanelsForMap() {
+    // Re-apply the persisted dock layout (visibility + geometry) that was hidden for the welcome
+    // screen. Suppress saving so re-applying it isn't mistaken for a user change.
+    const bool previousSuppression = _suppressDockStateSave;
+    _suppressDockStateSave = true;
+    if (!_restoredDockState.isEmpty()) {
+        restoreState(_restoredDockState);
     }
-
-    // For tabified docks, visibilityChanged(false) can fire when the dock just loses focus.
-    // Treat only truly hidden docks (isHidden == true) as user intent to hide.
-    if (!visible && !dock->isHidden()) {
-        return;
-    }
-
-    const bool isShown = !dock->isHidden();
-
-    auto& settings = *_settings;
-    const QString dockName = dock->objectName();
-    if (dockName.isEmpty()) {
-        return;
-    }
-
-    auto preference = settings.getPanelVisibilityPreference(dockName);
-    if (!preference.has_value() || preference.value() != isShown) {
-        settings.setPanelVisibilityPreference(dockName, isShown);
-        settings.save();
-    }
-}
-
-void MainWindow::snapshotPanelVisibility() {
-    if (_suppressPanelSnapshotUpdates) {
-        return;
-    }
-
-    auto isPanelEnabled = [](QAction* action, QDockWidget* dock) {
-        if (action) {
-            return action->isChecked();
-        }
-        return dock && dock->isVisible();
-    };
-
-    for (const auto& [dock, action] : managedDockActionPairs()) {
-        if (dock) {
-            _panelVisibilitySnapshot[dock] = isPanelEnabled(action, dock);
-        }
-    }
-}
-
-void MainWindow::restorePanelVisibilitySnapshot() {
-    if (_panelVisibilitySnapshot.empty()) {
-        snapshotPanelVisibility();
-    }
-
-    auto& settings = *_settings;
-
-    auto applySnapshot = [&](QDockWidget* dock, QAction* action) {
-        if (!dock) {
-            return;
-        }
-        const auto it = _panelVisibilitySnapshot.find(dock);
-        bool visible = (it != _panelVisibilitySnapshot.end()) ? it->second : !dock->isHidden();
-
-        if (auto preference = settings.getPanelVisibilityPreference(dock->objectName()); preference.has_value()) {
-            visible = preference.value();
-        }
-        setDockVisibility(dock, action, visible);
-    };
-
-    for (const auto& [dock, action] : managedDockActionPairs()) {
-        applySnapshot(dock, action);
-    }
+    _suppressDockStateSave = previousSuppression;
 
     updatePanelMenuActions();
-    snapshotPanelVisibility();
 }
 
 void MainWindow::hidePanelsForNoMap() {
-    const bool previousSuppression = _suppressPanelSnapshotUpdates;
-    const bool previousPreferenceSuppression = _suppressPanelPreferenceUpdates;
-    _suppressPanelSnapshotUpdates = true;
-    _suppressPanelPreferenceUpdates = true;
+    const bool previousSuppression = _suppressDockStateSave;
+    _suppressDockStateSave = true; // hiding for the welcome screen must not overwrite the saved layout
 
     for (const auto& [dock, action] : managedDockActionPairs()) {
         setDockVisibility(dock, action, dock == _fileBrowserDock);
@@ -2120,8 +2078,7 @@ void MainWindow::hidePanelsForNoMap() {
         _fileBrowserDock->raise();
     }
 
-    _suppressPanelSnapshotUpdates = previousSuppression;
-    _suppressPanelPreferenceUpdates = previousPreferenceSuppression;
+    _suppressDockStateSave = previousSuppression;
 }
 
 void MainWindow::updatePanelMenuActions() {
@@ -2175,12 +2132,6 @@ QIcon MainWindow::themedIcon(const QString& iconPath) const {
     return QIcon(pixmap);
 }
 
-void MainWindow::hideNonEssentialPanels() {
-    spdlog::debug("Hiding non-essential panels (no map loaded)");
-    snapshotPanelVisibility();
-    hidePanelsForNoMap();
-}
-
 void MainWindow::refreshFileBrowser() {
     if (_fileBrowserPanel) {
         spdlog::debug("Refreshing file browser after data loading");
@@ -2195,8 +2146,6 @@ void MainWindow::showFileBrowserPanel() {
 
     // File browser is tabified with the tile/object palettes; focusing it makes it the active tab
     _fileBrowserDock->widget()->setFocus();
-
-    snapshotPanelVisibility();
 
     spdlog::debug("File browser panel shown and raised");
 }

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -11,12 +11,12 @@
 #include <QStatusBar>
 #include <QLabel>
 #include <QSettings>
+#include <QByteArray>
 #include <QMenu>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <filesystem>
-#include <unordered_map>
 #include <utility>
 #include <SFML/Window/Event.hpp>
 
@@ -69,7 +69,6 @@ public:
     void applySelectionColorsToEditor();
 
     // Panel visibility management
-    void hideNonEssentialPanels();
     void refreshFileBrowser();
     void showFileBrowserPanel();
 
@@ -160,7 +159,6 @@ private:
     void updatePanelMenuActions();
     void updateElevationMenu(Map* map);
     void syncMenuStateToEditorWidget();
-    void snapshotPanelVisibility();
     void updateUndoRedoActions();
     // Enables "Fill Selection…" only when a map is open and the selection has a fillable layer
     // (floor/roof tiles or hexes). Hooked to selectionChanged and re-seeded on map switch.
@@ -173,10 +171,11 @@ private:
     /// to discard the map (saved or explicitly discarded), false if the user cancelled.
     bool maybeSaveChanges();
     QIcon themedIcon(const QString& iconPath) const;
-    void restorePanelVisibilitySnapshot();
+    // A map just opened: re-apply the persisted dock layout that was transiently hidden for the
+    // welcome screen (no map). Restores from the saved Qt dock state, the single source of truth.
+    void showPanelsForMap();
     void hidePanelsForNoMap();
     void setDockVisibility(QDockWidget* dock, QAction* action, bool visible);
-    void persistPanelPreference(QDockWidget* dock, bool visible);
     QAction* addPanelToggleAction(const QString& label, QDockWidget* dock, QAction*& actionRef);
     std::array<QDockWidget*, 6> managedDocks() const;
     std::array<DockActionPair, 6> managedDockActionPairs() const;
@@ -268,9 +267,13 @@ private:
     QDockWidget* _scriptConsoleDock = nullptr;
     ScriptConsoleWidget* _scriptConsole = nullptr;
 #endif
-    std::unordered_map<QDockWidget*, bool> _panelVisibilitySnapshot;
-    bool _suppressPanelSnapshotUpdates = false;
-    bool _suppressPanelPreferenceUpdates = false;
+    // Guards the persisted dock layout while docks are re-laid-out programmatically (hidden for the
+    // welcome screen, re-shown for a map), so those transient changes aren't written back as if the
+    // user made them.
+    bool _suppressDockStateSave = false;
+    // The dock layout (visibility + geometry) to re-apply when a map opens; seeded at startup from the
+    // saved state and refreshed on every genuine user change. See saveDockWidgetState/showPanelsForMap.
+    QByteArray _restoredDockState;
     bool _mapModified = false; // current map has edits not yet written to disk
 
     // Panel widgets


### PR DESCRIPTION
## Problem

Two panel/dock annoyances:

1. **Panels don't persist** — panels that were open before a restart came back hidden. Especially noticeable when recompiling from an IDE, because the app is *killed* rather than closed cleanly.
2. **Map Info opens too narrow** — the panel showed a horizontal scrollbar because the default dock column was squeezed below the content width.

## Why (1) happened

Panel visibility + geometry were spread across **three** overlapping mechanisms that fought each other:

| Mechanism | Saved | Problem |
|---|---|---|
| Qt `saveState()`/`restoreState()` | only in the destructor | skipped on a non-clean exit (IDE kill) |
| per-panel visibility *preference* (Settings) | live, on explicit toggle | default-visible panels never got one |
| in-memory *snapshot* | session only | not persisted |

## Fix

Consolidate on Qt's `saveState()`/`restoreState()` as the **single source of truth** for both layout and visibility:

- Save the dock state **immediately on every genuine user show/hide** (survives a kill) and again **on close**, instead of only in the destructor.
- Keep *"hide panels while no map is open"* as a **transient** display state — the saved layout is re-applied from the persisted state when a map opens (`showPanelsForMap`).
- **Remove** the redundant per-panel visibility preference (Settings API + JSON serialization) and the in-memory snapshot.

Net: **58 insertions, 140 deletions.**

## Map Info width

Size the default dock columns to the panels' preferred width via `resizeDocks` in the default-layout path only, so Map Info shows its form without a horizontal scrollbar — and a **restored** layout still keeps the user's own widths.

## Testing

- `369/369` tests pass; clean Release build.
- ⚠️ The panel show/hide/restart cycle is native-GUI and can't be verified headlessly. Worth a manual check: arrange panels with a map open → quit (or kill) → relaunch → open a map → the layout returns; and Map Info opens wide enough on a fresh layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)