### PR TITLE
Tolerate missing tile art on map load; add resource-inspection tools

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -631,6 +631,8 @@ if(GECK_BUILD_CLI)
         cli/MapRender.cpp
         cli/FrmInspect.h
         cli/FrmInspect.cpp
+        cli/ResourceInspect.h
+        cli/ResourceInspect.cpp
         cli/PatternJson.h
         cli/PatternJson.cpp
         cli/PatternExtract.h

--- a/src/cli/ResourceInspect.cpp
+++ b/src/cli/ResourceInspect.cpp
@@ -13,6 +13,8 @@
 #include <nlohmann/json.hpp>
 
 #include <cctype>
+#include <cstdint>
+#include <optional>
 #include <ostream>
 #include <regex>
 #include <set>

--- a/src/cli/ResourceInspect.cpp
+++ b/src/cli/ResourceInspect.cpp
@@ -1,0 +1,199 @@
+#include "cli/ResourceInspect.h"
+
+#include "cli/MapLoad.h"
+#include "format/lst/Lst.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/Tile.h"
+#include "resource/DataFileSystem.h"
+#include "resource/FrmResolver.h"
+#include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cctype>
+#include <ostream>
+#include <regex>
+#include <set>
+#include <string>
+
+using json = nlohmann::json;
+
+namespace geck::cli {
+
+namespace {
+
+    // JSON for a resolved source, or null when the path isn't mounted.
+    json sourceInfoJson(const std::optional<resource::MountedSourceInfo>& info) {
+        if (!info) {
+            return nullptr;
+        }
+        const char* kind = info->kind == resource::MountedSourceInfo::Kind::Dat ? "dat" : "directory";
+        return json{ { "kind", kind }, { "path", info->sourcePath.generic_string() }, { "label", info->displayLabel } };
+    }
+
+    // Compile a glob ('*','?') into a case-insensitive substring matcher. Substring (not fully
+    // anchored) so a user pattern matches regardless of the VFS's leading slash / alias prefix:
+    // "art/tiles/gras*" and "gras03*" both find "/art/tiles/gras030.frm". Every other regex
+    // metacharacter is escaped so a path is matched literally.
+    std::regex compileGlob(const std::string& glob) {
+        std::string pattern;
+        pattern.reserve(glob.size() * 2);
+        for (char ch : glob) {
+            switch (ch) {
+                case '*':
+                    pattern.append(".*");
+                    break;
+                case '?':
+                    pattern.push_back('.');
+                    break;
+                case '.':
+                case '\\':
+                case '+':
+                case '(':
+                case ')':
+                case '[':
+                case ']':
+                case '{':
+                case '}':
+                case '^':
+                case '$':
+                case '|':
+                    pattern.push_back('\\');
+                    pattern.push_back(ch);
+                    break;
+                default:
+                    pattern.push_back(ch);
+                    break;
+            }
+        }
+        return std::regex(pattern, std::regex::icase);
+    }
+
+} // namespace
+
+int resourceFind(resource::GameResources& resources, const std::string& path, std::ostream& out) {
+    auto& files = resources.files();
+    const bool found = files.exists(path);
+    json result{
+        { "path", path },
+        { "found", found },
+        { "source", sourceInfoJson(found ? files.sourceInfo(path) : std::nullopt) },
+    };
+    out << result.dump() << "\n";
+    return 0; // "not found" is a valid answer, not a failure
+}
+
+int resourceList(resource::GameResources& resources, const std::string& glob, std::ostream& out) {
+    // Cap the reported entries so a broad glob (or "*") can't dump tens of thousands of lines; the
+    // 'truncated' flag tells the caller the match set was larger.
+    constexpr std::size_t kMaxEntries = 2000;
+
+    auto& files = resources.files();
+    const std::regex matcher = compileGlob(glob);
+
+    auto entries = json::array();
+    std::size_t matched = 0;
+    for (const auto& entry : files.list("*")) {
+        if (!std::regex_search(entry.generic_string(), matcher)) {
+            continue;
+        }
+        ++matched;
+        if (entries.size() < kMaxEntries) {
+            entries.push_back({ { "path", entry.generic_string() }, { "source", sourceInfoJson(files.sourceInfo(entry)) } });
+        }
+    }
+
+    json result{
+        { "pattern", glob },
+        { "count", matched },
+        { "truncated", matched > kMaxEntries },
+        { "entries", std::move(entries) },
+    };
+    out << result.dump() << "\n";
+    return 0;
+}
+
+int resourceMissing(resource::GameResources& resources, const std::string& mapPath, std::ostream& out) {
+    auto map = cli::loadMap(resources, mapPath);
+    if (!map) {
+        out << json{ { "map", mapPath }, { "error", "could not read or parse map" } }.dump() << "\n";
+        return 1;
+    }
+
+    auto& files = resources.files();
+
+    // --- Tiles: distinct floor/roof ids across every elevation -> tiles.lst filename -> exists? ---
+    std::set<int> usedTileIds;
+    for (const auto& [elevation, tiles] : map->getMapFile().tiles) {
+        for (const auto& tile : tiles) {
+            if (tile.getFloor() != Map::EMPTY_TILE) {
+                usedTileIds.insert(tile.getFloor());
+            }
+            if (tile.getRoof() != Map::EMPTY_TILE) {
+                usedTileIds.insert(tile.getRoof());
+            }
+        }
+    }
+
+    const Lst* tilesLst = nullptr;
+    try {
+        tilesLst = resources.repository().load<Lst>(std::string(ResourcePaths::Lst::TILES));
+    } catch (const std::exception&) {
+        tilesLst = nullptr; // reported below as an unresolved tiles.lst
+    }
+
+    auto missingTiles = json::array();
+    for (int id : usedTileIds) {
+        if (tilesLst == nullptr) {
+            missingTiles.push_back({ { "id", id }, { "art", nullptr }, { "reason", "tiles.lst not mounted" } });
+            continue;
+        }
+        const auto& names = tilesLst->list();
+        if (id < 0 || static_cast<std::size_t>(id) >= names.size()) {
+            missingTiles.push_back({ { "id", id }, { "art", nullptr }, { "reason", "tile id out of tiles.lst range" } });
+            continue;
+        }
+        const std::string art = "art/tiles/" + names[static_cast<std::size_t>(id)];
+        if (!files.exists(art)) {
+            missingTiles.push_back({ { "id", id }, { "art", art } });
+        }
+    }
+
+    // --- Object art: distinct FIDs -> resolved art path -> exists? (resolve() can throw) ---
+    std::set<std::uint32_t> checkedFids;
+    auto missingObjectArt = json::array();
+    for (const auto& [elevation, objects] : map->objects()) {
+        for (const auto& object : objects) {
+            if (object->position == -1) {
+                continue; // inventory/container child, not placed on the map
+            }
+            if (!checkedFids.insert(object->frm_pid).second) {
+                continue; // this FID already checked
+            }
+            std::string art;
+            try {
+                art = resources.frmResolver().resolve(object->frm_pid);
+            } catch (const std::exception&) {
+                missingObjectArt.push_back({ { "pid", object->frm_pid }, { "art", nullptr }, { "reason", "FID does not resolve" } });
+                continue;
+            }
+            if (art.empty() || !files.exists(art)) {
+                missingObjectArt.push_back({ { "pid", object->frm_pid }, { "art", art.empty() ? json(nullptr) : json(art) } });
+            }
+        }
+    }
+
+    json result{
+        { "map", mapPath },
+        { "usedTileCount", usedTileIds.size() },
+        { "objectArtCount", checkedFids.size() },
+        { "missingTiles", std::move(missingTiles) },
+        { "missingObjectArt", std::move(missingObjectArt) },
+    };
+    out << result.dump() << "\n";
+    return 0;
+}
+
+} // namespace geck::cli

