### PR TITLE
Interactive map-edge (.edg) editor

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -10,6 +10,7 @@
 
 #include "version.h"
 #include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
 #include "state/loader/MapLoader.h"
 #include "util/GameDataPathResolver.h"
 #include "ui/Settings.h"
@@ -41,7 +42,7 @@ Application::Application(int argc, char** argv)
 
     initUI();
 
-    checkFirstRun();
+    checkDataConfiguration();
 
     loadMap(finalMapPath);
 }
@@ -158,21 +159,50 @@ bool Application::isRunning() const {
     return _mainWindow && _mainWindow->isVisible();
 }
 
-void Application::checkFirstRun() {
+void Application::checkDataConfiguration() {
     auto& settings = *_settings;
     if (!settings.exists()) {
         spdlog::info("First run detected, showing settings dialog");
-
-        SettingsDialog dialog(_settings, _mainWindow.get());
-        dialog.exec();
-
-        // Save and reload data paths whether or not the dialog was accepted, so we keep at least the
-        // default data path from the command line and the app is usable either way.
-        settings.save();
+        showStartupSettingsDialog();
         loadDataPaths();
-    } else {
-        loadDataPaths();
+        return;
     }
+
+    loadDataPaths();
+
+    // Settings exist, but the configured paths no longer provide the files the editor can't
+    // run without (the game install moved or was deleted since the last run). Prompt once with
+    // the same dialog as on first run, then remount whatever the user configured.
+    if (!hasEssentialGameData()) {
+        spdlog::warn("Configured data paths are missing essential game files, showing settings dialog");
+        if (showStartupSettingsDialog()) {
+            _resources->clearAllDataPaths();
+            loadDataPaths();
+        }
+    }
+}
+
+bool Application::showStartupSettingsDialog() {
+    SettingsDialog dialog(_settings, _mainWindow.get());
+
+    bool dataPathsChanged = false;
+    QObject::connect(&dialog, &SettingsDialog::settingsSaved, [&dataPathsChanged](bool changed) {
+        dataPathsChanged = dataPathsChanged || changed;
+    });
+
+    dialog.exec();
+
+    // Save whether or not the dialog was accepted, so we keep at least the default data path
+    // from the command line and the app is usable either way.
+    _settings->save();
+    return dataPathsChanged;
+}
+
+bool Application::hasEssentialGameData() const {
+    // The palette and the tile list back every rendering path; if the mounted data paths can't
+    // resolve them, no map can be displayed and the data configuration needs fixing.
+    const auto& files = _resources->files();
+    return files.exists(ResourcePaths::Pal::COLOR) && files.exists(ResourcePaths::Lst::TILES);
 }
 
 void Application::loadDataPaths() {

--- a/src/Application.h
+++ b/src/Application.h
@@ -31,7 +31,9 @@ public:
 private:
     void initUI();
     std::string processCommandLineArgs();
-    void checkFirstRun();
+    void checkDataConfiguration();
+    bool showStartupSettingsDialog();
+    bool hasEssentialGameData() const;
     void loadDataPaths();
 
     std::unique_ptr<QApplication> _qtApp;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -571,6 +571,8 @@ add_library(gecko_editing STATIC
     editing/commands/InventoryEditService.cpp
     editing/commands/ScriptEditService.h
     editing/commands/ScriptEditService.cpp
+    editing/commands/EdgeEditService.h
+    editing/commands/EdgeEditService.cpp
     editing/commands/MapEditService.h
     editing/commands/MapEditService.cpp
     editing/commands/ObjectEditService.h

--- a/src/editing/commands/EdgeEditService.cpp
+++ b/src/editing/commands/EdgeEditService.cpp
@@ -167,7 +167,9 @@ bool EdgeEditService::upgradeToVersion2() {
 }
 
 bool EdgeEditService::setSquareSide(int elevation, Side side, int colOrRow) {
-    if (!hasEdge() || !validElevation(elevation)) {
+    // The square/clip block is only serialized for v2 edges (MapEdgeWriter), so reject the edit on v1
+    // rather than "succeed" with a change that would never be saved.
+    if (!hasEdge() || !validElevation(elevation) || !_map->edge()->isVersion2()) {
         return false;
     }
     std::optional<MapEdge> before = _map->edge();
@@ -192,7 +194,8 @@ bool EdgeEditService::setSquareSide(int elevation, Side side, int colOrRow) {
 }
 
 bool EdgeEditService::toggleClipSide(int elevation, Side side) {
-    if (!hasEdge() || !validElevation(elevation)) {
+    // Clip flags are only serialized for v2 edges, so a v1 toggle would silently not persist.
+    if (!hasEdge() || !validElevation(elevation) || !_map->edge()->isVersion2()) {
         return false;
     }
     std::optional<MapEdge> before = _map->edge();
@@ -217,7 +220,8 @@ bool EdgeEditService::toggleClipSide(int elevation, Side side) {
 }
 
 bool EdgeEditService::resetSquare(int elevation) {
-    if (!hasEdge() || !validElevation(elevation)) {
+    // The square/clip block only exists in v2 files, so resetting it on a v1 edge would not persist.
+    if (!hasEdge() || !validElevation(elevation) || !_map->edge()->isVersion2()) {
         return false;
     }
     std::optional<MapEdge> before = _map->edge();

--- a/src/editing/commands/EdgeEditService.cpp
+++ b/src/editing/commands/EdgeEditService.cpp
@@ -17,6 +17,23 @@ namespace {
     int clampCoord(int value, int maxInclusive) {
         return value < 0 ? 0 : (value > maxInclusive ? maxInclusive : value);
     }
+
+    void assignRectSide(MapEdge::Rect& rect, EdgeEditService::Side side, int value) {
+        switch (side) {
+            case EdgeEditService::LEFT:
+                rect.left = value;
+                break;
+            case EdgeEditService::TOP:
+                rect.top = value;
+                break;
+            case EdgeEditService::RIGHT:
+                rect.right = value;
+                break;
+            case EdgeEditService::BOTTOM:
+                rect.bottom = value;
+                break;
+        }
+    }
 } // namespace
 
 EdgeEditService::EdgeEditService(std::unique_ptr<Map>& map, UndoBatcher& batcher)
@@ -105,23 +122,37 @@ bool EdgeEditService::setZoneSide(int elevation, int zoneIndex, Side side, int h
         return false;
     }
     std::optional<MapEdge> before = _map->edge();
-    MapEdge::Rect& rect = zones[zoneIndex];
-    switch (side) {
-        case LEFT:
-            rect.left = hexIndex;
-            break;
-        case TOP:
-            rect.top = hexIndex;
-            break;
-        case RIGHT:
-            rect.right = hexIndex;
-            break;
-        case BOTTOM:
-            rect.bottom = hexIndex;
-            break;
-    }
+    assignRectSide(zones[zoneIndex], side, hexIndex);
     _map->setEdge(std::move(working));
     return recordEdgeEdit("Move Edge Side", std::move(before));
+}
+
+std::optional<MapEdge> EdgeEditService::snapshot() const {
+    return _map ? _map->edge() : std::nullopt;
+}
+
+void EdgeEditService::previewZoneSide(int elevation, int zoneIndex, Side side, int hexIndex) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return;
+    }
+    if (hexIndex < 0 || hexIndex >= HexagonGrid::POSITION_COUNT) {
+        return;
+    }
+    MapEdge working = *_map->edge();
+    auto& zones = working.elevations[elevation].zones;
+    if (zoneIndex < 0 || zoneIndex >= static_cast<int>(zones.size())) {
+        return;
+    }
+    assignRectSide(zones[zoneIndex], side, hexIndex);
+    _map->setEdge(std::move(working)); // live preview: no undo recorded
+}
+
+void EdgeEditService::restore(const std::optional<MapEdge>& before) {
+    applyEdgeSnapshot(before);
+}
+
+bool EdgeEditService::commitEdit(const std::string& description, std::optional<MapEdge> before) {
+    return recordEdgeEdit(description, std::move(before));
 }
 
 bool EdgeEditService::upgradeToVersion2() {

--- a/src/editing/commands/EdgeEditService.cpp
+++ b/src/editing/commands/EdgeEditService.cpp
@@ -1,0 +1,201 @@
+#include "editing/commands/EdgeEditService.h"
+
+#include <utility>
+
+#include "editing/commands/UndoBatcher.h"
+#include "editor/HexagonGrid.h"
+#include "format/map/Map.h"
+#include "util/UndoStack.h"
+
+namespace geck {
+
+namespace {
+    bool validElevation(int elevation) {
+        return elevation >= 0 && elevation < MapEdge::ELEVATION_COUNT;
+    }
+
+    int clampCoord(int value, int maxInclusive) {
+        return value < 0 ? 0 : (value > maxInclusive ? maxInclusive : value);
+    }
+} // namespace
+
+EdgeEditService::EdgeEditService(std::unique_ptr<Map>& map, UndoBatcher& batcher)
+    : _map(map)
+    , _batcher(batcher) {
+}
+
+const std::optional<MapEdge>& EdgeEditService::edge() const {
+    static const std::optional<MapEdge> none;
+    return _map ? _map->edge() : none;
+}
+
+bool EdgeEditService::hasEdge() const {
+    return _map && _map->edge().has_value();
+}
+
+int EdgeEditService::zoneCount(int elevation) const {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return 0;
+    }
+    return static_cast<int>(_map->edge()->elevations[elevation].zones.size());
+}
+
+void EdgeEditService::applyEdgeSnapshot(const std::optional<MapEdge>& snapshot) {
+    if (_map) {
+        _map->setEdge(snapshot);
+    }
+}
+
+bool EdgeEditService::recordEdgeEdit(const std::string& description, std::optional<MapEdge> before) {
+    if (!_map) {
+        return false;
+    }
+    // The caller already applied the edit; capture the resulting "after" state and skip recording a
+    // no-op so an unchanged drag/click doesn't clutter the undo stack.
+    std::optional<MapEdge> after = _map->edge();
+    if (after == before) {
+        return false;
+    }
+
+    UndoCommand cmd;
+    cmd.description = description;
+    cmd.undo = [this, before = std::move(before)]() { applyEdgeSnapshot(before); };
+    cmd.redo = [this, after = std::move(after)]() { applyEdgeSnapshot(after); };
+    return _batcher.push(std::move(cmd));
+}
+
+int EdgeEditService::addZone(int elevation, const MapEdge::Rect& seed) {
+    if (!_map || !validElevation(elevation)) {
+        return -1;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge working = _map->edge().value_or(MapEdge{});
+    working.elevations[elevation].zones.push_back(seed);
+    const int index = static_cast<int>(working.elevations[elevation].zones.size()) - 1;
+    _map->setEdge(std::move(working));
+    recordEdgeEdit("Add Edge Zone", std::move(before));
+    return index;
+}
+
+bool EdgeEditService::deleteZone(int elevation, int zoneIndex) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return false;
+    }
+    MapEdge working = *_map->edge();
+    auto& zones = working.elevations[elevation].zones;
+    if (zoneIndex < 0 || zoneIndex >= static_cast<int>(zones.size())) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    zones.erase(zones.begin() + zoneIndex);
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Delete Edge Zone", std::move(before));
+}
+
+bool EdgeEditService::setZoneSide(int elevation, int zoneIndex, Side side, int hexIndex) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return false;
+    }
+    if (hexIndex < 0 || hexIndex >= HexagonGrid::POSITION_COUNT) {
+        return false;
+    }
+    MapEdge working = *_map->edge();
+    auto& zones = working.elevations[elevation].zones;
+    if (zoneIndex < 0 || zoneIndex >= static_cast<int>(zones.size())) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge::Rect& rect = zones[zoneIndex];
+    switch (side) {
+        case LEFT:
+            rect.left = hexIndex;
+            break;
+        case TOP:
+            rect.top = hexIndex;
+            break;
+        case RIGHT:
+            rect.right = hexIndex;
+            break;
+        case BOTTOM:
+            rect.bottom = hexIndex;
+            break;
+    }
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Move Edge Side", std::move(before));
+}
+
+bool EdgeEditService::upgradeToVersion2() {
+    if (!hasEdge() || _map->edge()->version == 2) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge working = *_map->edge();
+    working.version = 2;
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Enable Angled Map Edge (v2)", std::move(before));
+}
+
+bool EdgeEditService::setSquareSide(int elevation, Side side, int colOrRow) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge working = *_map->edge();
+    MapEdge::Rect& square = working.elevations[elevation].squareRect;
+    switch (side) {
+        case LEFT:
+            square.left = clampCoord(colOrRow, MapEdge::SQUARE_GRID_WIDTH - 1);
+            break;
+        case RIGHT:
+            square.right = clampCoord(colOrRow, MapEdge::SQUARE_GRID_WIDTH - 1);
+            break;
+        case TOP:
+            square.top = clampCoord(colOrRow, MapEdge::SQUARE_GRID_HEIGHT - 1);
+            break;
+        case BOTTOM:
+            square.bottom = clampCoord(colOrRow, MapEdge::SQUARE_GRID_HEIGHT - 1);
+            break;
+    }
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Move Square Edge Side", std::move(before));
+}
+
+bool EdgeEditService::toggleClipSide(int elevation, Side side) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge working = *_map->edge();
+    MapEdge::ClipSides& clip = working.elevations[elevation].clipSides;
+    switch (side) {
+        case LEFT:
+            clip.left = !clip.left;
+            break;
+        case TOP:
+            clip.top = !clip.top;
+            break;
+        case RIGHT:
+            clip.right = !clip.right;
+            break;
+        case BOTTOM:
+            clip.bottom = !clip.bottom;
+            break;
+    }
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Toggle Edge Clip Side", std::move(before));
+}
+
+bool EdgeEditService::resetSquare(int elevation) {
+    if (!hasEdge() || !validElevation(elevation)) {
+        return false;
+    }
+    std::optional<MapEdge> before = _map->edge();
+    MapEdge working = *_map->edge();
+    working.elevations[elevation].squareRect
+        = MapEdge::Rect{ MapEdge::SQUARE_GRID_WIDTH - 1, 0, 0, MapEdge::SQUARE_GRID_HEIGHT - 1 };
+    working.elevations[elevation].clipSides = MapEdge::ClipSides{};
+    _map->setEdge(std::move(working));
+    return recordEdgeEdit("Reset Square Edge", std::move(before));
+}
+
+} // namespace geck

--- a/src/editing/commands/EdgeEditService.h
+++ b/src/editing/commands/EdgeEditService.h
@@ -57,6 +57,19 @@ public:
     /// Restores an elevation's squareRect + clip flags to the engine defaults (map_edge.cc:229).
     bool resetSquare(int elevation);
 
+    // --- Live drag support (mutates without recording undo until commit) ---
+
+    /// A copy of the current edge, held by the UI as the "before" state across a drag gesture.
+    std::optional<MapEdge> snapshot() const;
+    /// Sets a zone side to a hex index for live preview, WITHOUT recording undo. Silently ignores bad
+    /// args. Used each mouse-move of a side drag; the gesture is committed once via commitEdit().
+    void previewZoneSide(int elevation, int zoneIndex, Side side, int hexIndex);
+    /// Restores the edge to `before` WITHOUT recording undo (drag cancel).
+    void restore(const std::optional<MapEdge>& before);
+    /// Records the current edge as the result of a gesture that started at `before`, as one undo
+    /// command. Records nothing and returns false if the edge is unchanged.
+    bool commitEdit(const std::string& description, std::optional<MapEdge> before);
+
     // --- Reads ---
 
     const std::optional<MapEdge>& edge() const;

--- a/src/editing/commands/EdgeEditService.h
+++ b/src/editing/commands/EdgeEditService.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "format/map/MapEdge.h"
+
+namespace geck {
+
+class Map;
+class UndoBatcher;
+
+/**
+ * @brief Undoable editing of the `.edg` map-edge sidecar (Map::edge()).
+ *
+ * One of the aggregate services ObjectCommandController delegates to. Mirrors ScriptEditService's
+ * snapshot pattern, but the snapshot unit is the whole `std::optional<MapEdge>` — a value type with
+ * `operator==`, so a before/after copy is trivially correct and round-trip-safe.
+ *
+ * The engine's mapper (fallout2-ce `map_edge_setup.cc`) is the semantic reference: a zone side value
+ * is a hex index, a new zone is seeded with the full-grid rect, and v2 adds the per-elevation
+ * square-grid clip block. UX (click-select, drag) lives in the UI layer; this service only mutates
+ * data and records undo.
+ */
+class EdgeEditService {
+public:
+    /// A side of a zone's tileRect (or the v2 squareRect). Matches the renderer's `activeEdgeSide`.
+    enum Side { LEFT = 0,
+        TOP = 1,
+        RIGHT = 2,
+        BOTTOM = 3 };
+
+    EdgeEditService(std::unique_ptr<Map>& map, UndoBatcher& batcher);
+
+    // --- Zone editing (undoable) ---
+
+    /// Appends `seed` as a new zone on `elevation`, creating the edge if none exists yet. Returns the
+    /// new zone's index, or -1 on failure. The caller supplies `seed` (e.g. mapEdgeFullGridZone()).
+    int addZone(int elevation, const MapEdge::Rect& seed);
+    /// Removes zone `zoneIndex` on `elevation`. Returns false if there is no edge or the index is out
+    /// of range.
+    bool deleteZone(int elevation, int zoneIndex);
+    /// Sets one side of a zone's tileRect to a hex index (0..POSITION_COUNT-1). Returns false on bad
+    /// args or when the value is unchanged.
+    bool setZoneSide(int elevation, int zoneIndex, Side side, int hexIndex);
+
+    // --- v2 square/clip editing (undoable) ---
+
+    /// Marks the edge as version 2 so its per-elevation square/clip block is written. No-op if there
+    /// is no edge or it is already v2.
+    bool upgradeToVersion2();
+    /// Sets one side of an elevation's squareRect (LEFT/RIGHT = column, TOP/BOTTOM = row; 0..99).
+    bool setSquareSide(int elevation, Side side, int colOrRow);
+    /// Flips one clip-side flag of an elevation's square block.
+    bool toggleClipSide(int elevation, Side side);
+    /// Restores an elevation's squareRect + clip flags to the engine defaults (map_edge.cc:229).
+    bool resetSquare(int elevation);
+
+    // --- Reads ---
+
+    const std::optional<MapEdge>& edge() const;
+    bool hasEdge() const;
+    int zoneCount(int elevation) const;
+
+private:
+    void applyEdgeSnapshot(const std::optional<MapEdge>& snapshot);
+    /// Records the before/after snapshot of Map::edge() (already mutated by the caller) under
+    /// `description`. Records nothing and returns false when the mutation left the edge unchanged.
+    bool recordEdgeEdit(const std::string& description, std::optional<MapEdge> before);
+
+    std::unique_ptr<Map>& _map;
+    UndoBatcher& _batcher;
+};
+
+} // namespace geck

--- a/src/editing/commands/ObjectCommandController.cpp
+++ b/src/editing/commands/ObjectCommandController.cpp
@@ -204,6 +204,22 @@ int ObjectCommandController::edgeZoneCount(int elevation) const {
     return _edgeService.zoneCount(elevation);
 }
 
+std::optional<MapEdge> ObjectCommandController::edgeSnapshot() const {
+    return _edgeService.snapshot();
+}
+
+void ObjectCommandController::previewEdgeZoneSide(int elevation, int zoneIndex, EdgeEditService::Side side, int hexIndex) {
+    _edgeService.previewZoneSide(elevation, zoneIndex, side, hexIndex);
+}
+
+void ObjectCommandController::restoreEdge(const std::optional<MapEdge>& before) {
+    _edgeService.restore(before);
+}
+
+bool ObjectCommandController::commitEdgeEdit(const std::string& description, std::optional<MapEdge> before) {
+    return _edgeService.commitEdit(description, std::move(before));
+}
+
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {
     return _batcher.push(std::move(cmd));
 }

--- a/src/editing/commands/ObjectCommandController.cpp
+++ b/src/editing/commands/ObjectCommandController.cpp
@@ -29,6 +29,7 @@ ObjectCommandController::ObjectCommandController(resource::GameResources& resour
     , _tileService(map, _batcher, [this](int elevation) -> std::vector<Tile>& { return _host.ensureElevationTiles(elevation); }, [this] { return _host.getCurrentElevation(); }, [this](int hexIndex, bool isRoof, int elevation) { _host.updateTileSprite(hexIndex, isRoof, elevation); })
     , _inventoryService(_batcher)
     , _scriptService(map, _batcher)
+    , _edgeService(map, _batcher)
     , _refreshObjects([this] { _host.refreshObjects(); })
     , _reloadTiles([this] { _host.reloadTiles(); })
     , _mapService(map, objects, wallBlockerOverlays, _scriptService, _batcher, _refreshObjects, _reloadTiles)
@@ -165,6 +166,42 @@ bool ObjectCommandController::removeSpatialScript(uint32_t sid) {
 
 const MapScript* ObjectCommandController::findSpatialScript(uint32_t sid) const {
     return _scriptService.findSpatialScript(sid);
+}
+
+int ObjectCommandController::addEdgeZone(int elevation, const MapEdge::Rect& seed) {
+    return _edgeService.addZone(elevation, seed);
+}
+
+bool ObjectCommandController::deleteEdgeZone(int elevation, int zoneIndex) {
+    return _edgeService.deleteZone(elevation, zoneIndex);
+}
+
+bool ObjectCommandController::setEdgeZoneSide(int elevation, int zoneIndex, EdgeEditService::Side side, int hexIndex) {
+    return _edgeService.setZoneSide(elevation, zoneIndex, side, hexIndex);
+}
+
+bool ObjectCommandController::upgradeEdgeToVersion2() {
+    return _edgeService.upgradeToVersion2();
+}
+
+bool ObjectCommandController::setEdgeSquareSide(int elevation, EdgeEditService::Side side, int colOrRow) {
+    return _edgeService.setSquareSide(elevation, side, colOrRow);
+}
+
+bool ObjectCommandController::toggleEdgeClipSide(int elevation, EdgeEditService::Side side) {
+    return _edgeService.toggleClipSide(elevation, side);
+}
+
+bool ObjectCommandController::resetEdgeSquare(int elevation) {
+    return _edgeService.resetSquare(elevation);
+}
+
+const std::optional<MapEdge>& ObjectCommandController::mapEdge() const {
+    return _edgeService.edge();
+}
+
+int ObjectCommandController::edgeZoneCount(int elevation) const {
+    return _edgeService.zoneCount(elevation);
 }
 
 bool ObjectCommandController::pushCommand(UndoCommand cmd) {

--- a/src/editing/commands/ObjectCommandController.h
+++ b/src/editing/commands/ObjectCommandController.h
@@ -166,6 +166,12 @@ public:
     /// The current map-edge model (may be empty), for reading zone geometry to render/hit-test.
     const std::optional<MapEdge>& mapEdge() const;
     int edgeZoneCount(int elevation) const;
+    // Live side-drag: snapshot the edge at drag start, previewZoneSide each move (no undo), then either
+    // commitEdgeEdit (records the whole gesture as one undo) or restoreEdge (cancel).
+    std::optional<MapEdge> edgeSnapshot() const;
+    void previewEdgeZoneSide(int elevation, int zoneIndex, EdgeEditService::Side side, int hexIndex);
+    void restoreEdge(const std::optional<MapEdge>& before);
+    bool commitEdgeEdit(const std::string& description, std::optional<MapEdge> before);
 
 private:
     resource::GameResources& _resources;

--- a/src/editing/commands/ObjectCommandController.h
+++ b/src/editing/commands/ObjectCommandController.h
@@ -14,6 +14,7 @@
 #include "editing/commands/TileEditService.h"
 #include "editing/commands/InventoryEditService.h"
 #include "editing/commands/ScriptEditService.h"
+#include "editing/commands/EdgeEditService.h"
 #include "editing/commands/MapEditService.h"
 #include "editing/commands/ObjectEditService.h"
 
@@ -152,6 +153,20 @@ public:
     bool removeSpatialScript(uint32_t sid);
     const MapScript* findSpatialScript(uint32_t sid) const;
 
+    // Map-edge (.edg sidecar) editing (undoable). `seed` for addEdgeZone is the initial tileRect
+    // (the caller computes the full-grid rect from the hex grid). `side` uses EdgeEditService::Side
+    // (0=left,1=top,2=right,3=bottom). See EdgeEditService for details.
+    int addEdgeZone(int elevation, const MapEdge::Rect& seed);
+    bool deleteEdgeZone(int elevation, int zoneIndex);
+    bool setEdgeZoneSide(int elevation, int zoneIndex, EdgeEditService::Side side, int hexIndex);
+    bool upgradeEdgeToVersion2();
+    bool setEdgeSquareSide(int elevation, EdgeEditService::Side side, int colOrRow);
+    bool toggleEdgeClipSide(int elevation, EdgeEditService::Side side);
+    bool resetEdgeSquare(int elevation);
+    /// The current map-edge model (may be empty), for reading zone geometry to render/hit-test.
+    const std::optional<MapEdge>& mapEdge() const;
+    int edgeZoneCount(int elevation) const;
+
 private:
     resource::GameResources& _resources;
     std::unique_ptr<Map>& _map;
@@ -164,6 +179,7 @@ private:
     TileEditService _tileService;
     InventoryEditService _inventoryService;
     ScriptEditService _scriptService;
+    EdgeEditService _edgeService;
     std::function<void()> _refreshObjects;
     std::function<void()> _reloadTiles;
     MapEditService _mapService;

--- a/src/rendering/MapEdgeOverlayGeometry.h
+++ b/src/rendering/MapEdgeOverlayGeometry.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <optional>
 
@@ -49,6 +50,48 @@ inline std::optional<sf::FloatRect> mapEdgeZoneWorldBounds(const HexagonGrid& gr
     const float minY = std::min(top->y, bottom->y);
     const float maxY = std::max(top->y, bottom->y);
     return sf::FloatRect({ minX, minY }, { maxX - minX, maxY - minY });
+}
+
+/// Shortest distance from point `p` to the segment `a`-`b`.
+inline float pointSegmentDistance(sf::Vector2f p, sf::Vector2f a, sf::Vector2f b) {
+    const sf::Vector2f ab{ b.x - a.x, b.y - a.y };
+    const float lengthSq = ab.x * ab.x + ab.y * ab.y;
+    float t = lengthSq > 0.f ? ((p.x - a.x) * ab.x + (p.y - a.y) * ab.y) / lengthSq : 0.f;
+    t = std::clamp(t, 0.f, 1.f);
+    const float dx = p.x - (a.x + t * ab.x);
+    const float dy = p.y - (a.y + t * ab.y);
+    return std::sqrt(dx * dx + dy * dy);
+}
+
+/// Distance from `p` to the four sides of rect `r`, indexed 0=left,1=top,2=right,3=bottom (matching
+/// EdgeEditService::Side and RenderData::activeEdgeSide).
+inline std::array<float, 4> mapEdgeSideDistances(sf::Vector2f p, const sf::FloatRect& r) {
+    const float l = r.position.x;
+    const float t = r.position.y;
+    const float rr = l + r.size.x;
+    const float b = t + r.size.y;
+    const sf::Vector2f tl{ l, t };
+    const sf::Vector2f tr{ rr, t };
+    const sf::Vector2f br{ rr, b };
+    const sf::Vector2f bl{ l, b };
+    return {
+        pointSegmentDistance(p, tl, bl), // left
+        pointSegmentDistance(p, tl, tr), // top
+        pointSegmentDistance(p, tr, br), // right
+        pointSegmentDistance(p, bl, br), // bottom
+    };
+}
+
+/// Distance from `p` to the nearest point on rect `r`'s outline (0 when on the border).
+inline float mapEdgeDistanceToBorder(sf::Vector2f p, const sf::FloatRect& r) {
+    const auto d = mapEdgeSideDistances(p, r);
+    return std::min({ d[0], d[1], d[2], d[3] });
+}
+
+/// The side of rect `r` (0=left,1=top,2=right,3=bottom) whose segment is nearest `p`.
+inline int mapEdgeNearestSide(sf::Vector2f p, const sf::FloatRect& r) {
+    const auto d = mapEdgeSideDistances(p, r);
+    return static_cast<int>(std::distance(d.begin(), std::min_element(d.begin(), d.end())));
 }
 
 /// The zone `tileRect` covering the whole hex grid — the seed the engine's mapper uses for a newly

--- a/src/rendering/MapEdgeOverlayGeometry.h
+++ b/src/rendering/MapEdgeOverlayGeometry.h
@@ -51,6 +51,52 @@ inline std::optional<sf::FloatRect> mapEdgeZoneWorldBounds(const HexagonGrid& gr
     return sf::FloatRect({ minX, minY }, { maxX - minX, maxY - minY });
 }
 
+/// The zone `tileRect` covering the whole hex grid — the seed the engine's mapper uses for a newly
+/// added zone (fallout2-ce map_edge_setup.cc `fullGridTileRect`). Corners are the grid's four extreme
+/// hex indices; `left`/`right` take the hexes with the max/min world X (X is stored inverted, matching
+/// the engine), `top`/`bottom` the min/max world Y. Any corner that is off-grid is skipped.
+inline MapEdge::Rect mapEdgeFullGridZone(const HexagonGrid& grid) {
+    const std::array<int, 4> corners{
+        0,
+        HexagonGrid::GRID_WIDTH - 1,
+        (HexagonGrid::GRID_HEIGHT - 1) * HexagonGrid::GRID_WIDTH,
+        HexagonGrid::POSITION_COUNT - 1,
+    };
+
+    MapEdge::Rect rect{ corners[0], corners[0], corners[0], corners[0] };
+    float maxX = 0.f;
+    float minX = 0.f;
+    float minY = 0.f;
+    float maxY = 0.f;
+    bool init = false;
+    for (int corner : corners) {
+        const auto hex = grid.getHexByPosition(static_cast<uint32_t>(corner));
+        if (!hex.has_value()) {
+            continue;
+        }
+        const float x = static_cast<float>(hex->get().x());
+        const float y = static_cast<float>(hex->get().y());
+        if (!init || x > maxX) {
+            maxX = x;
+            rect.left = corner; // X inverted: left holds the larger world X
+        }
+        if (!init || x < minX) {
+            minX = x;
+            rect.right = corner;
+        }
+        if (!init || y < minY) {
+            minY = y;
+            rect.top = corner;
+        }
+        if (!init || y > maxY) {
+            maxY = y;
+            rect.bottom = corner;
+        }
+        init = true;
+    }
+    return rect;
+}
+
 /// World-space centre of a square-grid cell `(col, row)` in the 100x100 floor grid.
 inline sf::Vector2f mapEdgeSquareCellCentre(int col, int row) {
     const int index = row * static_cast<int>(MAP_WIDTH) + col;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -15,6 +15,7 @@
 #include <QPoint>
 #include <QSize>
 #include <QStringList>
+#include "editing/commands/EdgeEditService.h"
 #include "editing/commands/ObjectCommandController.h"
 #include "format/map/MapScript.h"
 #include "util/BuiltTile.h"
@@ -331,6 +332,61 @@ void EditorWidget::deleteSpatialScript(uint32_t sid) {
     }
 }
 
+int EditorWidget::currentElevation() const {
+    return _session.currentElevation();
+}
+
+const std::optional<MapEdge>& EditorWidget::mapEdge() const {
+    return _controller.commandController().mapEdge();
+}
+
+void EditorWidget::addEdgeZone() {
+    if (!_session.map()) {
+        return;
+    }
+    const MapEdge::Rect seed = mapEdgeFullGridZone(_session.hexgrid());
+    const int index = _controller.commandController().addEdgeZone(_session.currentElevation(), seed);
+    if (index < 0) {
+        return;
+    }
+    _selectedEdgeZone = index; // select the new zone so it can be dragged/deleted right away
+    _activeEdgeSide = -1;
+    Q_EMIT mapEdgeChanged();
+}
+
+void EditorWidget::deleteSelectedEdgeZone() {
+    if (_selectedEdgeZone < 0) {
+        return;
+    }
+    if (_controller.commandController().deleteEdgeZone(_session.currentElevation(), _selectedEdgeZone)) {
+        _selectedEdgeZone = -1;
+        _activeEdgeSide = -1;
+        Q_EMIT mapEdgeChanged();
+    }
+}
+
+void EditorWidget::toggleEdgeClipSide(int side) {
+    if (side < 0 || side > 3) {
+        return;
+    }
+    if (_controller.commandController().toggleEdgeClipSide(_session.currentElevation(),
+            static_cast<EdgeEditService::Side>(side))) {
+        Q_EMIT mapEdgeChanged();
+    }
+}
+
+void EditorWidget::upgradeMapEdgeToVersion2() {
+    if (_controller.commandController().upgradeEdgeToVersion2()) {
+        Q_EMIT mapEdgeChanged();
+    }
+}
+
+void EditorWidget::resetMapEdgeSquare() {
+    if (_controller.commandController().resetEdgeSquare(_session.currentElevation())) {
+        Q_EMIT mapEdgeChanged();
+    }
+}
+
 void EditorWidget::setSelectedSpatialScript(uint32_t sid) {
     if (_session.selectedSpatialScriptSid() == sid) {
         return; // no change; also breaks the map<->panel selection sync feedback loop
@@ -416,8 +472,12 @@ bool EditorWidget::trySelectEdgeZoneAt(sf::Vector2f worldPos) {
     }
 
     if (bestZone < 0) {
-        _selectedEdgeZone = -1; // clicked away from any border: fall through to object selection
-        _activeEdgeSide = -1;
+        // Clicked away from any border: fall through to object selection.
+        if (_selectedEdgeZone != -1) {
+            _selectedEdgeZone = -1;
+            _activeEdgeSide = -1;
+            Q_EMIT mapEdgeChanged();
+        }
         return false;
     }
 
@@ -425,6 +485,7 @@ bool EditorWidget::trySelectEdgeZoneAt(sf::Vector2f worldPos) {
     setSelectedSpatialScript(MapScript::NONE);     // and with spatial scripts
     _selectedEdgeZone = bestZone;
     _activeEdgeSide = -1;
+    Q_EMIT mapEdgeChanged(); // refresh the panel's Delete-button enablement
     return true;
 }
 
@@ -1041,6 +1102,11 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
             deleteSpatialScript(_session.selectedSpatialScriptSid());
             return;
         }
+        // Likewise, Delete removes the selected map-edge zone only while its overlay is visible.
+        if (_session.visibility().showMapEdges && _selectedEdgeZone >= 0) {
+            deleteSelectedEdgeZone();
+            return;
+        }
         deleteSelectedObjects();
     };
 
@@ -1370,6 +1436,9 @@ void EditorWidget::rotateSelectedObject() {
 void EditorWidget::changeElevation(int elevation) {
     if (elevation >= ELEVATION_1 && elevation <= ELEVATION_3) {
         _session.setCurrentElevation(elevation);
+        // Edge zones are per-elevation, so a selected zone index doesn't carry across elevations.
+        _selectedEdgeZone = -1;
+        _activeEdgeSide = -1;
         loadSprites();
     }
 }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -18,6 +18,7 @@
 #include "editing/commands/ObjectCommandController.h"
 #include "format/map/MapScript.h"
 #include "util/BuiltTile.h"
+#include "rendering/MapEdgeOverlayGeometry.h"
 #include "rendering/MapSpriteLoader.h"
 #include "rendering/RenderingEngine.h"
 #include "ui/dragdrop/DragDropManager.h"
@@ -386,6 +387,45 @@ bool EditorWidget::trySelectSpatialScriptAt(sf::Vector2f worldPos) {
     _lastSpatialClickSid = MapScript::NONE;
     setSelectedSpatialScript(MapScript::NONE);
     return false;
+}
+
+bool EditorWidget::trySelectEdgeZoneAt(sf::Vector2f worldPos) {
+    if (!_session.visibility().showMapEdges || !_session.map() || !_session.map()->edge().has_value()) {
+        return false;
+    }
+    const int elevation = _session.currentElevation();
+    if (elevation < 0 || elevation >= MapEdge::ELEVATION_COUNT) {
+        return false;
+    }
+    const auto& zones = _session.map()->edge()->elevations[elevation].zones;
+
+    // Grab radius in world units: how close to a zone's outline a click must land to select it.
+    constexpr float kGrabTolerance = 12.f;
+    int bestZone = -1;
+    float bestDistance = kGrabTolerance;
+    for (int i = 0; i < static_cast<int>(zones.size()); ++i) {
+        const auto box = mapEdgeZoneWorldBounds(_session.hexgrid(), zones[i]);
+        if (!box.has_value()) {
+            continue;
+        }
+        const float distance = mapEdgeDistanceToBorder(worldPos, *box);
+        if (distance <= bestDistance) {
+            bestDistance = distance; // <= so a later (topmost-drawn) zone wins ties
+            bestZone = i;
+        }
+    }
+
+    if (bestZone < 0) {
+        _selectedEdgeZone = -1; // clicked away from any border: fall through to object selection
+        _activeEdgeSide = -1;
+        return false;
+    }
+
+    _session.selectionManager()->clearSelection(); // edge selection is exclusive with objects/tiles
+    setSelectedSpatialScript(MapScript::NONE);     // and with spatial scripts
+    _selectedEdgeZone = bestZone;
+    _activeEdgeSide = -1;
+    return true;
 }
 
 EditorWidget::~EditorWidget() {
@@ -815,6 +855,10 @@ void EditorWidget::bindSelectionCallbacks(InputHandler::Callbacks& callbacks) {
         // edits) that script instead of the object/tile underneath. Modified clicks (add/toggle/
         // range) stay object-selection operations and leave the spatial selection untouched.
         if (modifier == InputHandler::SelectionModifier::NONE && trySelectSpatialScriptAt(worldPos)) {
+            return;
+        }
+        // Likewise, a plain click near a map-edge zone's border selects that zone (overlay must be on).
+        if (modifier == InputHandler::SelectionModifier::NONE && trySelectEdgeZoneAt(worldPos)) {
             return;
         }
         SelectionModifier selectionModifier;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -489,6 +489,94 @@ bool EditorWidget::trySelectEdgeZoneAt(sf::Vector2f worldPos) {
     return true;
 }
 
+std::optional<std::pair<int, int>> EditorWidget::edgeSideAtForDrag(sf::Vector2f worldPos) const {
+    if (!_session.visibility().showMapEdges || !_session.map() || !_session.map()->edge().has_value()) {
+        return std::nullopt;
+    }
+    const int elevation = _session.currentElevation();
+    if (elevation < 0 || elevation >= MapEdge::ELEVATION_COUNT) {
+        return std::nullopt;
+    }
+    const auto& zones = _session.map()->edge()->elevations[elevation].zones;
+
+    constexpr float kGrabTolerance = 12.f;
+    int bestZone = -1;
+    int bestSide = -1;
+    float bestDistance = kGrabTolerance;
+    for (int i = 0; i < static_cast<int>(zones.size()); ++i) {
+        const auto box = mapEdgeZoneWorldBounds(_session.hexgrid(), zones[i]);
+        if (!box.has_value()) {
+            continue;
+        }
+        const auto sideDistances = mapEdgeSideDistances(worldPos, *box);
+        for (int side = 0; side < 4; ++side) {
+            if (sideDistances[side] <= bestDistance) {
+                bestDistance = sideDistances[side];
+                bestZone = i;
+                bestSide = side;
+            }
+        }
+    }
+    if (bestZone < 0) {
+        return std::nullopt;
+    }
+    return std::make_pair(bestZone, bestSide);
+}
+
+bool EditorWidget::beginEdgeSideDrag(sf::Vector2f worldPos) {
+    const auto hit = edgeSideAtForDrag(worldPos);
+    if (!hit.has_value()) {
+        return false;
+    }
+    _session.selectionManager()->clearSelection(); // exclusive with objects/tiles/scripts
+    setSelectedSpatialScript(MapScript::NONE);
+    _selectedEdgeZone = hit->first;
+    _edgeDragSide = hit->second;
+    _activeEdgeSide = hit->second; // draw the grabbed side highlighted while dragging
+    _draggingEdgeSide = true;
+    _edgeDragBefore = _controller.commandController().edgeSnapshot();
+    Q_EMIT mapEdgeChanged();
+    return true;
+}
+
+void EditorWidget::previewEdgeSideDrag(sf::Vector2f worldPos) {
+    if (!_draggingEdgeSide) {
+        return;
+    }
+    const int hex = _controller.viewport().worldPosToHexIndex(worldPos);
+    if (hex < 0) {
+        return; // cursor off-grid: keep the last previewed position
+    }
+    _controller.commandController().previewEdgeZoneSide(_session.currentElevation(), _selectedEdgeZone,
+        static_cast<EdgeEditService::Side>(_edgeDragSide), hex);
+}
+
+void EditorWidget::commitEdgeSideDrag(sf::Vector2f worldPos) {
+    if (!_draggingEdgeSide) {
+        return;
+    }
+    previewEdgeSideDrag(worldPos); // apply the final cursor position
+    // Record the whole gesture (drag start -> release) as a single undo entry.
+    _controller.commandController().commitEdgeEdit("Move Edge Side", _edgeDragBefore);
+    _draggingEdgeSide = false;
+    _edgeDragSide = -1;
+    _activeEdgeSide = -1;
+    _edgeDragBefore.reset();
+    Q_EMIT mapEdgeChanged();
+}
+
+void EditorWidget::cancelEdgeSideDrag() {
+    if (!_draggingEdgeSide) {
+        return;
+    }
+    _controller.commandController().restoreEdge(_edgeDragBefore); // discard the live preview
+    _draggingEdgeSide = false;
+    _edgeDragSide = -1;
+    _activeEdgeSide = -1;
+    _edgeDragBefore.reset();
+    Q_EMIT mapEdgeChanged();
+}
+
 EditorWidget::~EditorWidget() {
 }
 
@@ -975,26 +1063,45 @@ void EditorWidget::bindInteractionCallbacks(InputHandler::Callbacks& callbacks) 
     };
 
     callbacks.canStartObjectDrag = [this](sf::Vector2f worldPos) {
+        // A grabbable map-edge side takes priority over object dragging (both use this gesture).
+        if (edgeSideAtForDrag(worldPos).has_value()) {
+            return true;
+        }
         return _dragDropManager ? _dragDropManager->canStartObjectDrag(worldPos) : false;
     };
 
     callbacks.onObjectDragStart = [this](sf::Vector2f worldPos) {
+        if (beginEdgeSideDrag(worldPos)) {
+            return true;
+        }
         return _dragDropManager ? _dragDropManager->startObjectDrag(worldPos) : false;
     };
 
     callbacks.onObjectDragUpdate = [this](sf::Vector2f worldPos) {
+        if (_draggingEdgeSide) {
+            previewEdgeSideDrag(worldPos);
+            return;
+        }
         if (_dragDropManager) {
             _dragDropManager->updateObjectDrag(worldPos);
         }
     };
 
     callbacks.onObjectDragEnd = [this](sf::Vector2f worldPos) {
+        if (_draggingEdgeSide) {
+            commitEdgeSideDrag(worldPos);
+            return;
+        }
         if (_dragDropManager) {
             _dragDropManager->finishObjectDrag(worldPos);
         }
     };
 
     callbacks.onObjectDragCancel = [this]() {
+        if (_draggingEdgeSide) {
+            cancelEdgeSideDrag();
+            return;
+        }
         if (_dragDropManager) {
             _dragDropManager->cancelObjectDrag();
         }

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -562,6 +562,7 @@ void EditorWidget::commitEdgeSideDrag(sf::Vector2f worldPos) {
     _edgeDragSide = -1;
     _activeEdgeSide = -1;
     _edgeDragBefore.reset();
+    updateEdgeHoverCursor(worldPos); // the released side usually still sits under the cursor
     Q_EMIT mapEdgeChanged();
 }
 
@@ -574,7 +575,42 @@ void EditorWidget::cancelEdgeSideDrag() {
     _edgeDragSide = -1;
     _activeEdgeSide = -1;
     _edgeDragBefore.reset();
+    resetEdgeHoverCursor(); // the zone snapped back; the next mouse move re-evaluates the hover
     Q_EMIT mapEdgeChanged();
+}
+
+void EditorWidget::updateEdgeHoverCursor(sf::Vector2f worldPos) {
+    int side = -1;
+    if (_draggingEdgeSide) {
+        side = _edgeDragSide;
+    } else if (_mode == EditorMode::Select && _inputHandler
+        && _inputHandler->getCurrentAction() == InputHandler::EditorAction::NONE) {
+        // Side-dragging is a Select-mode gesture; skip the hover cursor mid-pan/drag-select.
+        if (const auto hit = edgeSideAtForDrag(worldPos)) {
+            side = hit->second;
+        }
+    }
+    if (side == _edgeHoverCursorSide) {
+        return;
+    }
+    _edgeHoverCursorSide = side;
+    if (!_sfmlWidget) {
+        return;
+    }
+    if (side < 0) {
+        _sfmlWidget->unsetCursor();
+    } else {
+        // Zone bounds are world-axis-aligned: sides 0/2 are the vertical left/right borders, 1/3 the
+        // horizontal top/bottom ones.
+        _sfmlWidget->setCursor((side == 0 || side == 2) ? Qt::SizeHorCursor : Qt::SizeVerCursor);
+    }
+}
+
+void EditorWidget::resetEdgeHoverCursor() {
+    if (_edgeHoverCursorSide >= 0 && _sfmlWidget) {
+        _sfmlWidget->unsetCursor();
+    }
+    _edgeHoverCursorSide = -1;
 }
 
 EditorWidget::~EditorWidget() {
@@ -1168,6 +1204,7 @@ void EditorWidget::bindToolModeCallbacks(InputHandler::Callbacks& callbacks) {
     callbacks.onMouseMove = [this](sf::Vector2f worldPos) {
         _currentHoverHex = _controller.viewport().updateHoverHex(worldPos);
         Q_EMIT hexHoverChanged(_currentHoverHex);
+        updateEdgeHoverCursor(worldPos);
         if (_mode == EditorMode::StampPattern) {
             updateStampPreview(worldPos);
         }

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -429,6 +429,16 @@ private:
     // selection. A miss clears the edge selection and returns false.
     bool trySelectEdgeZoneAt(sf::Vector2f worldPos);
 
+    // Edge side-drag, layered onto the existing object-drag gesture. edgeSideAtForDrag returns the
+    // {zone, side} whose side lies within grab range of worldPos (nullopt if none). begin selects that
+    // zone and snapshots the edge; preview moves the side live (no undo); commit records the whole
+    // gesture as one undo entry; cancel restores the snapshot.
+    std::optional<std::pair<int, int>> edgeSideAtForDrag(sf::Vector2f worldPos) const;
+    bool beginEdgeSideDrag(sf::Vector2f worldPos);
+    void previewEdgeSideDrag(sf::Vector2f worldPos);
+    void commitEdgeSideDrag(sf::Vector2f worldPos);
+    void cancelEdgeSideDrag();
+
     // Handles a click in SetPlayerPosition mode: routes to an armed beginHexPick callback (one-shot)
     // or, failing that, emits playerPositionSelected (legacy player-start pick).
     void handlePositionPickClick(sf::Vector2f worldPos);
@@ -558,6 +568,11 @@ private:
     // (-1 = none); _activeEdgeSide is the side being dragged (0=left,1=top,2=right,3=bottom; -1 = none).
     int _selectedEdgeZone = -1;
     int _activeEdgeSide = -1;
+    // Live side-drag state: while _draggingEdgeSide, mouse moves preview _edgeDragSide of the selected
+    // zone; _edgeDragBefore is the pre-drag edge snapshot, committed as one undo entry on release.
+    bool _draggingEdgeSide = false;
+    int _edgeDragSide = -1;
+    std::optional<MapEdge> _edgeDragBefore;
 
     // Base positions of the selected floor/roof sprites captured while a region is being dragged, so
     // the live preview can offset them and restore them when the drag ends.

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -342,6 +342,18 @@ public:
     };
     [[nodiscard]] std::optional<SpatialScriptInfo> spatialScriptInfo(uint32_t sid) const;
 
+    // Map-edge (.edg) editing (undoable). All operate on the current elevation and emit
+    // mapEdgeChanged() so the Map Edges panel refreshes. addEdgeZone seeds a full-grid zone and
+    // selects it; deleteSelectedEdgeZone / toggleEdgeClipSide act on the current selection/elevation.
+    void addEdgeZone();
+    void deleteSelectedEdgeZone();
+    void toggleEdgeClipSide(int side); // 0=left,1=top,2=right,3=bottom
+    void upgradeMapEdgeToVersion2();
+    void resetMapEdgeSquare();
+    [[nodiscard]] int selectedEdgeZone() const { return _selectedEdgeZone; }
+    [[nodiscard]] int currentElevation() const;
+    [[nodiscard]] const std::optional<MapEdge>& mapEdge() const;
+
 signals:
     /// The map-side spatial-script selection changed (marker click or clear). MainWindow mirrors it
     /// onto the Scripts panel row. Carries MapScript::NONE when nothing is selected.
@@ -351,6 +363,9 @@ signals:
     void spatialScriptEditActivated(uint32_t sid);
     /// A spatial script was added / edited / deleted, so the script panels must repopulate.
     void mapScriptsChanged();
+    /// The map edge changed (zone added/removed/moved, clip/version/square edit) or the selected
+    /// zone changed, so the Map Edges panel must refresh its counts, buttons and clip state.
+    void mapEdgeChanged();
 
     void selectionChanged(const selection::SelectionState& selection, int elevation);
     void mapLoadRequested(const std::string& mapPath);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -408,6 +408,12 @@ private:
     // selection and returns false so normal object selection proceeds.
     bool trySelectSpatialScriptAt(sf::Vector2f worldPos);
 
+    // If the map-edge overlay is visible and the click lands near a zone's border on the current
+    // elevation, select that zone (clearing object/tile/spatial selection) and return true. Selection
+    // is by border proximity, not area, so a click in a zone's interior falls through to normal object
+    // selection. A miss clears the edge selection and returns false.
+    bool trySelectEdgeZoneAt(sf::Vector2f worldPos);
+
     // Handles a click in SetPlayerPosition mode: routes to an armed beginHexPick callback (one-shot)
     // or, failing that, emits playerPositionSelected (legacy player-start pick).
     void handlePositionPickClick(sf::Vector2f worldPos);

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -110,6 +110,7 @@ public:
         if (!show) {
             _selectedEdgeZone = -1;
             _activeEdgeSide = -1;
+            resetEdgeHoverCursor(); // a lingering resize cursor would suggest a still-grabbable side
         }
     }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
@@ -439,6 +440,11 @@ private:
     void commitEdgeSideDrag(sf::Vector2f worldPos);
     void cancelEdgeSideDrag();
 
+    // Hover feedback for the side-drag: show a horizontal/vertical resize cursor while the mouse is
+    // over a grabbable zone side (and while dragging one); restore the default cursor otherwise.
+    void updateEdgeHoverCursor(sf::Vector2f worldPos);
+    void resetEdgeHoverCursor();
+
     // Handles a click in SetPlayerPosition mode: routes to an armed beginHexPick callback (one-shot)
     // or, failing that, emits playerPositionSelected (legacy player-start pick).
     void handlePositionPickClick(sf::Vector2f worldPos);
@@ -573,6 +579,9 @@ private:
     bool _draggingEdgeSide = false;
     int _edgeDragSide = -1;
     std::optional<MapEdge> _edgeDragBefore;
+    // The side whose resize cursor is currently applied to the viewport (-1 = default cursor); see
+    // updateEdgeHoverCursor.
+    int _edgeHoverCursorSide = -1;
 
     // Base positions of the selected floor/roof sprites captured while a region is being dragged, so
     // the live preview can offset them and restore them when the drag ends.

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -474,7 +474,8 @@ void MainWindow::setupMenuBar() {
             updateUndoRedoActions();
             if (_selectionPanel)
                 _selectionPanel->refresh();
-            refreshScriptsPanel(); // an undone spatial add/edit/delete must re-appear in the panel
+            refreshScriptsPanel();  // an undone spatial add/edit/delete must re-appear in the panel
+            refreshMapEdgesPanel(); // and an undone edge edit must re-sync the Map Edges group
         }
     });
 
@@ -487,7 +488,8 @@ void MainWindow::setupMenuBar() {
             updateUndoRedoActions();
             if (_selectionPanel)
                 _selectionPanel->refresh();
-            refreshScriptsPanel(); // keep the panel in step with a redone spatial add/edit/delete
+            refreshScriptsPanel();  // keep the panel in step with a redone spatial add/edit/delete
+            refreshMapEdgesPanel(); // and with a redone edge edit
         }
     });
 
@@ -1041,8 +1043,10 @@ void MainWindow::setupDockWidgets() {
             _currentEditorWidget->setShowMapEdges(enabled);
     });
     connect(this, &MainWindow::elevationChanged, this, [this](int elevation) {
-        if (_currentEditorWidget)
+        if (_currentEditorWidget) {
             _currentEditorWidget->changeElevation(elevation);
+            refreshMapEdgesPanel(); // edge zones/clip are per-elevation, so re-sync the panel
+        }
     });
     connect(this, &MainWindow::rotateObjectRequested, this, [this]() {
         if (_currentEditorWidget)
@@ -1571,6 +1575,38 @@ void MainWindow::connectPanelSignals() {
         connect(_mapInfoPanel, &MapInfoPanel::addSpatialScriptRequested,
             this, [this]() { openSpatialScriptDialog(std::nullopt); });
 
+        // Map-edge (.edg) editing routed to the editor's EdgeEditService (undoable).
+        connect(_mapInfoPanel, &MapInfoPanel::addEdgeZoneRequested, this, [this]() {
+            if (!_currentEditorWidget) {
+                return;
+            }
+            // Make the overlay visible so the new zone and its drag handles can be seen and shaped.
+            if (_showMapEdgesAction && !_showMapEdgesAction->isChecked()) {
+                _showMapEdgesAction->setChecked(true); // cascades to setShowMapEdges
+            }
+            _currentEditorWidget->addEdgeZone();
+        });
+        connect(_mapInfoPanel, &MapInfoPanel::deleteEdgeZoneRequested, this, [this]() {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->deleteSelectedEdgeZone();
+            }
+        });
+        connect(_mapInfoPanel, &MapInfoPanel::upgradeEdgeVersion2Requested, this, [this]() {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->upgradeMapEdgeToVersion2();
+            }
+        });
+        connect(_mapInfoPanel, &MapInfoPanel::edgeClipToggled, this, [this](int side) {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->toggleEdgeClipSide(side);
+            }
+        });
+        connect(_mapInfoPanel, &MapInfoPanel::resetEdgeSquareRequested, this, [this]() {
+            if (_currentEditorWidget) {
+                _currentEditorWidget->resetMapEdgeSquare();
+            }
+        });
+
         // Header edits in the Info panel write straight to the map (no undo command), so flag the map
         // modified here. These also fire while the panel is being populated from a freshly loaded map,
         // but setEditorWidget()/createNewMap clear the flag right after populating, so that's harmless.
@@ -1683,6 +1719,8 @@ void MainWindow::connectToEditorWidget() {
         [this](uint32_t sid) { openSpatialScriptDialog(sid); });
     connect(_currentEditorWidget, &EditorWidget::mapScriptsChanged, this,
         [this]() { refreshScriptsPanel(); });
+    connect(_currentEditorWidget, &EditorWidget::mapEdgeChanged, this,
+        [this]() { refreshMapEdgesPanel(); });
 
     if (_mapInfoPanel) {
         connect(_currentEditorWidget, &EditorWidget::playerPositionSelected,
@@ -1787,6 +1825,34 @@ void MainWindow::refreshScriptsPanel() {
     }
 }
 
+void MainWindow::refreshMapEdgesPanel() {
+    if (!_mapInfoPanel) {
+        return;
+    }
+    if (!_currentEditorWidget) {
+        _mapInfoPanel->setMapEdgeState(false, 0, 0, false, { false, false, false, false });
+        return;
+    }
+
+    const bool hasMap = _currentEditorWidget->getMap() != nullptr;
+    const int elevation = _currentEditorWidget->currentElevation();
+    const auto& edge = _currentEditorWidget->mapEdge();
+
+    int version = 0;
+    int zoneCount = 0;
+    std::array<bool, 4> clip{ false, false, false, false };
+    if (edge.has_value() && elevation >= 0 && elevation < MapEdge::ELEVATION_COUNT) {
+        version = edge->version;
+        const auto& elev = edge->elevations[elevation];
+        zoneCount = static_cast<int>(elev.zones.size());
+        clip = { elev.clipSides.left, elev.clipSides.top, elev.clipSides.right, elev.clipSides.bottom };
+    }
+    const int selected = _currentEditorWidget->selectedEdgeZone();
+    const bool hasSelectedZone = selected >= 0 && selected < zoneCount;
+
+    _mapInfoPanel->setMapEdgeState(hasMap, version, zoneCount, hasSelectedZone, clip);
+}
+
 void MainWindow::applySelectionColorsToEditor() {
     if (!_currentEditorWidget || !_settings) {
         return;
@@ -1842,6 +1908,7 @@ void MainWindow::syncMenuStateToEditorWidget() {
 void MainWindow::updateMapInfo(Map* map) {
     if (_mapInfoPanel) {
         _mapInfoPanel->setMap(map);
+        refreshMapEdgesPanel(); // setMap resets the edge group; re-fill it from the loaded map's .edg
     }
 
     if (_scriptsPanel) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -1039,8 +1039,11 @@ void MainWindow::setupDockWidgets() {
             _currentEditorWidget->setShowSpatialScripts(enabled);
     });
     connect(this, &MainWindow::showMapEdgesToggled, this, [this](bool enabled) {
-        if (_currentEditorWidget)
+        if (_currentEditorWidget) {
             _currentEditorWidget->setShowMapEdges(enabled);
+            // Hiding the overlay drops the edge-zone selection, so re-sync the panel's button state.
+            refreshMapEdgesPanel();
+        }
     });
     connect(this, &MainWindow::elevationChanged, this, [this](int elevation) {
         if (_currentEditorWidget) {

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -195,6 +195,7 @@ void MainWindow::setupUI() {
     _welcomeWidget = new WelcomeWidget(this);
     connect(_welcomeWidget, &WelcomeWidget::newMapRequested, this, &MainWindow::newMapRequested);
     connect(_welcomeWidget, &WelcomeWidget::browseMapsRequested, this, &MainWindow::showMapBrowserDialog);
+    connect(_welcomeWidget, &WelcomeWidget::preferencesRequested, this, &MainWindow::showPreferences);
     _centralStack->addWidget(_welcomeWidget);
     _centralStack->setCurrentWidget(_welcomeWidget);
 

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -196,6 +196,9 @@ private:
     // Rebuild the Scripts panel from the current map and re-assert the shared spatial selection.
     // Called after a spatial-script add/edit/delete and after undo/redo.
     void refreshScriptsPanel();
+    // Refresh the Info panel's Map Edges group from the editor's current edge/elevation/selection.
+    // Called after an edge edit, on elevation change, on undo/redo, and on map load.
+    void refreshMapEdgesPanel();
     void replaceDockPanelWidget(QDockWidget* dock, QWidget* panel, QSizePolicy::Policy verticalPolicy);
     void rebuildResourcePanels();
     void rebuildGameResourcesFromSettings();

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -319,6 +319,53 @@ void MapInfoPanel::setupUI() {
 
     _contentLayout->addWidget(_mapOperationsGroup);
 
+    // === Map Edges group (.edg zones + v2 diagonal square / clip) ===
+    _mapEdgesGroup = new QGroupBox("Map Edges");
+    QVBoxLayout* edgesLayout = new QVBoxLayout(_mapEdgesGroup);
+
+    _edgeZoneCountLabel = new QLabel();
+    _edgeZoneCountLabel->setWordWrap(true);
+    edgesLayout->addWidget(_edgeZoneCountLabel);
+
+    QHBoxLayout* zoneButtonRow = new QHBoxLayout();
+    _addEdgeZoneButton = new QPushButton("Add Zone");
+    _addEdgeZoneButton->setToolTip("Add a full-grid edge zone on the current elevation, then drag its sides on the map to shape it.");
+    _deleteEdgeZoneButton = new QPushButton("Delete Zone");
+    _deleteEdgeZoneButton->setToolTip("Delete the selected edge zone (or press Delete while the overlay is visible).");
+    zoneButtonRow->addWidget(_addEdgeZoneButton);
+    zoneButtonRow->addWidget(_deleteEdgeZoneButton);
+    edgesLayout->addLayout(zoneButtonRow);
+
+    _upgradeEdgeButton = new QPushButton("Enable Angled Edge (v2)");
+    _upgradeEdgeButton->setToolTip("Upgrade this edge to version 2, adding a diagonal \"square\" boundary and per-side clipping.");
+    edgesLayout->addWidget(_upgradeEdgeButton);
+
+    QHBoxLayout* clipRow = new QHBoxLayout();
+    clipRow->addWidget(new QLabel("Clip:"));
+    const std::array<const char*, 4> clipNames{ "Left", "Top", "Right", "Bottom" };
+    for (int side = 0; side < 4; ++side) {
+        _edgeClipChecks[side] = new QCheckBox(clipNames[side]);
+        clipRow->addWidget(_edgeClipChecks[side]);
+        connect(_edgeClipChecks[side], &QCheckBox::toggled, this, [this, side]() {
+            if (!_suppressEdgeEdit) {
+                Q_EMIT edgeClipToggled(side);
+            }
+        });
+    }
+    clipRow->addStretch();
+    edgesLayout->addLayout(clipRow);
+
+    _resetEdgeSquareButton = new QPushButton("Reset Square");
+    _resetEdgeSquareButton->setToolTip("Reset the v2 diagonal square to the full grid and clear all clip flags on the current elevation.");
+    edgesLayout->addWidget(_resetEdgeSquareButton);
+
+    connect(_addEdgeZoneButton, &QPushButton::clicked, this, &MapInfoPanel::onAddEdgeZoneClicked);
+    connect(_deleteEdgeZoneButton, &QPushButton::clicked, this, &MapInfoPanel::onDeleteEdgeZoneClicked);
+    connect(_upgradeEdgeButton, &QPushButton::clicked, this, &MapInfoPanel::onUpgradeEdgeClicked);
+    connect(_resetEdgeSquareButton, &QPushButton::clicked, this, &MapInfoPanel::onResetEdgeSquareClicked);
+
+    _contentLayout->addWidget(_mapEdgesGroup);
+
     _contentLayout->addStretch();
 
     _scrollArea->setWidget(_contentWidget);
@@ -619,7 +666,8 @@ void MapInfoPanel::clearMapInfo() {
     _globalVarsEdited = false;
     _mapScriptName = "no script";
 
-    updateGlobalVarButtons(); // no map -> Add/Remove disabled
+    updateGlobalVarButtons();                                            // no map -> Add/Remove disabled
+    setMapEdgeState(false, 0, 0, false, { false, false, false, false }); // no map -> edge group disabled
 }
 
 void MapInfoPanel::onFieldChanged() {
@@ -920,6 +968,53 @@ void MapInfoPanel::onAddSpatialScriptClicked() {
     }
     // The dialog (with its map-pick flow) is owned by MainWindow, which brokers the map click.
     Q_EMIT addSpatialScriptRequested();
+}
+
+void MapInfoPanel::onAddEdgeZoneClicked() {
+    Q_EMIT addEdgeZoneRequested();
+}
+
+void MapInfoPanel::onDeleteEdgeZoneClicked() {
+    Q_EMIT deleteEdgeZoneRequested();
+}
+
+void MapInfoPanel::onUpgradeEdgeClicked() {
+    Q_EMIT upgradeEdgeVersion2Requested();
+}
+
+void MapInfoPanel::onResetEdgeSquareClicked() {
+    Q_EMIT resetEdgeSquareRequested();
+}
+
+void MapInfoPanel::setMapEdgeState(bool hasMap, int version, int zoneCount, bool hasSelectedZone,
+    const std::array<bool, 4>& clip) {
+    if (!_mapEdgesGroup) {
+        return;
+    }
+    const bool hasEdge = version > 0;
+    const bool isVersion2 = version >= 2;
+
+    if (!hasMap) {
+        _edgeZoneCountLabel->setText("No map loaded.");
+    } else if (!hasEdge) {
+        _edgeZoneCountLabel->setText("No map edge yet — add a zone to create one.");
+    } else {
+        _edgeZoneCountLabel->setText(
+            QString("Edge zones on this elevation: %1  (version %2)").arg(zoneCount).arg(version));
+    }
+
+    _addEdgeZoneButton->setEnabled(hasMap);
+    _deleteEdgeZoneButton->setEnabled(hasMap && hasSelectedZone);
+    _upgradeEdgeButton->setVisible(!isVersion2); // one-way upgrade: hide once done
+    _upgradeEdgeButton->setEnabled(hasMap && hasEdge);
+    _resetEdgeSquareButton->setEnabled(hasMap && isVersion2);
+
+    _suppressEdgeEdit = true; // programmatic; don't re-emit edgeClipToggled
+    for (int side = 0; side < 4; ++side) {
+        _edgeClipChecks[side]->setChecked(clip[side]);
+        _edgeClipChecks[side]->setEnabled(hasMap && isVersion2);
+    }
+    _suppressEdgeEdit = false;
 }
 
 void MapInfoPanel::onGlobalVarChanged(QTreeWidgetItem* item, int column) {

--- a/src/ui/panels/MapInfoPanel.h
+++ b/src/ui/panels/MapInfoPanel.h
@@ -14,6 +14,7 @@
 #include <QComboBox>
 #include <QPushButton>
 #include "format/gam/Gam.h"
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -41,6 +42,13 @@ public:
 
     void setMap(Map* map);
     void setPlayerPosition(int hexPosition, int elevation);
+
+    /// Refresh the "Map Edges" group from the editor's current edge state (driven by MainWindow, which
+    /// owns the current elevation and the selected zone). `version` is 0 when the map has no `.edg`,
+    /// else 1 or 2; `clip` holds the four v2 clip flags (left,top,right,bottom) for the current
+    /// elevation. Programmatic; does not emit the edge-edit signals.
+    void setMapEdgeState(bool hasMap, int version, int zoneCount, bool hasSelectedZone,
+        const std::array<bool, 4>& clip);
 
     /// Write any pending Map name / Lookup name edits to the writable copy of map.msg / maps.txt.
     /// Called when the map is saved (the panel itself only marks the map modified on edit). A no-op
@@ -73,6 +81,13 @@ signals:
     void clearElevationRequested(int elevation);
     void copyElevationRequested(int fromElevation, int toElevation);
     void addSpatialScriptRequested();
+    /// Map-edge (.edg) editing, routed to EditorWidget's EdgeEditService (undoable). They act on the
+    /// current elevation / selected zone, which the editor owns. `side` is 0=left,1=top,2=right,3=bottom.
+    void addEdgeZoneRequested();
+    void deleteEdgeZoneRequested();
+    void upgradeEdgeVersion2Requested();
+    void edgeClipToggled(int side);
+    void resetEdgeSquareRequested();
 
 private slots:
     void onFieldChanged();
@@ -83,6 +98,10 @@ private slots:
     void onClearElevationClicked();
     void onCopyElevationClicked();
     void onAddSpatialScriptClicked();
+    void onAddEdgeZoneClicked();
+    void onDeleteEdgeZoneClicked();
+    void onUpgradeEdgeClicked();
+    void onResetEdgeSquareClicked();
     void onGlobalVarChanged(QTreeWidgetItem* item, int column);
     void onAddGlobalVar();
     void onRemoveGlobalVar();
@@ -147,6 +166,17 @@ private:
     QComboBox* _clearElevationCombo;
     QComboBox* _copyFromCombo;
     QComboBox* _copyToCombo;
+
+    // Map edges group (.edg zones + v2 clip). State is pushed in by MainWindow via setMapEdgeState;
+    // _suppressEdgeEdit guards the programmatic checkbox updates from firing edgeClipToggled.
+    QGroupBox* _mapEdgesGroup = nullptr;
+    QLabel* _edgeZoneCountLabel = nullptr;
+    QPushButton* _addEdgeZoneButton = nullptr;
+    QPushButton* _deleteEdgeZoneButton = nullptr;
+    QPushButton* _upgradeEdgeButton = nullptr;
+    QPushButton* _resetEdgeSquareButton = nullptr;
+    std::array<QCheckBox*, 4> _edgeClipChecks{}; // 0=left,1=top,2=right,3=bottom
+    bool _suppressEdgeEdit = false;
 
     resource::GameResources& _resources;
     std::shared_ptr<Settings> _settings;                  // for the writable data root used when editing names

--- a/src/ui/widgets/WelcomeWidget.cpp
+++ b/src/ui/widgets/WelcomeWidget.cpp
@@ -25,7 +25,8 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
     , _imageLabel(nullptr)
     , _versionLabel(nullptr)
     , _newMapButton(nullptr)
-    , _browseButton(nullptr) {
+    , _browseButton(nullptr)
+    , _preferencesButton(nullptr) {
     setupUI();
 }
 
@@ -62,19 +63,23 @@ void WelcomeWidget::createActionButtons() {
     // File menu's New Map / Browse Maps actions. MainWindow connects these signals to those handlers.
     _newMapButton = new QPushButton(createIcon(":/icons/actions/new.svg"), "New Map", this);
     _browseButton = new QPushButton(createIcon(":/icons/actions/open.svg"), "Browse Maps…", this);
-    for (QPushButton* button : { _newMapButton, _browseButton }) {
+    _preferencesButton = new QPushButton(createIcon(":/icons/actions/settings.svg"), "Preferences…", this);
+    for (QPushButton* button : { _newMapButton, _browseButton, _preferencesButton }) {
         button->setCursor(Qt::PointingHandCursor);
         button->setMinimumWidth(150);
     }
 
     connect(_newMapButton, &QPushButton::clicked, this, &WelcomeWidget::newMapRequested);
     connect(_browseButton, &QPushButton::clicked, this, &WelcomeWidget::browseMapsRequested);
+    connect(_preferencesButton, &QPushButton::clicked, this, &WelcomeWidget::preferencesRequested);
 
     auto* buttonRow = new QHBoxLayout();
     buttonRow->addStretch();
     buttonRow->addWidget(_newMapButton);
     buttonRow->addSpacing(ui::theme::spacing::NORMAL);
     buttonRow->addWidget(_browseButton);
+    buttonRow->addSpacing(ui::theme::spacing::NORMAL);
+    buttonRow->addWidget(_preferencesButton);
     buttonRow->addStretch();
 
     _layout->addSpacing(ui::theme::spacing::LOOSE);

--- a/src/ui/widgets/WelcomeWidget.h
+++ b/src/ui/widgets/WelcomeWidget.h
@@ -27,6 +27,8 @@ signals:
     void newMapRequested();
     /// The user asked to open the map browser from the welcome screen.
     void browseMapsRequested();
+    /// The user asked to open the preferences dialog from the welcome screen.
+    void preferencesRequested();
 
 private:
     void setupUI();
@@ -39,6 +41,7 @@ private:
     QLabel* _versionLabel;
     QPushButton* _newMapButton;
     QPushButton* _browseButton;
+    QPushButton* _preferencesButton;
 };
 
 } // namespace geck

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(general_tests
     general/test_map_edge_roundtrip.cpp
     general/test_undo_stack.cpp
     general/test_object_command_controller.cpp
+    general/test_edge_edit_service.cpp
     general/test_animation_layout.cpp
     general/test_reading_lst.cpp
     general/test_reading_pal.cpp

--- a/tests/general/test_edge_edit_service.cpp
+++ b/tests/general/test_edge_edit_service.cpp
@@ -81,6 +81,53 @@ TEST_CASE("EdgeEditService::deleteZone removes the right zone and is undoable", 
     CHECK(f.svc.edge()->elevations[0].zones[0] == EdgeFixture::seed());
 }
 
+TEST_CASE("EdgeEditService live side drag previews without undo, commits once", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed()); // undo entry #1 (creates the edge)
+
+    // Drag start: snapshot the edge, then preview several mouse-moves (no undo recorded per move).
+    const std::optional<MapEdge> before = f.svc.snapshot();
+    f.svc.previewZoneSide(0, 0, EdgeEditService::LEFT, 500);
+    f.svc.previewZoneSide(0, 0, EdgeEditService::LEFT, 800);
+    f.svc.previewZoneSide(0, 0, EdgeEditService::LEFT, 1200);
+    CHECK(f.svc.edge()->elevations[0].zones[0].left == 1200);
+
+    // Release: commit the whole gesture as a single undo entry (#2).
+    CHECK(f.svc.commitEdit("Move Edge Side", before));
+
+    REQUIRE(f.stack.undo()); // one undo reverts the entire drag, not just the last move
+    CHECK(f.svc.edge()->elevations[0].zones[0].left == EdgeFixture::seed().left);
+    REQUIRE(f.stack.redo());
+    CHECK(f.svc.edge()->elevations[0].zones[0].left == 1200);
+
+    // Exactly two commands were ever recorded (drag + add): the previews added none. Two undos empty
+    // the stack.
+    REQUIRE(f.stack.undo()); // undo the drag
+    REQUIRE(f.stack.undo()); // undo the add
+    CHECK_FALSE(f.svc.hasEdge());
+    CHECK_FALSE(f.stack.canUndo());
+}
+
+TEST_CASE("EdgeEditService restore discards a preview without recording", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed()); // the only undo entry
+
+    const std::optional<MapEdge> before = f.svc.snapshot();
+    f.svc.previewZoneSide(0, 0, EdgeEditService::TOP, 777);
+    CHECK(f.svc.edge()->elevations[0].zones[0].top == 777);
+
+    f.svc.restore(before); // drag cancel
+    CHECK(f.svc.edge()->elevations[0].zones[0].top == EdgeFixture::seed().top);
+
+    // An unchanged commit (no net move) records nothing.
+    CHECK_FALSE(f.svc.commitEdit("Move Edge Side", before));
+
+    // Only the add is on the stack: neither restore nor the no-op commit recorded anything.
+    REQUIRE(f.stack.undo());
+    CHECK_FALSE(f.svc.hasEdge());
+    CHECK_FALSE(f.stack.canUndo());
+}
+
 TEST_CASE("EdgeEditService v2 upgrade, clip, square and reset are undoable", "[edge_edit]") {
     EdgeFixture f;
     f.svc.addZone(0, EdgeFixture::seed()); // creates the edge as v1

--- a/tests/general/test_edge_edit_service.cpp
+++ b/tests/general/test_edge_edit_service.cpp
@@ -128,6 +128,22 @@ TEST_CASE("EdgeEditService restore discards a preview without recording", "[edge
     CHECK_FALSE(f.stack.canUndo());
 }
 
+TEST_CASE("EdgeEditService rejects v2 square/clip edits on a v1 edge", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed()); // edge starts at v1
+    REQUIRE(f.svc.edge()->version == 1);
+
+    // These only serialize for v2, so they must be rejected (not silently non-persisting edits).
+    CHECK_FALSE(f.svc.toggleClipSide(0, EdgeEditService::LEFT));
+    CHECK_FALSE(f.svc.setSquareSide(0, EdgeEditService::LEFT, 10));
+    CHECK_FALSE(f.svc.resetSquare(0));
+    CHECK_FALSE(f.svc.edge()->elevations[0].clipSides.left); // v1 block untouched
+
+    // Only the addZone is on the undo stack — the three rejected edits recorded nothing.
+    REQUIRE(f.stack.undo());
+    CHECK_FALSE(f.stack.canUndo());
+}
+
 TEST_CASE("EdgeEditService v2 upgrade, clip, square and reset are undoable", "[edge_edit]") {
     EdgeFixture f;
     f.svc.addZone(0, EdgeFixture::seed()); // creates the edge as v1

--- a/tests/general/test_edge_edit_service.cpp
+++ b/tests/general/test_edge_edit_service.cpp
@@ -1,0 +1,108 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <functional>
+#include <memory>
+
+#include "editing/commands/EdgeEditService.h"
+#include "editing/commands/UndoBatcher.h"
+#include "editor/HexagonGrid.h"
+#include "format/map/Map.h"
+#include "format/map/MapEdge.h"
+#include "util/UndoStack.h"
+
+using namespace geck;
+
+namespace {
+// EdgeEditService only touches Map::edge()/setEdge(), so a bare Map (no MapFile) is enough.
+struct EdgeFixture {
+    UndoStack stack{ 100 };
+    UndoBatcher batcher{ stack, [] { } };
+    std::unique_ptr<Map> map = std::make_unique<Map>(std::filesystem::path{});
+    EdgeEditService svc{ map, batcher };
+
+    static MapEdge::Rect seed() { return MapEdge::Rect{ 100, 200, 300, 400 }; }
+};
+} // namespace
+
+TEST_CASE("EdgeEditService::addZone creates the edge and is undoable", "[edge_edit]") {
+    EdgeFixture f;
+    CHECK_FALSE(f.svc.hasEdge());
+
+    const int index = f.svc.addZone(0, EdgeFixture::seed());
+    CHECK(index == 0);
+    REQUIRE(f.svc.hasEdge());
+    CHECK(f.svc.zoneCount(0) == 1);
+    CHECK(f.svc.edge()->elevations[0].zones[0] == EdgeFixture::seed());
+
+    REQUIRE(f.stack.undo());
+    CHECK_FALSE(f.svc.hasEdge()); // back to no edge at all
+
+    REQUIRE(f.stack.redo());
+    REQUIRE(f.svc.hasEdge());
+    CHECK(f.svc.zoneCount(0) == 1);
+}
+
+TEST_CASE("EdgeEditService::setZoneSide moves a corner and round-trips through undo/redo", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(1, EdgeFixture::seed());
+
+    CHECK(f.svc.setZoneSide(1, 0, EdgeEditService::LEFT, 1234));
+    CHECK(f.svc.edge()->elevations[1].zones[0].left == 1234);
+
+    REQUIRE(f.stack.undo());
+    CHECK(f.svc.edge()->elevations[1].zones[0].left == EdgeFixture::seed().left);
+    REQUIRE(f.stack.redo());
+    CHECK(f.svc.edge()->elevations[1].zones[0].left == 1234);
+}
+
+TEST_CASE("EdgeEditService::setZoneSide rejects bad args", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed());
+
+    CHECK_FALSE(f.svc.setZoneSide(0, 0, EdgeEditService::RIGHT, -1));
+    CHECK_FALSE(f.svc.setZoneSide(0, 0, EdgeEditService::RIGHT, HexagonGrid::POSITION_COUNT));
+    CHECK_FALSE(f.svc.setZoneSide(0, 9, EdgeEditService::RIGHT, 10)); // no such zone
+    CHECK_FALSE(f.svc.setZoneSide(9, 0, EdgeEditService::RIGHT, 10)); // no such elevation
+}
+
+TEST_CASE("EdgeEditService::deleteZone removes the right zone and is undoable", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed());
+    f.svc.addZone(0, MapEdge::Rect{ 1, 2, 3, 4 });
+    CHECK(f.svc.zoneCount(0) == 2);
+
+    CHECK(f.svc.deleteZone(0, 0));
+    CHECK(f.svc.zoneCount(0) == 1);
+    CHECK(f.svc.edge()->elevations[0].zones[0] == (MapEdge::Rect{ 1, 2, 3, 4 }));
+
+    REQUIRE(f.stack.undo());
+    CHECK(f.svc.zoneCount(0) == 2);
+    CHECK(f.svc.edge()->elevations[0].zones[0] == EdgeFixture::seed());
+}
+
+TEST_CASE("EdgeEditService v2 upgrade, clip, square and reset are undoable", "[edge_edit]") {
+    EdgeFixture f;
+    f.svc.addZone(0, EdgeFixture::seed()); // creates the edge as v1
+    CHECK(f.svc.edge()->version == 1);
+
+    CHECK(f.svc.upgradeToVersion2());
+    CHECK(f.svc.edge()->isVersion2());
+    CHECK_FALSE(f.svc.upgradeToVersion2()); // already v2 -> no-op
+
+    CHECK(f.svc.toggleClipSide(0, EdgeEditService::TOP));
+    CHECK(f.svc.edge()->elevations[0].clipSides.top);
+
+    CHECK(f.svc.setSquareSide(0, EdgeEditService::LEFT, 42));
+    CHECK(f.svc.edge()->elevations[0].squareRect.left == 42);
+    CHECK(f.svc.setSquareSide(0, EdgeEditService::LEFT, 9999)); // clamped to grid width - 1
+    CHECK(f.svc.edge()->elevations[0].squareRect.left == MapEdge::SQUARE_GRID_WIDTH - 1);
+
+    CHECK(f.svc.resetSquare(0));
+    CHECK(f.svc.edge()->elevations[0].squareRect
+        == (MapEdge::Rect{ MapEdge::SQUARE_GRID_WIDTH - 1, 0, 0, MapEdge::SQUARE_GRID_HEIGHT - 1 }));
+    CHECK_FALSE(f.svc.edge()->elevations[0].clipSides.top); // reset cleared clip flags
+
+    REQUIRE(f.stack.undo()); // undo the reset restores clip.top
+    CHECK(f.svc.edge()->elevations[0].clipSides.top);
+}

--- a/tests/qt/test_ui_regressions.cpp
+++ b/tests/qt/test_ui_regressions.cpp
@@ -1537,27 +1537,34 @@ TEST_CASE("Exit-grid stroke creates on the non-overlapping hexes (partial overla
     CHECK(ExitGridPlacementManager::freshHexesForLine({}, { 1 }).empty());
 }
 
-// The no-map welcome screen offers New Map / Browse Maps buttons; each must emit the matching
-// request signal (MainWindow wires these to the File-menu handlers) so the screen is actionable.
-TEST_CASE("Welcome screen buttons request New Map and Browse Maps", "[qt][welcome]") {
+// The no-map welcome screen offers New Map / Browse Maps / Preferences buttons; each must emit the
+// matching request signal (MainWindow wires these to the File-menu handlers) so the screen is
+// actionable.
+TEST_CASE("Welcome screen buttons request New Map, Browse Maps and Preferences", "[qt][welcome]") {
     geck::WelcomeWidget welcome;
 
     QSignalSpy newSpy(&welcome, &geck::WelcomeWidget::newMapRequested);
     QSignalSpy browseSpy(&welcome, &geck::WelcomeWidget::browseMapsRequested);
+    QSignalSpy preferencesSpy(&welcome, &geck::WelcomeWidget::preferencesRequested);
     REQUIRE(newSpy.isValid());
     REQUIRE(browseSpy.isValid());
+    REQUIRE(preferencesSpy.isValid());
 
     QPushButton* newMapButton = nullptr;
     QPushButton* browseButton = nullptr;
+    QPushButton* preferencesButton = nullptr;
     for (QPushButton* button : welcome.findChildren<QPushButton*>()) {
         if (button->text().contains("New")) {
             newMapButton = button;
         } else if (button->text().contains("Browse")) {
             browseButton = button;
+        } else if (button->text().contains("Preferences")) {
+            preferencesButton = button;
         }
     }
     REQUIRE(newMapButton != nullptr);
     REQUIRE(browseButton != nullptr);
+    REQUIRE(preferencesButton != nullptr);
 
     newMapButton->click();
     CHECK(newSpy.count() == 1);
@@ -1566,4 +1573,9 @@ TEST_CASE("Welcome screen buttons request New Map and Browse Maps", "[qt][welcom
     browseButton->click();
     CHECK(browseSpy.count() == 1);
     CHECK(newSpy.count() == 1); // the New Map click above, unchanged
+
+    preferencesButton->click();
+    CHECK(preferencesSpy.count() == 1);
+    CHECK(newSpy.count() == 1);
+    CHECK(browseSpy.count() == 1);
 }


### PR DESCRIPTION
Builds the interactive `.edg` editor on top of the read-only overlay from #104, mirroring fallout2-ce `mapper/map_edge_setup.cc`. All editing is undoable.

## What you can do
- **Select** a zone: with `View › Show Map Edges` on, click near a zone's border to select it (highlighted amber). Selection is by border proximity, so clicking a zone's interior still selects the object underneath.
- **Add / delete** zones: the Info panel gains a **Map Edges** group — *Add Zone* seeds a full-grid zone on the current elevation (turning the overlay on) and selects it; *Delete Zone* (or the Delete key while the overlay is visible) removes the selected zone.
- **Drag a side**: grab a zone's side near its outline and drag it — a live preview follows the cursor's hex, and the whole gesture is a single undo entry.
- **v2 angled edge**: *Enable Angled Edge (v2)* upgrades the edge; the four **clip** checkboxes and *Reset Square* then edit the per-elevation diagonal-square block.

## Design
- New `EdgeEditService` (`src/editing/commands/`) does whole-`optional<MapEdge>` snapshot edits and live-drag primitives (`snapshot`/`previewZoneSide` (no undo) / `restore` / `commitEdit`), aggregated in `ObjectCommandController` next to `ScriptEditService`.
- Side-drag reuses the existing object-move gesture (`canStartObjectDrag`/`onObjectDragStart`/Update/End/Cancel) — a grabbable edge side wins over object dragging when the overlay is visible; Escape cancels; a no-move press falls through to a border-click select.
- `MainWindow::refreshMapEdgesPanel()` keeps the panel in sync on edit / elevation-change / undo-redo / load. Edge zones are per-elevation, so switching elevation drops the zone selection.

## Engine fidelity
Side value = hex index; new zones seed the full-grid rect; v2 square/clip block matches the engine defaults — consistent with the model + reader/writer landed in #104.

## Tests
`test_edge_edit_service.cpp` (7 cases): add/delete/move + validation, v2 upgrade/clip/square/reset, and the drag lifecycle (previews record no undo, a drag commits atomically, cancel/no-op commit record nothing). Full suite green locally (395 ctest targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)