### PR TITLE
Add a dockable Log panel surfacing spdlog records in the UI

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -76,22 +76,20 @@ live with their library (`src/resource/`, `src/ui/`).
     selected folder as the default writable location, shown with a badge in the list and persisted in
     `Settings`; saves then target that folder regardless of list order. If none is marked, keep the
     current last-folder fallback and hint the user to pick one. DAT archives can't be marked (read-only).
-10. **Warnings/errors are console-only — no in-app log or map-completeness panel.** Map loading now
-    tolerates missing art and logs what it skipped (unresolved `tiles.lst` entries and object sprites,
-    named — see `MapLoader::loadMapResources`), but those records go to the `spdlog` sink (stderr /
-    console) and are invisible to a GUI user: they just see a map that silently renders some tiles or
-    objects blank, with no explanation. Other completeness signals are equally buried — unknown script
-    PIDs, protos that fail to resolve, references out of range, and the `resource missing` view (the
-    tiles/object art a map references but that isn't in the mounted data; see the CLI/MCP
-    resource-inspection tools). **Add a dockable Log / Diagnostics panel:** a custom `spdlog` sink
-    forwards warn/error/info records to a Qt model rendered in a filterable panel (level filter, copy,
-    clear, and jump-to-source where a record carries a hex/object), so load-time warnings surface in
-    the UI instead of the terminal. Pair it with a per-map **completeness summary** computed from the
-    same resolve checks the loader and `resource missing` already run — unresolved tiles (by id +
-    name), missing object sprites, unresolved scripts, plus a mount / data-path sanity line — so a user
-    can see at a glance what is absent and why a map looks incomplete. Unify this with the sslc/int2ssl
-    "output panel" the SSL-editing options call for (one panel, a separate compiler-output category)
-    rather than building two. Editor UX only; changes no map/format data.
+10. **In-app log panel — SHIPPED; completeness summary remaining.** The dockable **Log** panel
+    (View › Log, hidden by default like the Script Console) now surfaces every `spdlog` record in
+    the UI: `LogModelSink` (installed on the default logger at startup) feeds a bounded, thread-safe
+    `LogModel`, shown in a filterable table (minimum-level combo, message text filter, copy
+    selection/all, clear) with warning/error rows colour-coded (`src/ui/logging/`,
+    `src/ui/panels/LogPanel.*`). Load-time warnings — unresolved `tiles.lst` entries, missing object
+    sprites, map parse failures — are visible in-app instead of stderr. **Remaining follow-ups:**
+    (a) the per-map **completeness summary** computed from the same resolve checks the loader and
+    `resource missing` already run — unresolved tiles (by id + name), missing object sprites,
+    unresolved scripts, plus a mount / data-path sanity line — as a structured section rather than
+    prose warnings (MapLoader already collects the name lists; retain + surface them); (b)
+    jump-to-source where a record carries a hex/object (needs structured records, not text);
+    (c) when the SSL-editing output panel lands, make compiler output a category of this panel
+    rather than a second dock. Editor UX only; changes no map/format data.
 
 ### Generation-side exit placement — current state & smarter follow-up
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,8 +1,6 @@
 #define QT_NO_EMIT
 #include "Application.h"
 
-#include <algorithm>
-
 #include <spdlog/spdlog.h>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