--- a/src/cli/ResourceInspect.h
+++ b/src/cli/ResourceInspect.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+
+namespace geck {
+
+namespace resource {
+    class GameResources;
+}
+
+namespace cli {
+
+    /// Resolve a single VFS path against the mounted data and report WHICH source provides it.
+    /// Writes JSON: {path, found, source:{kind,path,label}|null}. "Not found" is a valid answer,
+    /// not an error — the exit code is 0 either way. The direct answer to "is X present, and does it
+    /// come from master.dat, a patch dir, or a mod?".
+    int resourceFind(resource::GameResources& resources, const std::string& path, std::ostream& out);
+
+    /// List every mounted entry whose path matches <glob> ('*' and '?'), each tagged with the source
+    /// that provides it. Matching is case-insensitive and substring-anchored (tolerant of the VFS's
+    /// leading slash / alias prefix), so "art/tiles/gras*" or "gras03*" both work. Writes JSON:
+    /// {pattern, count, truncated, entries:[{path, source:{kind,label}}]} (capped; 'truncated' flags
+    /// an over-long result). Browse a DAT / data set's contents without extracting.
+    int resourceList(resource::GameResources& resources, const std::string& glob, std::ostream& out);
+
+    /// Report the art a map REFERENCES but that does not resolve in the mounted data: the diagnostic
+    /// for "why won't this map load / render fully". Writes JSON: {map, usedTileCount, objectCount,
+    /// missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}. Empty arrays mean everything resolves.
+    /// Mirrors what the editor's (now tolerant) loader would skip. Exit code 1 only when the map
+    /// itself can't be read.
+    int resourceMissing(resource::GameResources& resources, const std::string& mapPath, std::ostream& out);
+
+} // namespace cli
+} // namespace geck

--- a/src/cli/ResourceInspect.h
+++ b/src/cli/ResourceInspect.h
@@ -20,15 +20,16 @@ namespace cli {
     /// List every mounted entry whose path matches <glob> ('*' and '?'), each tagged with the source
     /// that provides it. Matching is case-insensitive and substring-anchored (tolerant of the VFS's
     /// leading slash / alias prefix), so "art/tiles/gras*" or "gras03*" both work. Writes JSON:
-    /// {pattern, count, truncated, entries:[{path, source:{kind,label}}]} (capped; 'truncated' flags
-    /// an over-long result). Browse a DAT / data set's contents without extracting.
+    /// {pattern, count, truncated, entries:[{path, source:{kind,path,label}}]} (capped; 'truncated'
+    /// flags an over-long result). Browse a DAT / data set's contents without extracting.
     int resourceList(resource::GameResources& resources, const std::string& glob, std::ostream& out);
 
     /// Report the art a map REFERENCES but that does not resolve in the mounted data: the diagnostic
-    /// for "why won't this map load / render fully". Writes JSON: {map, usedTileCount, objectCount,
-    /// missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}. Empty arrays mean everything resolves.
-    /// Mirrors what the editor's (now tolerant) loader would skip. Exit code 1 only when the map
-    /// itself can't be read.
+    /// for "why won't this map load / render fully". Writes JSON: {map, usedTileCount, objectArtCount,
+    /// missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}, where a missing entry carries an extra
+    /// "reason" when the art path couldn't even be formed ("tiles.lst not mounted", "tile id out of
+    /// tiles.lst range", "FID does not resolve"). Empty arrays mean everything resolves. Mirrors what
+    /// the editor's (now tolerant) loader would skip. Exit code 1 only when the map itself can't be read.
     int resourceMissing(resource::GameResources& resources, const std::string& mapPath, std::ostream& out);
 
 } // namespace cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -13,6 +13,7 @@
 #include "cli/MapRender.h"
 #include "cli/MapReachability.h"
 #include "cli/PatternExtract.h"
+#include "cli/ResourceInspect.h"
 #include "cli/ScriptIntrospect.h"
 #include "resource/GameResources.h"
 
@@ -133,6 +134,15 @@ void printUsage(const char* program) {
               << "      Decode a FID (0x.. hex or decimal) to JSON {fid, type, index, artPath}.\n"
               << "  " << program << " frm list <glob> --data <dir-or-.dat> [--data <...>]\n"
               << "      Art entries whose name matches <glob> (e.g. ext2grd*), each {name, artPath, fid}.\n"
+              << "  " << program << " resource find <path> --data <dir-or-.dat> [--data <...>]\n"
+              << "      Locate a VFS path (e.g. art/tiles/gras030.frm) in the mounted data: JSON\n"
+              << "      {path, found, source:{kind,path,label}} — which .dat/dir provides it, or found=false.\n"
+              << "  " << program << " resource list <glob> --data <dir-or-.dat> [--data <...>]\n"
+              << "      Mounted entries matching <glob> ('*'/'?', e.g. art/tiles/gras*), each tagged with its\n"
+              << "      source. Browse a DAT/data set without extracting (result is capped; 'truncated' flags it).\n"
+              << "  " << program << " resource missing <map> --data <dir-or-.dat> [--data <...>]\n"
+              << "      Art a map references but that does NOT resolve in the mounted data: missing tiles\n"
+              << "      (by tiles.lst id) and object art (by FID). Diagnoses 'why won't this map load fully'.\n"
               << "  --data may be a Fallout 2 data directory or a .dat archive; repeat to mount several.\n";
 }
 
@@ -673,6 +683,84 @@ int runFrmCommand(const std::vector<std::string>& args, const char* program) {
     return dispatchFrm(resources, fa);
 }
 