@@ -137,8 +135,9 @@ std::string Application::processCommandLineArgs() {
 
 Application::~Application() {
     if (_logSink) {
-        auto& sinks = spdlog::default_logger()->sinks();
-        sinks.erase(std::remove(sinks.begin(), sinks.end(), _logSink), sinks.end());
+        // Detach only — do not mutate the logger's sink list here: a worker thread still logging
+        // would race the unsynchronized vector. The detached sink stays installed but inert
+        // (detach and sink_it_ hold the same base_sink mutex) until spdlog tears down at exit.
         _logSink->detach();
     }
     if (_mainWindow) {

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,6 +1,8 @@
 #define QT_NO_EMIT
 #include "Application.h"
 
+#include <algorithm>
+
 #include <spdlog/spdlog.h>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
@@ -11,6 +13,8 @@
 #include "version.h"
 #include "resource/GameResources.h"
 #include "resource/ResourcePaths.h"
+#include "ui/logging/LogModel.h"
+#include "ui/logging/LogModelSink.h"
 #include "state/loader/MapLoader.h"
 #include "util/GameDataPathResolver.h"
 #include "ui/Settings.h"
@@ -33,6 +37,12 @@ Application::Application(int argc, char** argv)
     _qtApp->setApplicationName(geck::version::name);
     _qtApp->setApplicationDisplayName(geck::version::name);
     _qtApp->setApplicationVersion(geck::version::string);
+
+    // Mirror every log record into the Log panel's model from here on, so load-time warnings
+    // (missing tile art, unresolved sprites, ...) reach the UI, not just the console.
+    _logModel = std::make_unique<LogModel>();
+    _logSink = std::make_shared<LogModelSink>(_logModel.get());
+    spdlog::default_logger()->sinks().push_back(_logSink);
 
     std::filesystem::path iconPath = getResourcesPath() / "icon.png";
     QIcon appIcon(QString::fromStdString(iconPath.string()));
@@ -126,6 +136,11 @@ std::string Application::processCommandLineArgs() {
 }
 
 Application::~Application() {
+    if (_logSink) {
+        auto& sinks = spdlog::default_logger()->sinks();
+        sinks.erase(std::remove(sinks.begin(), sinks.end(), _logSink), sinks.end());
+        _logSink->detach();
+    }
     if (_mainWindow) {
         _mainWindow->stopGameLoop();
     }
@@ -138,6 +153,7 @@ Application::~Application() {
 
 void Application::initUI() {
     _mainWindow = std::make_unique<MainWindow>(_resources, _settings);
+    _mainWindow->setLogModel(_logModel.get());
 
     // Check if this is first run or if user prefers maximized
     auto& settings = *_settings;

--- a/src/Application.h
+++ b/src/Application.h
@@ -10,6 +10,8 @@ namespace geck {
 
 class MainWindow;
 class Settings;
+class LogModel;
+class LogModelSink;
 namespace resource {
     class GameResources;
 }
@@ -38,6 +40,11 @@ private:
 
     std::unique_ptr<QApplication> _qtApp;
     std::shared_ptr<Settings> _settings;
+    // Log-panel record store + the spdlog sink feeding it. Declared before _mainWindow so the
+    // model outlives the window's Log panel; the sink is detached in ~Application before either
+    // goes away.
+    std::unique_ptr<LogModel> _logModel;
+    std::shared_ptr<LogModelSink> _logSink;
     std::unique_ptr<MainWindow> _mainWindow;
     std::shared_ptr<resource::GameResources> _resources;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,16 @@ set(GECK_APP_SOURCES
     ui/panels/SelectionPanel.cpp
     ui/panels/FileBrowserPanel.h
     ui/panels/FileBrowserPanel.cpp
+    ui/panels/LogPanel.h
+    ui/panels/LogPanel.cpp
+
+    # In-app log capture (spdlog sink -> Qt model shown by LogPanel)
+    ui/logging/LogModel.h
+    ui/logging/LogModel.cpp
+    ui/logging/LogModelSink.h
+    ui/logging/LogModelSink.cpp
+    ui/logging/LogFilterProxy.h
+    ui/logging/LogFilterProxy.cpp
 
     # Qt6 UI Dialogs
     ui/dialogs/FrmSelectorDialog.h

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -12,6 +12,7 @@
 #include "ui/panels/TilePalettePanel.h"
 #include "ui/panels/ObjectPalettePanel.h"
 #include "ui/panels/FileBrowserPanel.h"
+#include "ui/panels/LogPanel.h"
 #ifdef GECK_SCRIPTING_ENABLED
 #include "ui/panels/ScriptConsoleWidget.h"
 #include "scripting/LuaScriptRuntime.h" // ScriptResult
@@ -944,15 +945,14 @@ void MainWindow::wireScriptConsole() {
         const ScriptResult result = _currentEditorWidget->runScript(source.toStdString());
         _scriptConsole->showResult(result.ok, QString::fromStdString(result.output), QString::fromStdString(result.error));
     });
-
-    if (_viewMenu) {
-        _viewMenu->addSeparator();
-        QAction* consoleAction = _scriptConsoleDock->toggleViewAction();
-        consoleAction->setText(tr("Script &Console"));
-        _viewMenu->addAction(consoleAction);
-    }
 }
 #endif
+
+void MainWindow::setLogModel(LogModel* model) {
+    if (_logPanel) {
+        _logPanel->setModel(model);
+    }
+}
 
 void MainWindow::setupDockWidgets() {
     auto createDock = [this](const QString& title, const char* objectName, QWidget* panel, Qt::DockWidgetArea area, QSizePolicy::Policy verticalPolicy, int minHeight) {
@@ -996,6 +996,25 @@ void MainWindow::setupDockWidgets() {
     _scriptConsoleDock->hide();
     wireScriptConsole();
 #endif
+
+    // Log & diagnostics: same shape as the script console — a bottom dock outside the managed
+    // layout persistence, hidden until opened from the View menu. The record store is the
+    // application's LogModel, attached via setLogModel() once the window exists.
+    _logPanel = new LogPanel();
+    _logDock = createDock("Log", "LogDock", _logPanel, Qt::BottomDockWidgetArea, QSizePolicy::Expanding, ui::constants::dock::MIN_HEIGHT_SMALL);
+    _logDock->hide();
+
+    if (_viewMenu) {
+        _viewMenu->addSeparator();
+#ifdef GECK_SCRIPTING_ENABLED
+        QAction* consoleAction = _scriptConsoleDock->toggleViewAction();
+        consoleAction->setText(tr("Script &Console"));
+        _viewMenu->addAction(consoleAction);
+#endif
+        QAction* logAction = _logDock->toggleViewAction();
+        logAction->setText(tr("&Log"));
+        _viewMenu->addAction(logAction);
+    }
 
     // MainWindow signals → current editor widget (connected once; both sender
     // and receiver are MainWindow, so these survive for the lifetime of the window)

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -48,6 +48,8 @@ class ObjectPalettePanel;
 class FileBrowserPanel;
 class ScriptConsoleWidget;
 class SpatialScriptDialog;
+class LogPanel;
+class LogModel;
 class Map;
 
 class MainWindow : public QMainWindow {
@@ -87,6 +89,10 @@ public:
     void raiseTilePalette();
 
     resource::GameResources& resources() const { return *_resourcesShared; }
+
+    // Attach the application-wide log record store to the Log panel (the model outlives this
+    // window; the in-app spdlog sink feeds it from application startup on).
+    void setLogModel(LogModel* model);
 
 signals:
     void newMapRequested();
@@ -271,6 +277,8 @@ private:
     QDockWidget* _scriptConsoleDock = nullptr;
     ScriptConsoleWidget* _scriptConsole = nullptr;
 #endif
+    QDockWidget* _logDock = nullptr;
+    LogPanel* _logPanel = nullptr;
     // Guards the persisted dock layout while docks are re-laid-out programmatically (hidden for the
     // welcome screen, re-shown for a map), so those transient changes aren't written back as if the
     // user made them.

--- a/src/ui/logging/LogFilterProxy.cpp
+++ b/src/ui/logging/LogFilterProxy.cpp
@@ -1,0 +1,39 @@
+#include "LogFilterProxy.h"
+
+namespace geck {
+
+LogFilterProxy::LogFilterProxy(QObject* parent)
+    : QSortFilterProxyModel(parent) {
+}
+
+void LogFilterProxy::setMinimumLevel(LogModel::Level level) {
+    if (_minimumLevel == level) {
+        return;
+    }
+    _minimumLevel = level;
+    invalidateRowsFilter();
+}
+
+void LogFilterProxy::setSearchText(const QString& text) {
+    if (_searchText == text) {
+        return;
+    }
+    _searchText = text;
+    invalidateRowsFilter();
+}
+
+bool LogFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const {
+    const QModelIndex index = sourceModel()->index(sourceRow, LogModel::MessageColumn, sourceParent);
+
+    const int level = sourceModel()->data(index, LogModel::LEVEL_ROLE).toInt();
+    if (level < static_cast<int>(_minimumLevel)) {
+        return false;
+    }
+
+    if (_searchText.isEmpty()) {
+        return true;
+    }
+    return sourceModel()->data(index, Qt::DisplayRole).toString().contains(_searchText, Qt::CaseInsensitive);
+}
+
+} // namespace geck

--- a/src/ui/logging/LogFilterProxy.h
+++ b/src/ui/logging/LogFilterProxy.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QSortFilterProxyModel>
+
+#include "LogModel.h"
+
+namespace geck {
+
+/// Filters LogModel rows by a minimum level and a case-insensitive message substring.
+class LogFilterProxy : public QSortFilterProxyModel {
+    Q_OBJECT
+
+public:
+    explicit LogFilterProxy(QObject* parent = nullptr);
+
+    void setMinimumLevel(LogModel::Level level);
+    void setSearchText(const QString& text);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+
+private:
+    LogModel::Level _minimumLevel = LogModel::Level::Debug;
+    QString _searchText;
+};
+
+} // namespace geck

--- a/src/ui/logging/LogModel.cpp
+++ b/src/ui/logging/LogModel.cpp
@@ -1,0 +1,125 @@
+#include "LogModel.h"
+
+#include <QColor>
+#include <QThread>
+
+#include "ui/theme/ThemeManager.h"
+
+namespace geck {
+
+LogModel::LogModel(QObject* parent)
+    : QAbstractTableModel(parent) {
+}
+
+void LogModel::appendRecord(Level level, const QString& message, const QDateTime& time) {
+    const Record record{ time, level, message };
+    if (QThread::currentThread() == thread()) {
+        appendOnModelThread(record);
+        return;
+    }
+
+    // Queued to the model's thread; if the model is destroyed first, Qt drops the call.
+    QMetaObject::invokeMethod(
+        this, [this, record]() { appendOnModelThread(record); }, Qt::QueuedConnection);
+}
+
+void LogModel::appendOnModelThread(const Record& record) {
+    if (_records.size() >= MAX_RECORDS) {
+        beginRemoveRows(QModelIndex(), 0, 0);
+        _records.removeFirst();
+        endRemoveRows();
+    }
+
+    beginInsertRows(QModelIndex(), static_cast<int>(_records.size()), static_cast<int>(_records.size()));
+    _records.append(record);
+    endInsertRows();
+}
+
+void LogModel::clear() {
+    if (_records.isEmpty()) {
+        return;
+    }
+    beginResetModel();
+    _records.clear();
+    endResetModel();
+}
+
+QString LogModel::levelName(Level level) {
+    switch (level) {
+        case Level::Debug:
+            return QStringLiteral("debug");
+        case Level::Info:
+            return QStringLiteral("info");
+        case Level::Warning:
+            return QStringLiteral("warning");
+        case Level::Error:
+            return QStringLiteral("error");
+    }
+    return {};
+}
+
+int LogModel::rowCount(const QModelIndex& parent) const {
+    return parent.isValid() ? 0 : static_cast<int>(_records.size());
+}
+
+int LogModel::columnCount(const QModelIndex& parent) const {
+    return parent.isValid() ? 0 : ColumnCount;
+}
+
+QVariant LogModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() < 0 || index.row() >= _records.size()) {
+        return {};
+    }
+
+    const Record& record = _records.at(index.row());
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+            case TimeColumn:
+                return record.time.toString(QStringLiteral("HH:mm:ss.zzz"));
+            case LevelColumn:
+                return levelName(record.level);
+            case MessageColumn:
+                return record.message;
+            default:
+                return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        switch (record.level) {
+            case Level::Error:
+                return QColor(ui::theme::colors::STATUS_ERROR);
+            case Level::Warning:
+                return ui::theme::colors::statusWarningRgb();
+            case Level::Debug:
+                return QColor(ui::theme::colors::TEXT_MUTED);
+            case Level::Info:
+                return {};
+        }
+    }
+
+    if (role == LEVEL_ROLE) {
+        return static_cast<int>(record.level);
+    }
+
+    return {};
+}
+
+QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole) {
+        return {};
+    }
+    switch (section) {
+        case TimeColumn:
+            return tr("Time");
+        case LevelColumn:
+            return tr("Level");
+        case MessageColumn:
+            return tr("Message");
+        default:
+            return {};
+    }
+}
+
+} // namespace geck

--- a/src/ui/logging/LogModel.h
+++ b/src/ui/logging/LogModel.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QAbstractTableModel>
+#include <QDateTime>
+#include <QList>
+#include <QString>
+
+namespace geck {
+
+/// In-memory store of log records backing the Log panel. Records arrive from LogModelSink on
+/// whatever thread spdlog was called on; appendRecord() marshals them to the model's thread, so
+/// all model state and signals stay on the GUI thread. The store is bounded: once MAX_RECORDS is
+/// reached the oldest records are evicted.
+class LogModel : public QAbstractTableModel {
+    Q_OBJECT
+
+public:
+    enum class Level {
+        Debug = 0,
+        Info,
+        Warning,
+        Error,
+    };
+
+    enum Column {
+        TimeColumn = 0,
+        LevelColumn,
+        MessageColumn,
+        ColumnCount,
+    };
+
+    /// Role returning the record's Level as an int, on any column (used by LogFilterProxy).
+    static constexpr int LEVEL_ROLE = Qt::UserRole + 1;
+
+    static constexpr int MAX_RECORDS = 5000;
+
+    explicit LogModel(QObject* parent = nullptr);
+
+    /// Thread-safe append. When called off the model's thread the record is queued to it; the
+    /// row appears once that thread's event loop runs.
+    void appendRecord(Level level, const QString& message, const QDateTime& time = QDateTime::currentDateTime());
+
+    void clear();
+
+    static QString levelName(Level level);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+private:
+    struct Record {
+        QDateTime time;
+        Level level;
+        QString message;
+    };
+
+    void appendOnModelThread(const Record& record);
+
+    QList<Record> _records;
+};
+
+} // namespace geck

--- a/src/ui/logging/LogModelSink.cpp
+++ b/src/ui/logging/LogModelSink.cpp
@@ -1,0 +1,53 @@
+#include "LogModelSink.h"
+
+#include <chrono>
+
+#include <QDateTime>
+#include <QString>
+
+#include "LogModel.h"
+
+namespace geck {
+
+namespace {
+
+    LogModel::Level toModelLevel(spdlog::level::level_enum level) {
+        switch (level) {
+            case spdlog::level::trace:
+            case spdlog::level::debug:
+                return LogModel::Level::Debug;
+            case spdlog::level::info:
+                return LogModel::Level::Info;
+            case spdlog::level::warn:
+                return LogModel::Level::Warning;
+            default:
+                return LogModel::Level::Error;
+        }
+    }
+
+} // namespace
+
+LogModelSink::LogModelSink(LogModel* model)
+    : _model(model) {
+}
+
+void LogModelSink::detach() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    _model = nullptr;
+}
+
+void LogModelSink::sink_it_(const spdlog::details::log_msg& msg) {
+    if (!_model) {
+        return;
+    }
+
+    const auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(msg.time.time_since_epoch()).count();
+    _model->appendRecord(toModelLevel(msg.level),
+        QString::fromUtf8(msg.payload.data(), static_cast<qsizetype>(msg.payload.size())),
+        QDateTime::fromMSecsSinceEpoch(msecs));
+}
+
+void LogModelSink::flush_() {
+}
+
+} // namespace geck

--- a/src/ui/logging/LogModelSink.h
+++ b/src/ui/logging/LogModelSink.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <mutex>
+
+#include <spdlog/sinks/base_sink.h>
+
+namespace geck {
+
+class LogModel;
+
+/// spdlog sink that forwards each record to a LogModel. Safe to install on any logger:
+/// LogModel::appendRecord marshals cross-thread calls to the model's (GUI) thread itself.
+/// Call detach() before the model is destroyed if the sink outlives it.
+class LogModelSink : public spdlog::sinks::base_sink<std::mutex> {
+public:
+    explicit LogModelSink(LogModel* model);
+
+    /// Stop forwarding records (the model is about to go away).
+    void detach();
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override;
+    void flush_() override;
+
+private:
+    LogModel* _model; // guarded by base_sink's mutex_
+};
+
+} // namespace geck

--- a/src/ui/panels/LogPanel.cpp
+++ b/src/ui/panels/LogPanel.cpp
@@ -1,0 +1,130 @@
+#include "LogPanel.h"
+
+#include <algorithm>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QComboBox>
+#include <QFontDatabase>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QShortcut>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+#include "ui/logging/LogFilterProxy.h"
+#include "ui/logging/LogModel.h"
+#include "ui/theme/ThemeManager.h"
+
+namespace geck {
+
+LogPanel::LogPanel(QWidget* parent)
+    : QWidget(parent)
+    , _proxy(new LogFilterProxy(this))
+    , _view(new QTreeView(this))
+    , _levelFilter(new QComboBox(this))
+    , _search(new QLineEdit(this))
+    , _copyButton(new QPushButton(tr("Copy"), this))
+    , _clearButton(new QPushButton(tr("Clear"), this)) {
+
+    for (auto level : { LogModel::Level::Debug, LogModel::Level::Info, LogModel::Level::Warning, LogModel::Level::Error }) {
+        _levelFilter->addItem(LogModel::levelName(level), static_cast<int>(level));
+    }
+    _levelFilter->setToolTip(tr("Show records at or above this level"));
+
+    _search->setPlaceholderText(tr("Filter messages…"));
+    _search->setClearButtonEnabled(true);
+
+    auto* controls = new QHBoxLayout();
+    controls->setSpacing(ui::theme::spacing::NORMAL);
+    controls->addWidget(_levelFilter);
+    controls->addWidget(_search, 1);
+    controls->addWidget(_copyButton);
+    controls->addWidget(_clearButton);
+
+    _view->setModel(_proxy);
+    _view->setRootIsDecorated(false);
+    _view->setUniformRowHeights(true);
+    _view->setAlternatingRowColors(true);
+    _view->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    _view->setSelectionBehavior(QAbstractItemView::SelectRows);
+    _view->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    _view->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    _view->header()->setSectionResizeMode(LogModel::TimeColumn, QHeaderView::ResizeToContents);
+    _view->header()->setSectionResizeMode(LogModel::LevelColumn, QHeaderView::ResizeToContents);
+    _view->header()->setSectionResizeMode(LogModel::MessageColumn, QHeaderView::Stretch);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setSpacing(ui::theme::spacing::TIGHT);
+    layout->addLayout(controls);
+    layout->addWidget(_view, 1);
+
+    connect(_levelFilter, &QComboBox::currentIndexChanged, this, &LogPanel::onLevelFilterChanged);
+    connect(_search, &QLineEdit::textChanged, this, &LogPanel::onSearchTextChanged);
+    connect(_copyButton, &QPushButton::clicked, this, &LogPanel::onCopy);
+    connect(_clearButton, &QPushButton::clicked, this, &LogPanel::onClear);
+
+    const auto* copyShortcut = new QShortcut(QKeySequence::Copy, _view);
+    connect(copyShortcut, &QShortcut::activated, this, &LogPanel::onCopy);
+
+    // Follow the newest records unless the user has scrolled up to read something.
+    connect(_view->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        _followTail = value >= _view->verticalScrollBar()->maximum();
+    });
+    connect(_proxy, &QAbstractItemModel::rowsInserted, this, [this]() {
+        if (_followTail) {
+            _view->scrollToBottom();
+        }
+    });
+}
+
+void LogPanel::setModel(LogModel* model) {
+    _model = model;
+    _proxy->setSourceModel(model);
+}
+
+void LogPanel::onLevelFilterChanged(int index) {
+    _proxy->setMinimumLevel(static_cast<LogModel::Level>(_levelFilter->itemData(index).toInt()));
+}
+
+void LogPanel::onSearchTextChanged(const QString& text) {
+    _proxy->setSearchText(text);
+}
+
+void LogPanel::onCopy() {
+    QModelIndexList rows;
+    const auto* selection = _view->selectionModel();
+    if (selection && selection->hasSelection()) {
+        rows = selection->selectedRows();
+        std::sort(rows.begin(), rows.end(), [](const QModelIndex& a, const QModelIndex& b) { return a.row() < b.row(); });
+    } else {
+        rows.reserve(_proxy->rowCount());
+        for (int row = 0; row < _proxy->rowCount(); ++row) {
+            rows.append(_proxy->index(row, 0));
+        }
+    }
+
+    QStringList lines;
+    lines.reserve(rows.size());
+    for (const QModelIndex& row : rows) {
+        lines.append(QStringLiteral("[%1] [%2] %3")
+                .arg(_proxy->index(row.row(), LogModel::TimeColumn).data().toString(),
+                    _proxy->index(row.row(), LogModel::LevelColumn).data().toString(),
+                    _proxy->index(row.row(), LogModel::MessageColumn).data().toString()));
+    }
+
+    if (!lines.isEmpty()) {
+        QApplication::clipboard()->setText(lines.join(QLatin1Char('\n')));
+    }
+}
+
+void LogPanel::onClear() {
+    if (_model) {
+        _model->clear();
+    }
+}
+
+} // namespace geck

--- a/src/ui/panels/LogPanel.h
+++ b/src/ui/panels/LogPanel.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QWidget>
+
+class QComboBox;
+class QLineEdit;
+class QPushButton;
+class QTreeView;
+
+namespace geck {
+
+class LogModel;
+class LogFilterProxy;
+
+/// Dockable log & diagnostics panel: a filterable view over the LogModel that the in-app spdlog
+/// sink feeds, so load-time warnings (missing tile art, unresolved sprites, ...) are visible in
+/// the UI instead of only on the console. Offers a minimum-level filter, a message text filter,
+/// copy (selection or the whole filtered view), and clear.
+class LogPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit LogPanel(QWidget* parent = nullptr);
+
+    /// Attach the record store. The panel does not own the model.
+    void setModel(LogModel* model);
+
+private:
+    void onLevelFilterChanged(int index);
+    void onSearchTextChanged(const QString& text);
+    void onCopy();
+    void onClear();
+
+    LogModel* _model = nullptr;
+    LogFilterProxy* _proxy;
+    QTreeView* _view;
+    QComboBox* _levelFilter;
+    QLineEdit* _search;
+    QPushButton* _copyButton;
+    QPushButton* _clearButton;
+    bool _followTail = true;
+};
+
+} // namespace geck

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,8 @@ add_executable(qt_tests
     qt/test_input_handler.cpp
     # hintForContext is the pure status-bar key-hint provider (lives in gecko_app).
     qt/test_editor_hints.cpp
+    # Log panel plumbing: the LogModel store (cap, threading), the spdlog sink, the filter proxy.
+    qt/test_log_panel.cpp
 )
 
 # Round-trip the headless pattern writer (gecko_cli) through the editor's Qt PatternSerializer.

--- a/tests/qt/test_log_panel.cpp
+++ b/tests/qt/test_log_panel.cpp
@@ -1,0 +1,134 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+
+#include <spdlog/logger.h>
+
+#include "ui/logging/LogFilterProxy.h"
+#include "ui/logging/LogModel.h"
+#include "ui/logging/LogModelSink.h"
+
+using namespace geck;
+
+TEST_CASE("LogModel stores records with level, message, and time", "[qt][log]") {
+    LogModel model;
+    REQUIRE(model.rowCount() == 0);
+
+    model.appendRecord(LogModel::Level::Warning, "tile art missing",
+        QDateTime::fromMSecsSinceEpoch(0));
+
+    REQUIRE(model.rowCount() == 1);
+    REQUIRE(model.columnCount() == LogModel::ColumnCount);
+    CHECK(model.index(0, LogModel::LevelColumn).data().toString() == "warning");
+    CHECK(model.index(0, LogModel::MessageColumn).data().toString() == "tile art missing");
+    CHECK(model.index(0, LogModel::MessageColumn).data(LogModel::LEVEL_ROLE).toInt()
+        == static_cast<int>(LogModel::Level::Warning));
+    CHECK(!model.index(0, LogModel::TimeColumn).data().toString().isEmpty());
+}
+
+TEST_CASE("LogModel evicts the oldest records beyond the cap", "[qt][log]") {
+    LogModel model;
+    for (int i = 0; i < LogModel::MAX_RECORDS + 10; ++i) {
+        model.appendRecord(LogModel::Level::Info, QString::number(i));
+    }
+
+    REQUIRE(model.rowCount() == LogModel::MAX_RECORDS);
+    CHECK(model.index(0, LogModel::MessageColumn).data().toString() == "10");
+    CHECK(model.index(model.rowCount() - 1, LogModel::MessageColumn).data().toString()
+        == QString::number(LogModel::MAX_RECORDS + 9));
+}
+
+TEST_CASE("LogModel clear empties the store", "[qt][log]") {
+    LogModel model;
+    model.appendRecord(LogModel::Level::Error, "boom");
+    model.clear();
+    REQUIRE(model.rowCount() == 0);
+}
+
+TEST_CASE("LogModel delivers records appended from another thread", "[qt][log]") {
+    LogModel model;
+
+    std::thread worker([&model]() {
+        model.appendRecord(LogModel::Level::Info, "from worker thread");
+    });
+    worker.join();
+
+    // The append was queued to this (the model's) thread; run the event loop until it lands.
+    QElapsedTimer timer;
+    timer.start();
+    while (model.rowCount() == 0 && timer.elapsed() < 5000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    }
+
+    REQUIRE(model.rowCount() == 1);
+    CHECK(model.index(0, LogModel::MessageColumn).data().toString() == "from worker thread");
+}
+
+TEST_CASE("LogModelSink forwards spdlog records with mapped levels", "[qt][log]") {
+    LogModel model;
+    auto sink = std::make_shared<LogModelSink>(&model);
+    spdlog::logger logger("log-panel-test", sink);
+    logger.set_level(spdlog::level::trace);
+
+    logger.trace("t");
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+    logger.critical("c");
+
+    REQUIRE(model.rowCount() == 6);
+    auto levelAt = [&model](int row) {
+        return static_cast<LogModel::Level>(
+            model.index(row, LogModel::MessageColumn).data(LogModel::LEVEL_ROLE).toInt());
+    };
+    CHECK(levelAt(0) == LogModel::Level::Debug);
+    CHECK(levelAt(1) == LogModel::Level::Debug);
+    CHECK(levelAt(2) == LogModel::Level::Info);
+    CHECK(levelAt(3) == LogModel::Level::Warning);
+    CHECK(levelAt(4) == LogModel::Level::Error);
+    CHECK(levelAt(5) == LogModel::Level::Error);
+    CHECK(model.index(3, LogModel::MessageColumn).data().toString() == "w");
+}
+
+TEST_CASE("LogModelSink drops records after detach", "[qt][log]") {
+    LogModel model;
+    auto sink = std::make_shared<LogModelSink>(&model);
+    spdlog::logger logger("log-panel-detach-test", sink);
+
+    logger.info("before");
+    sink->detach();
+    logger.info("after");
+
+    REQUIRE(model.rowCount() == 1);
+    CHECK(model.index(0, LogModel::MessageColumn).data().toString() == "before");
+}
+
+TEST_CASE("LogFilterProxy filters by minimum level and message text", "[qt][log]") {
+    LogModel model;
+    model.appendRecord(LogModel::Level::Debug, "loading tiles");
+    model.appendRecord(LogModel::Level::Info, "map opened");
+    model.appendRecord(LogModel::Level::Warning, "12 tiles.lst entries could not be resolved");
+    model.appendRecord(LogModel::Level::Error, "failed to resolve sprite");
+
+    LogFilterProxy proxy;
+    proxy.setSourceModel(&model);
+    REQUIRE(proxy.rowCount() == 4);
+
+    proxy.setMinimumLevel(LogModel::Level::Warning);
+    REQUIRE(proxy.rowCount() == 2);
+    CHECK(proxy.index(0, LogModel::MessageColumn).data().toString().startsWith("12 tiles.lst"));
+
+    proxy.setSearchText("RESOLVE");
+    REQUIRE(proxy.rowCount() == 2); // case-insensitive: "resolved" + "resolve"
+
+    proxy.setMinimumLevel(LogModel::Level::Debug);
+    proxy.setSearchText("tiles");
+    REQUIRE(proxy.rowCount() == 2); // "loading tiles" + the warning
+
+    proxy.setSearchText("no such message");
+    REQUIRE(proxy.rowCount() == 0);
+}


### PR DESCRIPTION
## What

Adds the dockable **Log** panel from the improvement backlog (PLAN known-limitation #10): every `spdlog` record now reaches the UI, so a GUI user finally sees the load-time warnings the tolerant map loader emits (unresolved `tiles.lst` entries, missing object sprites, map parse failures) instead of a silently incomplete map.

- **`LogModelSink`** (`src/ui/logging/`) — a `spdlog` sink installed on the default logger at application startup, so records from the whole session are captured, including ones logged before the window exists.
- **`LogModel`** — bounded (5000 records) Qt table model; appends from worker threads (e.g. `MapLoader`) are marshalled to the GUI thread via a queued call, so the sink is safe to install on any logger.
- **`LogFilterProxy` + `LogPanel`** — filterable view: minimum-level combo, case-insensitive message filter, copy (selection or the whole filtered view, also Ctrl/Cmd+C), clear, colour-coded warning/error rows, and tail-follow that pauses while scrolled up.
- Wired as a bottom dock (**View › Log**), hidden by default — same shape as the Script Console dock, outside the managed-layout persistence.

## Verification

Drove the built app end to end: loaded a generated vanilla map (records from the loader worker thread appear live in the panel), and drove two real failure paths (nonexistent map, RP map against vanilla protos) — the exact error/warning text that previously went only to stderr shows up in the panel, colour-coded.

Unit coverage in `tests/qt/test_log_panel.cpp`: model store/cap/eviction, cross-thread delivery, spdlog level mapping, detach, and proxy level+text filtering.

## Follow-ups (tracked in PLAN.md)

- Per-map completeness summary (structured unresolved-resource lists, not prose warnings)
- Jump-to-source for records that carry a hex/object
- Compiler-output category for the future SSL toolchain panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)