+// --- resource subcommand ----------------------------------------------------------------------
+// The `resource` family (find/list/missing) inspects the mounted data itself — which source
+// provides a path, what matches a glob, what a map references but can't resolve. Self-contained
+// like `frm`: one positional (path / glob / map) plus its own --data list.
+struct ResourceArgs {
+    std::string action; // find | list | missing
+    std::string target; // path / glob / map
+    std::vector<std::string> dataPaths;
+};
+
+bool isResourceAction(const std::string& action) {
+    return action == "find" || action == "list" || action == "missing";
+}
+
+// Parse the tokens after `resource <action>` into `out`. Returns false (after printing why) on a
+// bad flag or a second positional.
+bool parseResourceArgs(const std::vector<std::string>& args, const char* program, ResourceArgs& out) {
+    for (std::size_t i = 2; i < args.size();) {
+        const std::string& arg = args[i];
+        if (arg == "--data") {
+            if (i + 1 >= args.size()) {
+                std::cerr << "error: --data needs a value\n";
+                printUsage(program);
+                return false;
+            }
+            out.dataPaths.push_back(args[i + 1]);
+            i += 2;
+        } else if (arg.rfind("--", 0) == 0) {
+            std::cerr << "error: unexpected argument: " << arg << "\n";
+            printUsage(program);
+            return false;
+        } else if (out.target.empty()) {
+            out.target = arg;
+            ++i;
+        } else {
+            std::cerr << "error: resource " << out.action << " takes one positional argument: " << arg << "\n";
+            printUsage(program);
+            return false;
+        }
+    }
+    return true;
+}
+
+int dispatchResource(geck::resource::GameResources& resources, const ResourceArgs& ra) {
+    if (ra.action == "find") {
+        return geck::cli::resourceFind(resources, ra.target, std::cout);
+    }
+    if (ra.action == "list") {
+        return geck::cli::resourceList(resources, ra.target, std::cout);
+    }
+    return geck::cli::resourceMissing(resources, ra.target, std::cout);
+}
+
+// Run a `resource ...` command end to end (parse, validate, mount, dispatch). Returns the exit code.
+int runResourceCommand(const std::vector<std::string>& args, const char* program) {
+    ResourceArgs ra;
+    ra.action = args[1];
+    if (!parseResourceArgs(args, program, ra)) {
+        return 2;
+    }
+    if (ra.target.empty()) {
+        const char* what = ra.action == "find" ? "<path>" : (ra.action == "list" ? "<glob>" : "<map>");
+        std::cerr << "error: resource " << ra.action << " requires a " << what << " argument\n";
+        printUsage(program);
+        return 2;
+    }
+    if (ra.dataPaths.empty()) {
+        std::cerr << "error: at least one --data <path> is required\n";
+        printUsage(program);
+        return 2;
+    }
+
+    spdlog::set_level(spdlog::level::off);
+    geck::resource::GameResources resources;
+    mountData(resources, ra.dataPaths, program);
+    return dispatchResource(resources, ra);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -682,6 +770,11 @@ int main(int argc, char** argv) {
     // the `map` subcommands below.
     if (args.size() >= 2 && args[0] == "frm" && isFrmAction(args[1])) {
         return runFrmCommand(args, argv[0]);
+    }
+
+    // The `resource` family (data-inspection) is likewise parsed and run on its own path.
+    if (args.size() >= 2 && args[0] == "resource" && isResourceAction(args[1])) {
+        return runResourceCommand(args, argv[0]);
     }
 
     CliArgs cli;

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -14,6 +14,7 @@
 #include "cli/MapReachability.h"
 #include "cli/MapRender.h"
 #include "cli/PatternExtract.h"
+#include "cli/ResourceInspect.h"
 #include "cli/ScriptIntrospect.h"
 #include "format/msg/Msg.h"
 #include "scripting/ScriptApiReference.h"
@@ -465,6 +466,43 @@ namespace {
         return toolText(oss.str(), rc != 0);
     }
 
+    // --- Resource / data-set inspection tools -----------------------------------
+    json toolResourceFind(resource::GameResources& resources, const json& args) {
+        const std::string path = requireString(args, "path");
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::resourceFind(resources, path, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("resource_find failed: ") + e.what(), true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolResourceList(resource::GameResources& resources, const json& args) {
+        const std::string glob = requireString(args, "glob");
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::resourceList(resources, glob, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("resource_list failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
+    json toolResourceMissing(resource::GameResources& resources, const json& args) {
+        const std::string map = requireString(args, "map");
+        std::ostringstream oss;
+        int rc = 0;
+        try {
+            rc = cli::resourceMissing(resources, map, oss);
+        } catch (const std::exception& e) {
+            return toolText(std::string("resource_missing failed: ") + e.what() + " (is the Fallout 2 data mounted?)", true);
+        }
+        return toolText(oss.str(), rc != 0);
+    }
+
     // Dispatch a tools/call by name. Returns the tool result, or nullopt for an unknown tool
     // (which the caller turns into a JSON-RPC method error).
     // One contract per tool: the schema advertised by tools/list and the handler run by
@@ -648,6 +686,33 @@ namespace {
             "(e.g. all exit-grid pieces) and feed an artPath/fid to frm_info or render_frm. Args: glob.",
             json({ { "type", "object" }, { "properties", { { "glob", { { "type", "string" } } } } }, { "required", json::array({ "glob" }) } }),
             [](resource::GameResources& r, const json& a) { return toolListFrms(r, a); } });
+        t.push_back({ "resource_find",
+            "Locate a VFS path in the mounted data and report WHICH source provides it: JSON {path, "
+            "found, source:{kind (dat|directory), path, label}|null}. kind/label identify master.dat vs a "
+            "patch directory vs a mod, so you can tell whether a file is present and where it comes from "
+            "(e.g. is art/tiles/gras030.frm actually shipped, or a dangling tiles.lst entry). Also exposes "
+            "mount-path mistakes: if the data dir was mounted one level too high, files show up under a "
+            "'/data/...' prefix. 'not found' is a normal answer, not an error. Args: path (e.g. "
+            "art/tiles/gras030.frm).",
+            json({ { "type", "object" }, { "properties", { { "path", { { "type", "string" } } } } }, { "required", json::array({ "path" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolResourceFind(r, a); } });
+        t.push_back({ "resource_list",
+            "List mounted entries whose path matches a glob ('*','?'), each tagged with the source that "
+            "provides it — browse a DAT / data set without extracting. Matching is case-insensitive and "
+            "substring-anchored (tolerant of the VFS leading slash / alias prefix), so 'art/tiles/gras*' or "
+            "'gras03*' both work. JSON {pattern, count, truncated, entries:[{path, source:{kind,label}}]} "
+            "(capped; 'truncated' flags an over-long result). Args: glob.",
+            json({ { "type", "object" }, { "properties", { { "glob", { { "type", "string" } } } } }, { "required", json::array({ "glob" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolResourceList(r, a); } });
+        t.push_back({ "resource_missing",
+            "Report the art a map REFERENCES but that does NOT resolve in the mounted data — the "
+            "diagnostic for 'why won't this map load / render fully'. JSON {map, usedTileCount, "
+            "objectArtCount, missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}. Empty arrays mean "
+            "everything the map uses resolves (so a load failure is elsewhere — e.g. a mount-path mistake; "
+            "check with resource_find). Mirrors what the editor's loader now tolerantly skips instead of "
+            "aborting. Args: map (.map path).",
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
+            [](resource::GameResources& r, const json& a) { return toolResourceMissing(r, a); } });
         t.push_back({ "script_api",
             "The generation-script `api` reference (Markdown): every function a `generate` Luau script "
             "can call on the global `api`, with signatures, plus the non-obvious runtime behaviour (runs "

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -700,17 +700,18 @@ namespace {
             "List mounted entries whose path matches a glob ('*','?'), each tagged with the source that "
             "provides it — browse a DAT / data set without extracting. Matching is case-insensitive and "
             "substring-anchored (tolerant of the VFS leading slash / alias prefix), so 'art/tiles/gras*' or "
-            "'gras03*' both work. JSON {pattern, count, truncated, entries:[{path, source:{kind,label}}]} "
+            "'gras03*' both work. JSON {pattern, count, truncated, entries:[{path, source:{kind,path,label}}]} "
             "(capped; 'truncated' flags an over-long result). Args: glob.",
             json({ { "type", "object" }, { "properties", { { "glob", { { "type", "string" } } } } }, { "required", json::array({ "glob" }) } }),
             [](resource::GameResources& r, const json& a) { return toolResourceList(r, a); } });
         t.push_back({ "resource_missing",
             "Report the art a map REFERENCES but that does NOT resolve in the mounted data — the "
             "diagnostic for 'why won't this map load / render fully'. JSON {map, usedTileCount, "
-            "objectArtCount, missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}. Empty arrays mean "
-            "everything the map uses resolves (so a load failure is elsewhere — e.g. a mount-path mistake; "
-            "check with resource_find). Mirrors what the editor's loader now tolerantly skips instead of "
-            "aborting. Args: map (.map path).",
+            "objectArtCount, missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}, where a missing entry "
+            "gains a 'reason' when the art path couldn't even be formed ('tiles.lst not mounted', 'tile id "
+            "out of tiles.lst range', 'FID does not resolve'). Empty arrays mean everything the map uses "
+            "resolves (so a load failure is elsewhere — e.g. a mount-path mistake; check with resource_find). "
+            "Mirrors what the editor's loader now tolerantly skips instead of aborting. Args: map (.map path).",
             json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),
             [](resource::GameResources& r, const json& a) { return toolResourceMissing(r, a); } });
         t.push_back({ "script_api",

--- a/src/state/loader/MapLoader.cpp
+++ b/src/state/loader/MapLoader.cpp
@@ -198,14 +198,31 @@ void MapLoader::loadMapResources() {
         size_t tiles_total = lst->list().size();
 
         // Progress for tiles: 20% to 60% (40% of total progress)
+        size_t unresolvedTiles = 0;
         for (const auto& tile : lst->list()) {
             setProgress("Loading map tile texture " + std::to_string(tile_number) + " of " + std::to_string(tiles_total));
-            _resources->textures().preload("art/tiles/" + tile);
+            try {
+                _resources->textures().preload("art/tiles/" + tile);
+            } catch (const std::exception& e) {
+                // A tiles.lst entry whose art isn't in the mounted data is NOT fatal. The engine
+                // loads tiles on demand, so a full tiles.lst that indexes art a given data set does
+                // not ship (common with mods that patch tiles.lst but rely on master.dat for the
+                // rest, or carry unused/placeholder slots) is normal. Skip it: the tile renders
+                // blank only if a map actually places it. Aborting here would make an otherwise
+                // loadable map fail on a tile it never uses.
+                ++unresolvedTiles;
+                spdlog::debug("MapLoader: skipping unresolved tile '{}': {}", tile, e.what());
+            }
 
             // Progress: 20% base + (current/total * 40%)
             int tileProgress = static_cast<int>((tile_number * 40) / tiles_total);
             _percentDone = 20 + tileProgress;
             tile_number++;
+        }
+        if (unresolvedTiles > 0) {
+            spdlog::warn("MapLoader: {} of {} tiles.lst entries could not be resolved in the mounted "
+                         "data; they render blank only where a map places them",
+                unresolvedTiles, tiles_total);
         }
 
         stopwatch_chunk.reset();
@@ -214,6 +231,7 @@ void MapLoader::loadMapResources() {
         size_t objectsTotal = _map->objects().at(_elevation).size();
 
         // Progress for objects: 60% to 95% (35% of total progress)
+        size_t unresolvedObjectArt = 0;
         for (const auto& object : _map->objects().at(_elevation)) {
             setProgress("Loading map object " + std::to_string(objectNumber) + " of " + std::to_string(objectsTotal));
 
@@ -222,13 +240,26 @@ void MapLoader::loadMapResources() {
                 continue; // object inside an inventory/container
             }
 
-            const std::string frmName = _resources->frmResolver().resolve(object->frm_pid);
-            _resources->textures().preload(frmName);
+            // Same tolerance as tiles: a single object whose art (or proto->FID mapping) can't be
+            // resolved must not abort the whole map. resolve() itself throws on an out-of-range FID,
+            // so both it and preload() sit inside the guard; the object just renders blank.
+            try {
+                _resources->textures().preload(_resources->frmResolver().resolve(object->frm_pid));
+            } catch (const std::exception& e) {
+                ++unresolvedObjectArt;
+                spdlog::debug("MapLoader: skipping unresolved art for object pid {}: {}",
+                    object->frm_pid, e.what());
+            }
 
             // Progress: 60% base + (current/total * 35%)
             int objectProgress = static_cast<int>((objectNumber * 35) / std::max(objectsTotal, size_t(1)));
             _percentDone = 60 + objectProgress;
             objectNumber++;
+        }
+        if (unresolvedObjectArt > 0) {
+            spdlog::warn("MapLoader: {} object(s) on elevation {} reference art missing from the "
+                         "mounted data; they render blank",
+                unresolvedObjectArt, _elevation);
         }
 
         // Load essential editor textures

--- a/src/state/loader/MapLoader.cpp
+++ b/src/state/loader/MapLoader.cpp
@@ -1,6 +1,9 @@
 #include "MapLoader.h"
+#include <algorithm>
 #include <string>
 #include <thread>
+#include <unordered_set>
+#include <vector>
 #include <spdlog/spdlog.h>
 #include <spdlog/stopwatch.h>
 #include "util/Constants.h"
@@ -21,6 +24,28 @@
 #include "resource/ResourceInitializer.h"
 
 namespace geck {
+
+namespace {
+    // Join up to `cap` names for a single log line, appending "… (+N more)" when truncated, so a
+    // warning stays readable even when a whole data set's worth of art is unresolved.
+    std::string joinCapped(const std::vector<std::string>& names, std::size_t cap) {
+        std::string out;
+        const std::size_t shown = std::min(names.size(), cap);
+        for (std::size_t i = 0; i < shown; ++i) {
+            if (i > 0) {
+                out += ", ";
+            }
+            out += names[i];
+        }
+        if (names.size() > cap) {
+            out += " … (+" + std::to_string(names.size() - cap) + " more)";
+        }
+        return out;
+    }
+
+    // How many names to spell out in a single warning before collapsing the rest into a count.
+    constexpr std::size_t kMaxNamesInWarning = 40;
+} // namespace
 
 MapLoader::MapLoader(std::shared_ptr<resource::GameResources> resources,
     const std::filesystem::path& mapFile,
@@ -198,7 +223,7 @@ void MapLoader::loadMapResources() {
         size_t tiles_total = lst->list().size();
 
         // Progress for tiles: 20% to 60% (40% of total progress)
-        size_t unresolvedTiles = 0;
+        std::vector<std::string> unresolvedTiles;
         for (const auto& tile : lst->list()) {
             setProgress("Loading map tile texture " + std::to_string(tile_number) + " of " + std::to_string(tiles_total));
             try {
@@ -210,7 +235,7 @@ void MapLoader::loadMapResources() {
                 // rest, or carry unused/placeholder slots) is normal. Skip it: the tile renders
                 // blank only if a map actually places it. Aborting here would make an otherwise
                 // loadable map fail on a tile it never uses.
-                ++unresolvedTiles;
+                unresolvedTiles.push_back(tile);
                 spdlog::debug("MapLoader: skipping unresolved tile '{}': {}", tile, e.what());
             }
 
@@ -219,10 +244,10 @@ void MapLoader::loadMapResources() {
             _percentDone = 20 + tileProgress;
             tile_number++;
         }
-        if (unresolvedTiles > 0) {
+        if (!unresolvedTiles.empty()) {
             spdlog::warn("MapLoader: {} of {} tiles.lst entries could not be resolved in the mounted "
-                         "data; they render blank only where a map places them",
-                unresolvedTiles, tiles_total);
+                         "data; they render blank only where a map places them: {}",
+                unresolvedTiles.size(), tiles_total, joinCapped(unresolvedTiles, kMaxNamesInWarning));
         }
 
         stopwatch_chunk.reset();
@@ -231,7 +256,8 @@ void MapLoader::loadMapResources() {
         size_t objectsTotal = _map->objects().at(_elevation).size();
 
         // Progress for objects: 60% to 95% (35% of total progress)
-        size_t unresolvedObjectArt = 0;
+        std::vector<std::string> unresolvedObjectArt;
+        std::unordered_set<std::string> seenUnresolvedArt; // dedupe: many objects can share one sprite
         for (const auto& object : _map->objects().at(_elevation)) {
             setProgress("Loading map object " + std::to_string(objectNumber) + " of " + std::to_string(objectsTotal));
 
@@ -242,12 +268,18 @@ void MapLoader::loadMapResources() {
 
             // Same tolerance as tiles: a single object whose art (or proto->FID mapping) can't be
             // resolved must not abort the whole map. resolve() itself throws on an out-of-range FID,
-            // so both it and preload() sit inside the guard; the object just renders blank.
+            // so both it and preload() sit inside the guard; the object just renders blank. `art`
+            // stays empty when resolve() is what threw, so we fall back to naming the FID.
+            std::string art;
             try {
-                _resources->textures().preload(_resources->frmResolver().resolve(object->frm_pid));
+                art = _resources->frmResolver().resolve(object->frm_pid);
+                _resources->textures().preload(art);
             } catch (const std::exception& e) {
-                ++unresolvedObjectArt;
-                spdlog::debug("MapLoader: skipping unresolved art for object pid {}: {}",
+                const std::string name = art.empty() ? ("fid " + std::to_string(object->frm_pid)) : art;
+                if (seenUnresolvedArt.insert(name).second) {
+                    unresolvedObjectArt.push_back(name);
+                }
+                spdlog::debug("MapLoader: skipping unresolved art for object fid {}: {}",
                     object->frm_pid, e.what());
             }
 
@@ -256,10 +288,10 @@ void MapLoader::loadMapResources() {
             _percentDone = 60 + objectProgress;
             objectNumber++;
         }
-        if (unresolvedObjectArt > 0) {
-            spdlog::warn("MapLoader: {} object(s) on elevation {} reference art missing from the "
-                         "mounted data; they render blank",
-                unresolvedObjectArt, _elevation);
+        if (!unresolvedObjectArt.empty()) {
+            spdlog::warn("MapLoader: {} distinct object sprite(s) on elevation {} could not be resolved "
+                         "in the mounted data; those objects render blank: {}",
+                unresolvedObjectArt.size(), _elevation, joinCapped(unresolvedObjectArt, kMaxNamesInWarning));
         }
 
         // Load essential editor textures

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 # no scripting or game data. test_frm_inspect covers the FRM tools' non-GL logic (FID parse/decode,
 # art-name resolution, glob listing) against a temp LST fixture.
 if(TARGET gecko_cli)
-    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp general/test_map_analyzer_scripts.cpp general/test_map_dump_grid.cpp general/test_frm_inspect.cpp)
+    target_sources(general_tests PRIVATE general/test_pattern_stamp.cpp general/test_map_reachability.cpp general/test_map_analyzer_scripts.cpp general/test_map_dump_grid.cpp general/test_frm_inspect.cpp general/test_resource_inspect.cpp)
     target_link_libraries(general_tests PRIVATE gecko_cli)
 endif()
 

--- a/tests/general/test_mcp_server.cpp
+++ b/tests/general/test_mcp_server.cpp
@@ -34,7 +34,7 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
             names.push_back(tool["name"].get<std::string>());
             CHECK(tool.contains("inputSchema"));
         }
-        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm" }) {
+        for (const char* expected : { "list_maps", "analyze", "palette", "proto_info", "describe_script", "reachability", "describe_map", "map_graph", "world_map", "world_encounters", "quests", "gvars", "endings", "find_gvar", "generate", "render_map", "extract_pattern", "script_api", "frm_info", "resolve_fid", "list_frms", "render_frm", "resource_find", "resource_list", "resource_missing" }) {
             CHECK(std::find(names.begin(), names.end(), expected) != names.end());
         }
     }
@@ -71,6 +71,21 @@ TEST_CASE("McpServer speaks JSON-RPC and exposes the tools", "[mcp]") {
     SECTION("proto_info without a pid is a tool error") {
         const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 7 }, { "method", "tools/call" },
             { "params", { { "name", "proto_info" }, { "arguments", json::object() } } } });
+        CHECK(resp["result"]["isError"] == true);
+    }
+
+    SECTION("resource_find with no data mounted reports found=false, not an error") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 15 }, { "method", "tools/call" },
+            { "params", { { "name", "resource_find" }, { "arguments", { { "path", "art/tiles/gras030.frm" } } } } } });
+        CHECK(resp["result"]["isError"] == false);
+        const json payload = json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+        CHECK(payload["found"] == false);
+        CHECK(payload["source"].is_null());
+    }
+
+    SECTION("resource_find without a path is a tool error") {
+        const json resp = server.handleMessage({ { "jsonrpc", "2.0" }, { "id", 16 }, { "method", "tools/call" },
+            { "params", { { "name", "resource_find" }, { "arguments", json::object() } } } });
         CHECK(resp["result"]["isError"] == true);
     }
 

--- a/tests/general/test_resource_inspect.cpp
+++ b/tests/general/test_resource_inspect.cpp
@@ -1,0 +1,77 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <sstream>
+#include <string>
+
+#include "cli/ResourceInspect.h"
+#include "resource/GameResources.h"
+#include "support/Fixtures.h"
+
+using json = nlohmann::json;
+using namespace geck;
+
+namespace {
+// f2_res.dat is the committed DAT fixture; art/intrface/hr_alltlk.frm is a known entry
+// (see test_reading_dat). GameResources is non-copyable, so mount into a caller-owned instance.
+void mountFixtureDat(resource::GameResources& resources) {
+    resources.files().addDataPath(geck::test::dataPath("f2_res.dat"));
+}
+} // namespace
+
+TEST_CASE("resourceFind locates a DAT entry and names its source", "[resource]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    std::ostringstream oss;
+    CHECK(cli::resourceFind(resources, "art/intrface/hr_alltlk.frm", oss) == 0);
+
+    const json j = json::parse(oss.str());
+    CHECK(j["found"] == true);
+    REQUIRE(j["source"].is_object());
+    CHECK(j["source"]["kind"] == "dat");
+    CHECK(std::string(j["source"]["path"]).find("f2_res.dat") != std::string::npos);
+}
+
+TEST_CASE("resourceFind reports an absent path as found=false, not an error", "[resource]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    std::ostringstream oss;
+    CHECK(cli::resourceFind(resources, "art/tiles/nope12345.frm", oss) == 0);
+
+    const json j = json::parse(oss.str());
+    CHECK(j["found"] == false);
+    CHECK(j["source"].is_null());
+}
+
+TEST_CASE("resourceList matches case-insensitively and tags each entry's source", "[resource]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    std::ostringstream oss;
+    // Upper-case glob against a lower-case entry exercises the case-insensitive match.
+    CHECK(cli::resourceList(resources, "*HR_ALLTLK*", oss) == 0);
+
+    const json j = json::parse(oss.str());
+    CHECK(j["count"].get<int>() >= 1);
+    CHECK(j["truncated"] == false);
+
+    bool found = false;
+    for (const auto& entry : j["entries"]) {
+        if (std::string(entry["path"]).find("hr_alltlk.frm") != std::string::npos) {
+            found = true;
+            CHECK(entry["source"]["kind"] == "dat");
+        }
+    }
+    CHECK(found);
+}
+
+TEST_CASE("resourceMissing reports an unreadable map as an error", "[resource]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    std::ostringstream oss;
+    CHECK(cli::resourceMissing(resources, "maps/does_not_exist.map", oss) == 1);
+
+    const json j = json::parse(oss.str());
+    CHECK(j.contains("error"));
+    CHECK(j["map"] == "maps/does_not_exist.map");
+}

--- a/tests/general/test_resource_inspect.cpp
+++ b/tests/general/test_resource_inspect.cpp
@@ -30,7 +30,7 @@ TEST_CASE("resourceFind locates a DAT entry and names its source", "[resource]")
     CHECK(j["found"] == true);
     REQUIRE(j["source"].is_object());
     CHECK(j["source"]["kind"] == "dat");
-    CHECK(std::string(j["source"]["path"]).find("f2_res.dat") != std::string::npos);
+    CHECK(j["source"]["path"].get<std::string>().find("f2_res.dat") != std::string::npos);
 }
 
 TEST_CASE("resourceFind reports an absent path as found=false, not an error", "[resource]") {
@@ -57,7 +57,7 @@ TEST_CASE("resourceList matches case-insensitively and tags each entry's source"
 
     bool found = false;
     for (const auto& entry : j["entries"]) {
-        if (std::string(entry["path"]).find("hr_alltlk.frm") != std::string::npos) {
+        if (entry["path"].get<std::string>().find("hr_alltlk.frm") != std::string::npos) {
             found = true;
             CHECK(entry["source"]["kind"] == "dat");
         }


### PR DESCRIPTION
## Why

Loading a Restoration Project map failed with `IO error: Failed to open file from data paths (file: art/tiles/gras030.frm)` even with `master.dat`, `critter.dat`, and the RP data directory all mounted. Investigation (using the new tool below) showed:

- `gras030.frm` is a **dangling `tiles.lst` entry** — listed in the RP's 3886-entry `tiles.lst` but shipped by no one (base `master.dat` has only `grass01`/`grass02`).
- The map being opened (`arbridge.map`) **never uses it** — it references 217 tiles + 143 object arts, all present.
- The editor died anyway because `MapLoader::loadMapResources` **eagerly preloads every entry in `tiles.lst`** and aborts the whole load if one FRM is missing. The engine loads tiles on demand, so an unused/placeholder entry is normal and harmless in-game.

## What

**1. Tolerant preload (the fix).** A tile whose art can't be resolved is now skipped with a warning instead of aborting the load; it renders blank only where a map actually places it. The same tolerance covers an object whose art (or proto→FID mapping) can't be resolved. A summary is logged (`N of M tiles.lst entries could not be resolved …`).

**2. `resource` inspection family** — so data-path/DAT resolution is visible instead of guessed:

| CLI | MCP | Purpose |
|-----|-----|---------|
| `resource find <path>` | `resource_find` | Which mounted source provides a path (`master.dat` vs patch dir vs mod), or `found=false`. Also surfaces mount-path mistakes (files under a stray `/data` prefix). |
| `resource list <glob>` | `resource_list` | Entries matching a glob, each tagged by source. Browse a DAT/data set without extracting. |
| `resource missing <map>` | `resource_missing` | Tiles/object art a map references that don't resolve — the "why won't this map load fully" diagnostic. |

Example — the diagnosis that motivated this, now a one-liner:
```
$ gecko-cli resource find art/tiles/gras030.frm --data master.dat --data critter.dat --data <RP>/data
{"found":false,"path":"art/tiles/gras030.frm","source":null}
$ gecko-cli resource missing maps/arbridge.map --data master.dat --data critter.dat --data <RP>/data
{"map":"maps/arbridge.map","missingTiles":[],"missingObjectArt":[],"usedTileCount":217,"objectArtCount":143}
```

## Tests

- `test_resource_inspect.cpp` — `find` (present/absent + source), `list` (case-insensitive glob + source tag), `missing` (unreadable-map error) against the committed `f2_res.dat` fixture.
- `test_mcp_server.cpp` — the three new tools are advertised by `tools/list`; `resource_find` dispatch returns `found=false` (not an error) with no data mounted, and errors on a missing `path` arg.
- Full suite green (365 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)