### PR TITLE
Add a per-map completeness summary as the Log dock's Map tab

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -76,20 +76,23 @@ live with their library (`src/resource/`, `src/ui/`).
     selected folder as the default writable location, shown with a badge in the list and persisted in
     `Settings`; saves then target that folder regardless of list order. If none is marked, keep the
     current last-folder fallback and hint the user to pick one. DAT archives can't be marked (read-only).
-10. **In-app log panel — SHIPPED; completeness summary remaining.** The dockable **Log** panel
-    (View › Log, hidden by default like the Script Console) now surfaces every `spdlog` record in
+10. **In-app log panel — SHIPPED, including the completeness summary.** The dockable **Log** panel
+    (View › Log, hidden by default like the Script Console) surfaces every `spdlog` record in
     the UI: `LogModelSink` (installed on the default logger at startup) feeds a bounded, thread-safe
     `LogModel`, shown in a filterable table (minimum-level combo, message text filter, copy
     selection/all, clear) with warning/error rows colour-coded (`src/ui/logging/`,
     `src/ui/panels/LogPanel.*`). Load-time warnings — unresolved `tiles.lst` entries, missing object
-    sprites, map parse failures — are visible in-app instead of stderr. **Remaining follow-ups:**
-    (a) the per-map **completeness summary** computed from the same resolve checks the loader and
-    `resource missing` already run — unresolved tiles (by id + name), missing object sprites,
-    unresolved scripts, plus a mount / data-path sanity line — as a structured section rather than
-    prose warnings (MapLoader already collects the name lists; retain + surface them); (b)
-    jump-to-source where a record carries a hex/object (needs structured records, not text);
-    (c) when the SSL-editing output panel lands, make compiler output a category of this panel
-    rather than a second dock. Editor UX only; changes no map/format data.
+    sprites, map parse failures — are visible in-app instead of stderr. The per-map **completeness
+    summary** shipped as the dock's second tab (**Map**): `resource::scanMapCompleteness`
+    (`src/resource/MapCompleteness.*`, the same scan `resource missing` now renders as JSON — the
+    CLI/MCP output gained `missingScripts` + `mounts` + index-mount flags) checks every referenced
+    tile, object sprite, and script against the mounted data, and `CompletenessView` shows the
+    result grouped (Tile art / Object sprites / Scripts / Data paths) with per-entry reasons, a
+    mount + index-file sanity section, copy, and a Refresh re-scan; refreshed on map
+    load/close/script-mutation, with a one-line totals warning in the Log tab. **Remaining
+    follow-ups:** (b) jump-to-source where a record carries a hex/object (needs structured records,
+    not text); (c) when the SSL-editing output panel lands, make compiler output a category of this
+    panel rather than a second dock. Editor UX only; changes no map/format data.
 
 ### Generation-side exit placement — current state & smarter follow-up
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,8 @@ set(GECK_APP_SOURCES
     ui/panels/FileBrowserPanel.cpp
     ui/panels/LogPanel.h
     ui/panels/LogPanel.cpp
+    ui/panels/CompletenessView.h
+    ui/panels/CompletenessView.cpp
 
     # In-app log capture (spdlog sink -> Qt model shown by LogPanel)
     ui/logging/LogModel.h
@@ -466,6 +468,8 @@ add_library(gecko_resource STATIC
 
     resource/MapNameResolver.h
     resource/MapNameResolver.cpp
+    resource/MapCompleteness.h
+    resource/MapCompleteness.cpp
     resource/AiTxtLoader.h
     resource/ScriptNames.h
     resource/WritableDataRoot.h

--- a/src/cli/ResourceInspect.cpp
+++ b/src/cli/ResourceInspect.cpp
@@ -1,23 +1,16 @@
 #include "cli/ResourceInspect.h"
 
 #include "cli/MapLoad.h"
-#include "format/lst/Lst.h"
 #include "format/map/Map.h"
-#include "format/map/MapObject.h"
-#include "format/map/Tile.h"
 #include "resource/DataFileSystem.h"
-#include "resource/FrmResolver.h"
 #include "resource/GameResources.h"
-#include "resource/ResourcePaths.h"
+#include "resource/MapCompleteness.h"
 
 #include <nlohmann/json.hpp>
 
-#include <cctype>
-#include <cstdint>
 #include <optional>
 #include <ostream>
 #include <regex>
-#include <set>
 #include <string>
 
 using json = nlohmann::json;
@@ -124,75 +117,47 @@ int resourceMissing(resource::GameResources& resources, const std::string& mapPa
         return 1;
     }
 
-    auto& files = resources.files();
-
-    // --- Tiles: distinct floor/roof ids across every elevation -> tiles.lst filename -> exists? ---
-    std::set<int> usedTileIds;
-    for (const auto& [elevation, tiles] : map->getMapFile().tiles) {
-        for (const auto& tile : tiles) {
-            if (tile.getFloor() != Map::EMPTY_TILE) {
-                usedTileIds.insert(tile.getFloor());
-            }
-            if (tile.getRoof() != Map::EMPTY_TILE) {
-                usedTileIds.insert(tile.getRoof());
-            }
-        }
-    }
-
-    const Lst* tilesLst = nullptr;
-    try {
-        tilesLst = resources.repository().load<Lst>(std::string(ResourcePaths::Lst::TILES));
-    } catch (const std::exception&) {
-        tilesLst = nullptr; // reported below as an unresolved tiles.lst
-    }
+    // The scan itself is shared with the editor's completeness panel (resource/MapCompleteness);
+    // this function only renders the report as JSON.
+    const resource::MapCompletenessReport report = resource::scanMapCompleteness(resources, *map);
 
     auto missingTiles = json::array();
-    for (int id : usedTileIds) {
-        if (tilesLst == nullptr) {
-            missingTiles.push_back({ { "id", id }, { "art", nullptr }, { "reason", "tiles.lst not mounted" } });
-            continue;
-        }
-        const auto& names = tilesLst->list();
-        if (id < 0 || static_cast<std::size_t>(id) >= names.size()) {
-            missingTiles.push_back({ { "id", id }, { "art", nullptr }, { "reason", "tile id out of tiles.lst range" } });
-            continue;
-        }
-        const std::string art = "art/tiles/" + names[static_cast<std::size_t>(id)];
-        if (!files.exists(art)) {
-            missingTiles.push_back({ { "id", id }, { "art", art } });
-        }
+    for (const auto& tile : report.missingTiles) {
+        missingTiles.push_back({ { "id", tile.id },
+            { "art", tile.art.empty() ? json(nullptr) : json(tile.art) },
+            { "reason", tile.reason } });
     }
 
-    // --- Object art: distinct FIDs -> resolved art path -> exists? (resolve() can throw) ---
-    std::set<std::uint32_t> checkedFids;
     auto missingObjectArt = json::array();
-    for (const auto& [elevation, objects] : map->objects()) {
-        for (const auto& object : objects) {
-            if (object->position == -1) {
-                continue; // inventory/container child, not placed on the map
-            }
-            if (!checkedFids.insert(object->frm_pid).second) {
-                continue; // this FID already checked
-            }
-            std::string art;
-            try {
-                art = resources.frmResolver().resolve(object->frm_pid);
-            } catch (const std::exception&) {
-                missingObjectArt.push_back({ { "pid", object->frm_pid }, { "art", nullptr }, { "reason", "FID does not resolve" } });
-                continue;
-            }
-            if (art.empty() || !files.exists(art)) {
-                missingObjectArt.push_back({ { "pid", object->frm_pid }, { "art", art.empty() ? json(nullptr) : json(art) } });
-            }
-        }
+    for (const auto& art : report.missingObjectArt) {
+        missingObjectArt.push_back({ { "pid", art.fid },
+            { "art", art.art.empty() ? json(nullptr) : json(art.art) },
+            { "reason", art.reason } });
+    }
+
+    auto missingScripts = json::array();
+    for (const auto& script : report.unresolvedScripts) {
+        missingScripts.push_back({ { "programIndex", script.programIndex },
+            { "name", script.name.empty() ? json(nullptr) : json(script.name) },
+            { "reason", script.reason } });
+    }
+
+    auto mounts = json::array();
+    for (const auto& mount : report.mounts) {
+        mounts.push_back(sourceInfoJson(mount));
     }
 
     json result{
         { "map", mapPath },
-        { "usedTileCount", usedTileIds.size() },
-        { "objectArtCount", checkedFids.size() },
+        { "usedTileCount", report.usedTileCount },
+        { "objectArtCount", report.objectArtCount },
+        { "scriptCount", report.scriptCount },
         { "missingTiles", std::move(missingTiles) },
         { "missingObjectArt", std::move(missingObjectArt) },
+        { "missingScripts", std::move(missingScripts) },
+        { "mounts", std::move(mounts) },
+        { "tilesLstMounted", report.tilesLstMounted },
+        { "scriptsLstMounted", report.scriptsLstMounted },
     };
     out << result.dump() << "\n";
     return 0;

--- a/src/cli/ResourceInspect.h
+++ b/src/cli/ResourceInspect.h
@@ -24,12 +24,16 @@ namespace cli {
     /// flags an over-long result). Browse a DAT / data set's contents without extracting.
     int resourceList(resource::GameResources& resources, const std::string& glob, std::ostream& out);
 
-    /// Report the art a map REFERENCES but that does not resolve in the mounted data: the diagnostic
-    /// for "why won't this map load / render fully". Writes JSON: {map, usedTileCount, objectArtCount,
-    /// missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}, where a missing entry carries an extra
-    /// "reason" when the art path couldn't even be formed ("tiles.lst not mounted", "tile id out of
-    /// tiles.lst range", "FID does not resolve"). Empty arrays mean everything resolves. Mirrors what
-    /// the editor's (now tolerant) loader would skip. Exit code 1 only when the map itself can't be read.
+    /// Report everything a map REFERENCES but that does not resolve in the mounted data: the
+    /// diagnostic for "why won't this map load / render fully". A JSON rendering of
+    /// resource::scanMapCompleteness (shared with the editor's completeness panel): {map,
+    /// usedTileCount, objectArtCount, scriptCount, missingTiles:[{id,art,reason}],
+    /// missingObjectArt:[{pid,art,reason}], missingScripts:[{programIndex,name,reason}],
+    /// mounts:[{kind,path,label}], tilesLstMounted, scriptsLstMounted}. "art"/"name" are null when
+    /// the path couldn't even be formed ("tiles.lst not mounted", "tile id out of tiles.lst range",
+    /// "FID does not resolve", "program index out of scripts.lst range"). Empty arrays mean
+    /// everything resolves. Mirrors what the editor's (now tolerant) loader would skip. Exit code 1
+    /// only when the map itself can't be read.
     int resourceMissing(resource::GameResources& resources, const std::string& mapPath, std::ostream& out);
 
 } // namespace cli

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -705,11 +705,13 @@ namespace {
             json({ { "type", "object" }, { "properties", { { "glob", { { "type", "string" } } } } }, { "required", json::array({ "glob" }) } }),
             [](resource::GameResources& r, const json& a) { return toolResourceList(r, a); } });
         t.push_back({ "resource_missing",
-            "Report the art a map REFERENCES but that does NOT resolve in the mounted data — the "
+            "Report everything a map REFERENCES but that does NOT resolve in the mounted data — the "
             "diagnostic for 'why won't this map load / render fully'. JSON {map, usedTileCount, "
-            "objectArtCount, missingTiles:[{id,art}], missingObjectArt:[{pid,art}]}, where a missing entry "
-            "gains a 'reason' when the art path couldn't even be formed ('tiles.lst not mounted', 'tile id "
-            "out of tiles.lst range', 'FID does not resolve'). Empty arrays mean everything the map uses "
+            "objectArtCount, scriptCount, missingTiles:[{id,art,reason}], missingObjectArt:"
+            "[{pid,art,reason}], missingScripts:[{programIndex,name,reason}], mounts:[{kind,path,label}], "
+            "tilesLstMounted, scriptsLstMounted}. 'art'/'name' are null when the path couldn't even be "
+            "formed ('tiles.lst not mounted', 'tile id out of tiles.lst range', 'FID does not resolve', "
+            "'program index out of scripts.lst range'). Empty arrays mean everything the map uses "
             "resolves (so a load failure is elsewhere — e.g. a mount-path mistake; check with resource_find). "
             "Mirrors what the editor's loader now tolerantly skips instead of aborting. Args: map (.map path).",
             json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } } } }, { "required", json::array({ "map" }) } }),

--- a/src/resource/DataFileSystem.cpp
+++ b/src/resource/DataFileSystem.cpp
@@ -185,6 +185,33 @@ void DataFileSystem::refresh() {
     }
 }
 
+namespace {
+
+    // Classify a mounted filesystem into the source description exposed to callers.
+    MountedSourceInfo describeMount(const vfspp::IFileSystemPtr& fileSystem) {
+        if (auto datFs = std::dynamic_pointer_cast<geck::GeckDat2FileSystem>(fileSystem)) {
+            const std::filesystem::path datPath(datFs->getDatPath());
+            std::string label = datPath.filename().string();
+            if (label.empty()) {
+                label = datPath.generic_string();
+            }
+            return MountedSourceInfo{ MountedSourceInfo::Kind::Dat, datPath, "DAT (" + label + ")" };
+        }
+
+        if (auto nativeFs = std::dynamic_pointer_cast<vfspp::NativeFileSystem>(fileSystem)) {
+            const std::filesystem::path nativePath(nativeFs->BasePath());
+            std::string label = nativePath.filename().string();
+            if (label.empty()) {
+                label = nativePath.generic_string();
+            }
+            return MountedSourceInfo{ MountedSourceInfo::Kind::Directory, nativePath, "Native (" + label + ")" };
+        }
+
+        return MountedSourceInfo{ MountedSourceInfo::Kind::Directory, std::filesystem::path(fileSystem->BasePath()), "VFS" };
+    }
+
+} // namespace
+
 std::optional<MountedSourceInfo> DataFileSystem::sourceInfo(const std::filesystem::path& path) const {
     const std::scoped_lock lock(_mutex);
     if (!_vfs) {
@@ -212,28 +239,31 @@ std::optional<MountedSourceInfo> DataFileSystem::sourceInfo(const std::filesyste
             continue;
         }
 
-        if (auto datFs = std::dynamic_pointer_cast<geck::GeckDat2FileSystem>(fileSystem)) {
-            const std::filesystem::path datPath(datFs->getDatPath());
-            std::string label = datPath.filename().string();
-            if (label.empty()) {
-                label = datPath.generic_string();
-            }
-            return MountedSourceInfo{ MountedSourceInfo::Kind::Dat, datPath, "DAT (" + label + ")" };
-        }
-
-        if (auto nativeFs = std::dynamic_pointer_cast<vfspp::NativeFileSystem>(fileSystem)) {
-            const std::filesystem::path nativePath(nativeFs->BasePath());
-            std::string label = nativePath.filename().string();
-            if (label.empty()) {
-                label = nativePath.generic_string();
-            }
-            return MountedSourceInfo{ MountedSourceInfo::Kind::Directory, nativePath, "Native (" + label + ")" };
-        }
-
-        return MountedSourceInfo{ MountedSourceInfo::Kind::Directory, std::filesystem::path(fileSystem->BasePath()), "VFS" };
+        return describeMount(fileSystem);
     }
 
     return std::nullopt;
+}
+
+std::vector<MountedSourceInfo> DataFileSystem::mounts() const {
+    const std::scoped_lock lock(_mutex);
+    if (!_vfs) {
+        return {};
+    }
+
+    const auto fileSystemsOpt = _vfs->GetFilesystems("/");
+    if (!fileSystemsOpt) {
+        return {};
+    }
+
+    std::vector<MountedSourceInfo> result;
+    for (const auto& fileSystem : fileSystemsOpt->get()) {
+        if (!fileSystem || !fileSystem->IsInitialized()) {
+            continue;
+        }
+        result.push_back(describeMount(fileSystem));
+    }
+    return result;
 }
 
 std::filesystem::path DataFileSystem::normalizeVfsPath(const std::filesystem::path& path) {

--- a/src/resource/DataFileSystem.h
+++ b/src/resource/DataFileSystem.h
@@ -50,6 +50,10 @@ public:
     [[nodiscard]] std::vector<std::filesystem::path> list(const std::string& pattern = "*") const;
     std::optional<MountedSourceInfo> sourceInfo(const std::filesystem::path& path) const;
 
+    /// Every initialized mount in mount (priority) order — the data paths a resource lookup
+    /// walks. Later mounts shadow earlier ones on lookup (sourceInfo probes in reverse).
+    [[nodiscard]] std::vector<MountedSourceInfo> mounts() const;
+
 private:
     // Mounts a path with _mutex already held; addDataPath() is the public locking entry point.
     void addDataPathLocked(const std::filesystem::path& path);

--- a/src/resource/DataFileSystem.h
+++ b/src/resource/DataFileSystem.h
@@ -50,8 +50,9 @@ public:
     [[nodiscard]] std::vector<std::filesystem::path> list(const std::string& pattern = "*") const;
     std::optional<MountedSourceInfo> sourceInfo(const std::filesystem::path& path) const;
 
-    /// Every initialized mount in mount (priority) order — the data paths a resource lookup
-    /// walks. Later mounts shadow earlier ones on lookup (sourceInfo probes in reverse).
+    /// Every initialized mount, in the order the data paths were added. Lookups probe the
+    /// mounts in the REVERSE of this order (see sourceInfo), so a later entry shadows an
+    /// earlier one that provides the same path.
     [[nodiscard]] std::vector<MountedSourceInfo> mounts() const;
 
 private:

--- a/src/resource/MapCompleteness.cpp
+++ b/src/resource/MapCompleteness.cpp
@@ -25,106 +25,112 @@ namespace {
         }
     }
 
+    // Tiles: distinct floor/roof ids across every elevation -> tiles.lst filename -> exists?
+    void scanTiles(GameResources& resources, const Map& map, MapCompletenessReport& report) {
+        std::set<int> usedTileIds;
+        for (const auto& [elevation, tiles] : map.getMapFile().tiles) {
+            for (const auto& tile : tiles) {
+                if (tile.getFloor() != Map::EMPTY_TILE) {
+                    usedTileIds.insert(tile.getFloor());
+                }
+                if (tile.getRoof() != Map::EMPTY_TILE) {
+                    usedTileIds.insert(tile.getRoof());
+                }
+            }
+        }
+        report.usedTileCount = usedTileIds.size();
+
+        const Lst* tilesLst = tryLoadLst(resources, ResourcePaths::Lst::TILES);
+        report.tilesLstMounted = tilesLst != nullptr;
+
+        for (int id : usedTileIds) {
+            if (tilesLst == nullptr) {
+                report.missingTiles.push_back({ id, {}, "tiles.lst not mounted" });
+                continue;
+            }
+            const auto& names = tilesLst->list();
+            if (id < 0 || static_cast<std::size_t>(id) >= names.size()) {
+                report.missingTiles.push_back({ id, {}, "tile id out of tiles.lst range" });
+                continue;
+            }
+            std::string art = std::string(ResourcePaths::Directories::TILES) + names[static_cast<std::size_t>(id)];
+            if (!resources.files().exists(art)) {
+                report.missingTiles.push_back({ id, std::move(art), "art not in mounted data" });
+            }
+        }
+    }
+
+    // Object art: distinct FIDs -> resolved art path -> exists? (resolve() can throw)
+    void scanObjectArt(GameResources& resources, const Map& map, MapCompletenessReport& report) {
+        std::set<std::uint32_t> checkedFids;
+        for (const auto& [elevation, objects] : map.objects()) {
+            for (const auto& object : objects) {
+                if (object->position == -1) {
+                    continue; // inventory/container child, not placed on the map
+                }
+                if (!checkedFids.insert(object->frm_pid).second) {
+                    continue; // this FID already checked
+                }
+                std::string art;
+                try {
+                    art = resources.frmResolver().resolve(object->frm_pid);
+                } catch (const std::exception&) {
+                    report.missingObjectArt.push_back({ object->frm_pid, {}, "FID does not resolve" });
+                    continue;
+                }
+                if (art.empty() || !resources.files().exists(art)) {
+                    report.missingObjectArt.push_back({ object->frm_pid, std::move(art), "art not in mounted data" });
+                }
+            }
+        }
+        report.objectArtCount = checkedFids.size();
+    }
+
+    // Scripts: distinct scripts.lst program indices -> filename -> compiled .int exists?
+    // The header's own script id is 1-based (0 / -1 = none); map_scripts entries carry the
+    // 0-based program index directly (see ScriptsPanel / MapInfoPanel).
+    void scanScripts(GameResources& resources, const Map& map, MapCompletenessReport& report) {
+        std::set<std::uint32_t> programIndices;
+        if (map.getMapFile().header.script_id > 0) {
+            programIndices.insert(static_cast<std::uint32_t>(map.getMapFile().header.script_id - 1));
+        }
+        for (const auto& section : map.getMapFile().map_scripts) {
+            for (const auto& script : section) {
+                if (script.script_id != MapScript::NONE) {
+                    programIndices.insert(script.script_id);
+                }
+            }
+        }
+        report.scriptCount = programIndices.size();
+
+        const Lst* scriptsLst = tryLoadLst(resources, ResourcePaths::Lst::SCRIPTS);
+        report.scriptsLstMounted = scriptsLst != nullptr;
+
+        for (std::uint32_t index : programIndices) {
+            if (scriptsLst == nullptr) {
+                report.unresolvedScripts.push_back({ index, {}, "scripts.lst not mounted" });
+                continue;
+            }
+            const auto& names = scriptsLst->list();
+            if (index >= names.size()) {
+                report.unresolvedScripts.push_back({ index, {}, "program index out of scripts.lst range" });
+                continue;
+            }
+            const std::string& name = names[index];
+            if (!resources.files().exists(std::string(ResourcePaths::Directories::SCRIPTS) + name)) {
+                report.unresolvedScripts.push_back({ index, name, "compiled script not in mounted data" });
+            }
+        }
+    }
+
 } // namespace
 
 MapCompletenessReport scanMapCompleteness(GameResources& resources, const Map& map) {
     MapCompletenessReport report;
-    auto& files = resources.files();
-
-    report.mounts = files.mounts();
-
-    // --- Tiles: distinct floor/roof ids across every elevation -> tiles.lst filename -> exists? ---
-    std::set<int> usedTileIds;
-    for (const auto& [elevation, tiles] : map.getMapFile().tiles) {
-        for (const auto& tile : tiles) {
-            if (tile.getFloor() != Map::EMPTY_TILE) {
-                usedTileIds.insert(tile.getFloor());
-            }
-            if (tile.getRoof() != Map::EMPTY_TILE) {
-                usedTileIds.insert(tile.getRoof());
-            }
-        }
-    }
-    report.usedTileCount = usedTileIds.size();
-
-    const Lst* tilesLst = tryLoadLst(resources, ResourcePaths::Lst::TILES);
-    report.tilesLstMounted = tilesLst != nullptr;
-
-    for (int id : usedTileIds) {
-        if (tilesLst == nullptr) {
-            report.missingTiles.push_back({ id, {}, "tiles.lst not mounted" });
-            continue;
-        }
-        const auto& names = tilesLst->list();
-        if (id < 0 || static_cast<std::size_t>(id) >= names.size()) {
-            report.missingTiles.push_back({ id, {}, "tile id out of tiles.lst range" });
-            continue;
-        }
-        std::string art = std::string(ResourcePaths::Directories::TILES) + names[static_cast<std::size_t>(id)];
-        if (!files.exists(art)) {
-            report.missingTiles.push_back({ id, std::move(art), "art not in mounted data" });
-        }
-    }
-
-    // --- Object art: distinct FIDs -> resolved art path -> exists? (resolve() can throw) ---
-    std::set<std::uint32_t> checkedFids;
-    for (const auto& [elevation, objects] : map.objects()) {
-        for (const auto& object : objects) {
-            if (object->position == -1) {
-                continue; // inventory/container child, not placed on the map
-            }
-            if (!checkedFids.insert(object->frm_pid).second) {
-                continue; // this FID already checked
-            }
-            std::string art;
-            try {
-                art = resources.frmResolver().resolve(object->frm_pid);
-            } catch (const std::exception&) {
-                report.missingObjectArt.push_back({ object->frm_pid, {}, "FID does not resolve" });
-                continue;
-            }
-            if (art.empty() || !files.exists(art)) {
-                report.missingObjectArt.push_back({ object->frm_pid, std::move(art), "art not in mounted data" });
-            }
-        }
-    }
-    report.objectArtCount = checkedFids.size();
-
-    // --- Scripts: distinct scripts.lst program indices -> filename -> compiled .int exists? ---
-    // The header's own script id is 1-based (0 / -1 = none); map_scripts entries carry the
-    // 0-based program index directly (see ScriptsPanel / MapInfoPanel).
-    std::set<std::uint32_t> programIndices;
-    if (map.getMapFile().header.script_id > 0) {
-        programIndices.insert(static_cast<std::uint32_t>(map.getMapFile().header.script_id - 1));
-    }
-    for (const auto& section : map.getMapFile().map_scripts) {
-        for (const auto& script : section) {
-            if (script.script_id != MapScript::NONE) {
-                programIndices.insert(script.script_id);
-            }
-        }
-    }
-    report.scriptCount = programIndices.size();
-
-    const Lst* scriptsLst = tryLoadLst(resources, ResourcePaths::Lst::SCRIPTS);
-    report.scriptsLstMounted = scriptsLst != nullptr;
-
-    for (std::uint32_t index : programIndices) {
-        if (scriptsLst == nullptr) {
-            report.unresolvedScripts.push_back({ index, {}, "scripts.lst not mounted" });
-            continue;
-        }
-        const auto& names = scriptsLst->list();
-        if (index >= names.size()) {
-            report.unresolvedScripts.push_back({ index, {}, "program index out of scripts.lst range" });
-            continue;
-        }
-        const std::string& name = names[index];
-        if (!files.exists(std::string(ResourcePaths::Directories::SCRIPTS) + name)) {
-            report.unresolvedScripts.push_back({ index, name, "compiled script not in mounted data" });
-        }
-    }
-
+    report.mounts = resources.files().mounts();
+    scanTiles(resources, map, report);
+    scanObjectArt(resources, map, report);
+    scanScripts(resources, map, report);
     return report;
 }
 

--- a/src/resource/MapCompleteness.cpp
+++ b/src/resource/MapCompleteness.cpp
@@ -1,0 +1,131 @@
+#include "resource/MapCompleteness.h"
+
+#include "format/lst/Lst.h"
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "format/map/Tile.h"
+#include "resource/FrmResolver.h"
+#include "resource/GameResources.h"
+#include "resource/ResourcePaths.h"
+
+#include <set>
+
+namespace geck::resource {
+
+namespace {
+
+    // Load an index .lst through the repository, degrading to nullptr when it isn't mounted —
+    // reported per-entry by the caller, never thrown.
+    const Lst* tryLoadLst(GameResources& resources, std::string_view path) {
+        try {
+            return resources.repository().load<Lst>(std::string(path));
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+    }
+
+} // namespace
+
+MapCompletenessReport scanMapCompleteness(GameResources& resources, const Map& map) {
+    MapCompletenessReport report;
+    auto& files = resources.files();
+
+    report.mounts = files.mounts();
+
+    // --- Tiles: distinct floor/roof ids across every elevation -> tiles.lst filename -> exists? ---
+    std::set<int> usedTileIds;
+    for (const auto& [elevation, tiles] : map.getMapFile().tiles) {
+        for (const auto& tile : tiles) {
+            if (tile.getFloor() != Map::EMPTY_TILE) {
+                usedTileIds.insert(tile.getFloor());
+            }
+            if (tile.getRoof() != Map::EMPTY_TILE) {
+                usedTileIds.insert(tile.getRoof());
+            }
+        }
+    }
+    report.usedTileCount = usedTileIds.size();
+
+    const Lst* tilesLst = tryLoadLst(resources, ResourcePaths::Lst::TILES);
+    report.tilesLstMounted = tilesLst != nullptr;
+
+    for (int id : usedTileIds) {
+        if (tilesLst == nullptr) {
+            report.missingTiles.push_back({ id, {}, "tiles.lst not mounted" });
+            continue;
+        }
+        const auto& names = tilesLst->list();
+        if (id < 0 || static_cast<std::size_t>(id) >= names.size()) {
+            report.missingTiles.push_back({ id, {}, "tile id out of tiles.lst range" });
+            continue;
+        }
+        std::string art = std::string(ResourcePaths::Directories::TILES) + names[static_cast<std::size_t>(id)];
+        if (!files.exists(art)) {
+            report.missingTiles.push_back({ id, std::move(art), "art not in mounted data" });
+        }
+    }
+
+    // --- Object art: distinct FIDs -> resolved art path -> exists? (resolve() can throw) ---
+    std::set<std::uint32_t> checkedFids;
+    for (const auto& [elevation, objects] : map.objects()) {
+        for (const auto& object : objects) {
+            if (object->position == -1) {
+                continue; // inventory/container child, not placed on the map
+            }
+            if (!checkedFids.insert(object->frm_pid).second) {
+                continue; // this FID already checked
+            }
+            std::string art;
+            try {
+                art = resources.frmResolver().resolve(object->frm_pid);
+            } catch (const std::exception&) {
+                report.missingObjectArt.push_back({ object->frm_pid, {}, "FID does not resolve" });
+                continue;
+            }
+            if (art.empty() || !files.exists(art)) {
+                report.missingObjectArt.push_back({ object->frm_pid, std::move(art), "art not in mounted data" });
+            }
+        }
+    }
+    report.objectArtCount = checkedFids.size();
+
+    // --- Scripts: distinct scripts.lst program indices -> filename -> compiled .int exists? ---
+    // The header's own script id is 1-based (0 / -1 = none); map_scripts entries carry the
+    // 0-based program index directly (see ScriptsPanel / MapInfoPanel).
+    std::set<std::uint32_t> programIndices;
+    if (map.getMapFile().header.script_id > 0) {
+        programIndices.insert(static_cast<std::uint32_t>(map.getMapFile().header.script_id - 1));
+    }
+    for (const auto& section : map.getMapFile().map_scripts) {
+        for (const auto& script : section) {
+            if (script.script_id != MapScript::NONE) {
+                programIndices.insert(script.script_id);
+            }
+        }
+    }
+    report.scriptCount = programIndices.size();
+
+    const Lst* scriptsLst = tryLoadLst(resources, ResourcePaths::Lst::SCRIPTS);
+    report.scriptsLstMounted = scriptsLst != nullptr;
+
+    for (std::uint32_t index : programIndices) {
+        if (scriptsLst == nullptr) {
+            report.unresolvedScripts.push_back({ index, {}, "scripts.lst not mounted" });
+            continue;
+        }
+        const auto& names = scriptsLst->list();
+        if (index >= names.size()) {
+            report.unresolvedScripts.push_back({ index, {}, "program index out of scripts.lst range" });
+            continue;
+        }
+        const std::string& name = names[index];
+        if (!files.exists(std::string(ResourcePaths::Directories::SCRIPTS) + name)) {
+            report.unresolvedScripts.push_back({ index, name, "compiled script not in mounted data" });
+        }
+    }
+
+    return report;
+}
+
+} // namespace geck::resource

--- a/src/resource/MapCompleteness.cpp
+++ b/src/resource/MapCompleteness.cpp
@@ -15,8 +15,9 @@ namespace geck::resource {
 
 namespace {
 
-    // Load an index .lst through the repository, degrading to nullptr when it isn't mounted —
-    // reported per-entry by the caller, never thrown.
+    // Load an index .lst through the repository, degrading to nullptr when it can't be loaded
+    // for any reason (not mounted, unreadable, unparseable) — surfaced per-entry by the caller
+    // as the "not mounted" reason, never thrown.
     const Lst* tryLoadLst(GameResources& resources, std::string_view path) {
         try {
             return resources.repository().load<Lst>(std::string(path));

--- a/src/resource/MapCompleteness.h
+++ b/src/resource/MapCompleteness.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "resource/DataFileSystem.h"
+
+namespace geck {
+
+class Map;
+
+namespace resource {
+
+    class GameResources;
+
+    /// A floor/roof tile id the map places but whose art does not resolve in the mounted data.
+    /// `art` is the tiles.lst-derived VFS path, or empty when it couldn't be formed — then
+    /// `reason` says why ("tiles.lst not mounted", "tile id out of tiles.lst range").
+    struct MissingTile {
+        int id = 0;
+        std::string art;
+        std::string reason;
+    };
+
+    /// A distinct object FID whose sprite does not resolve. `art` is the FrmResolver path, or
+    /// empty when resolution itself failed ("FID does not resolve").
+    struct MissingObjectArt {
+        std::uint32_t fid = 0;
+        std::string art;
+        std::string reason;
+    };
+
+    /// A distinct scripts.lst program index the map references (header script or a map_scripts
+    /// entry) that does not resolve to a compiled script in the mounted data. `name` is the
+    /// scripts.lst entry, or empty when the index itself is bad — then `reason` says why
+    /// ("scripts.lst not mounted", "program index out of scripts.lst range",
+    /// "compiled script not in mounted data").
+    struct UnresolvedScript {
+        std::uint32_t programIndex = 0;
+        std::string name;
+        std::string reason;
+    };
+
+    /// Everything a map references that the mounted data cannot supply, plus the mount context
+    /// needed to judge whether the data paths themselves are sane. Computed by
+    /// scanMapCompleteness; surfaced by the editor's completeness panel and by
+    /// `gecko-cli resource missing` / the MCP resource_missing tool.
+    struct MapCompletenessReport {
+        std::size_t usedTileCount = 0;  //!< distinct floor/roof tile ids across all elevations
+        std::size_t objectArtCount = 0; //!< distinct FIDs of placed (non-inventory) objects
+        std::size_t scriptCount = 0;    //!< distinct scripts.lst program indices referenced
+
+        std::vector<MissingTile> missingTiles;
+        std::vector<MissingObjectArt> missingObjectArt;
+        std::vector<UnresolvedScript> unresolvedScripts;
+
+        std::vector<MountedSourceInfo> mounts; //!< data paths in mount (priority) order
+        bool tilesLstMounted = false;          //!< art/tiles/tiles.lst loaded
+        bool scriptsLstMounted = false;        //!< scripts/scripts.lst loaded
+
+        bool complete() const {
+            return missingTiles.empty() && missingObjectArt.empty() && unresolvedScripts.empty();
+        }
+        std::size_t missingCount() const {
+            return missingTiles.size() + missingObjectArt.size() + unresolvedScripts.size();
+        }
+    };
+
+    /// Check every resource the map references against the mounted data: used tile art, placed
+    /// objects' sprites, and referenced scripts, mirroring the resolve steps the (tolerant) map
+    /// loader runs. Read-only and Qt-free; never throws — an unmounted index file becomes a
+    /// per-entry reason, not an error.
+    MapCompletenessReport scanMapCompleteness(GameResources& resources, const Map& map);
+
+} // namespace resource
+} // namespace geck

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -13,6 +13,8 @@
 #include "ui/panels/ObjectPalettePanel.h"
 #include "ui/panels/FileBrowserPanel.h"
 #include "ui/panels/LogPanel.h"
+#include "ui/panels/CompletenessView.h"
+#include "resource/MapCompleteness.h"
 #ifdef GECK_SCRIPTING_ENABLED
 #include "ui/panels/ScriptConsoleWidget.h"
 #include "scripting/LuaScriptRuntime.h" // ScriptResult
@@ -66,6 +68,7 @@
 #include <QToolButton>
 #include <QIcon>
 #include <QSignalBlocker>
+#include <QTabWidget>
 #include <QFileDialog>
 #include <QFile>
 #include <QFileInfo>
@@ -163,7 +166,11 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
     // Any edit (or undo/redo) marks the map dirty for the close/title prompts.
     connect(_currentEditorWidget, &EditorWidget::undoStackChanged, this, [this]() { setMapModified(true); });
     // Non-undoable Console-script mutations (newMap/setPlayerStart) flag the map dirty too.
-    connect(_currentEditorWidget, &EditorWidget::mapModifiedByScript, this, [this]() { setMapModified(true); });
+    // A script/fill can reference new protos or tiles wholesale, so re-check completeness as well.
+    connect(_currentEditorWidget, &EditorWidget::mapModifiedByScript, this, [this]() {
+        setMapModified(true);
+        refreshCompleteness();
+    });
 
     syncMenuStateToEditorWidget();
 
@@ -186,6 +193,7 @@ void MainWindow::setEditorWidget(std::unique_ptr<EditorWidget> editorWidget) {
     QTimer::singleShot(50, this, &MainWindow::updatePanelMenuActions);
     updateUndoRedoActions();
     updateFillSelectionAction();
+    refreshCompleteness();
 }
 
 void MainWindow::setupUI() {
@@ -230,6 +238,8 @@ void MainWindow::connectMenuSignals() {
             // The new map is clean; refresh the title to its name.
             _mapModified = false;
             updateWindowTitle();
+            // setEditorWidget scanned before createNewMap populated the map; re-check now.
+            refreshCompleteness();
         } catch (const std::exception& e) {
             spdlog::error("Failed to create a new map: {}", e.what());
             QtDialogs::showError(this, "Missing Game Files",
@@ -954,6 +964,30 @@ void MainWindow::setLogModel(LogModel* model) {
     }
 }
 
+void MainWindow::refreshCompleteness() {
+    if (!_completenessView) {
+        return;
+    }
+
+    Map* map = _currentEditorWidget ? _currentEditorWidget->getMap() : nullptr;
+    if (!map) {
+        _completenessView->clearReport();
+        return;
+    }
+
+    const auto report = resource::scanMapCompleteness(*_resourcesShared, *map);
+    _completenessView->setReport(report, QString::fromStdString(map->filename()));
+
+    // A one-line total in the Log tab (and on stderr) so the gaps are noticed even when the
+    // Map tab isn't the one showing; the tab holds the per-entry breakdown.
+    if (!report.complete()) {
+        spdlog::warn("Map completeness: {} references {} unresolved resource(s) — {} tile(s), "
+                     "{} object sprite(s), {} script(s); see the Log panel's Map tab",
+            map->filename(), report.missingCount(), report.missingTiles.size(),
+            report.missingObjectArt.size(), report.unresolvedScripts.size());
+    }
+}
+
 void MainWindow::setupDockWidgets() {
     auto createDock = [this](const QString& title, const char* objectName, QWidget* panel, Qt::DockWidgetArea area, QSizePolicy::Policy verticalPolicy, int minHeight) {
         QDockWidget* dock = new QDockWidget(title, this);
@@ -998,10 +1032,17 @@ void MainWindow::setupDockWidgets() {
 #endif
 
     // Log & diagnostics: same shape as the script console — a bottom dock outside the managed
-    // layout persistence, hidden until opened from the View menu. The record store is the
-    // application's LogModel, attached via setLogModel() once the window exists.
+    // layout persistence, hidden until opened from the View menu. Two tabs: the raw record
+    // stream (the application's LogModel, attached via setLogModel() once the window exists)
+    // and the structured per-map completeness summary (refreshed on map load/close).
     _logPanel = new LogPanel();
-    _logDock = createDock("Log", "LogDock", _logPanel, Qt::BottomDockWidgetArea, QSizePolicy::Expanding, ui::constants::dock::MIN_HEIGHT_SMALL);
+    _completenessView = new CompletenessView();
+    connect(_completenessView, &CompletenessView::refreshRequested, this, &MainWindow::refreshCompleteness);
+    auto* logTabs = new QTabWidget();
+    logTabs->setDocumentMode(true);
+    logTabs->addTab(_logPanel, tr("Log"));
+    logTabs->addTab(_completenessView, tr("Map"));
+    _logDock = createDock("Log", "LogDock", logTabs, Qt::BottomDockWidgetArea, QSizePolicy::Expanding, ui::constants::dock::MIN_HEIGHT_SMALL);
     _logDock->hide();
 
     if (_viewMenu) {
@@ -2274,6 +2315,7 @@ void MainWindow::closeCurrentMap() {
 
     spdlog::debug("Current map closed successfully");
     updateUndoRedoActions();
+    refreshCompleteness();
 }
 
 bool MainWindow::hasActiveMap() const {

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -50,6 +50,7 @@ class ScriptConsoleWidget;
 class SpatialScriptDialog;
 class LogPanel;
 class LogModel;
+class CompletenessView;
 class Map;
 
 class MainWindow : public QMainWindow {
@@ -93,6 +94,10 @@ public:
     // Attach the application-wide log record store to the Log panel (the model outlives this
     // window; the in-app spdlog sink feeds it from application startup on).
     void setLogModel(LogModel* model);
+
+    // Re-scan the open map's referenced resources against the mounted data and refresh the Log
+    // dock's "Map" tab (clears it when no map is open). Cheap — in-memory index lookups only.
+    void refreshCompleteness();
 
 signals:
     void newMapRequested();
@@ -279,6 +284,7 @@ private:
 #endif
     QDockWidget* _logDock = nullptr;
     LogPanel* _logPanel = nullptr;
+    CompletenessView* _completenessView = nullptr;
     // Guards the persisted dock layout while docks are re-laid-out programmatically (hidden for the
     // welcome screen, re-shown for a map), so those transient changes aren't written back as if the
     // user made them.

--- a/src/ui/panels/CompletenessView.cpp
+++ b/src/ui/panels/CompletenessView.cpp
@@ -1,0 +1,180 @@
+#include "CompletenessView.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+
+#include "resource/MapCompleteness.h"
+#include "ui/theme/ThemeManager.h"
+
+namespace geck {
+
+namespace {
+
+    constexpr int kResourceColumn = 0;
+    constexpr int kNameColumn = 1;
+    constexpr int kStatusColumn = 2;
+
+    void paintWarning(QTreeWidgetItem* item) {
+        const QBrush warning{ QColor(ui::theme::colors::WARNING) };
+        for (int column = 0; column < item->columnCount(); ++column) {
+            item->setForeground(column, warning);
+        }
+    }
+
+} // namespace
+
+CompletenessView::CompletenessView(QWidget* parent)
+    : QWidget(parent)
+    , _status(new QLabel(this))
+    , _refreshButton(new QPushButton(tr("Refresh"), this))
+    , _copyButton(new QPushButton(tr("Copy"), this))
+    , _tree(new QTreeWidget(this)) {
+
+    _refreshButton->setToolTip(tr("Re-check the open map against the mounted data (the report reflects load time, not later edits)"));
+
+    auto* controls = new QHBoxLayout();
+    controls->setSpacing(ui::theme::spacing::NORMAL);
+    controls->addWidget(_status, 1);
+    controls->addWidget(_refreshButton);
+    controls->addWidget(_copyButton);
+
+    _tree->setColumnCount(3);
+    _tree->setHeaderLabels({ tr("Resource"), tr("Name / path"), tr("Status") });
+    _tree->setRootIsDecorated(true);
+    _tree->setUniformRowHeights(true);
+    _tree->setAlternatingRowColors(true);
+    _tree->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    _tree->setSelectionBehavior(QAbstractItemView::SelectRows);
+    _tree->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    _tree->header()->setSectionResizeMode(kResourceColumn, QHeaderView::ResizeToContents);
+    _tree->header()->setSectionResizeMode(kNameColumn, QHeaderView::Stretch);
+    _tree->header()->setSectionResizeMode(kStatusColumn, QHeaderView::ResizeToContents);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setSpacing(ui::theme::spacing::TIGHT);
+    layout->addLayout(controls);
+    layout->addWidget(_tree, 1);
+
+    connect(_refreshButton, &QPushButton::clicked, this, [this]() { Q_EMIT refreshRequested(); });
+    connect(_copyButton, &QPushButton::clicked, this, &CompletenessView::onCopy);
+
+    clearReport();
+}
+
+QTreeWidgetItem* CompletenessView::addGroup(const QString& title, std::size_t missing, const QString& detail) {
+    auto* group = new QTreeWidgetItem(_tree);
+    group->setText(kResourceColumn, title);
+    group->setText(kNameColumn, detail);
+    QFont bold = group->font(kResourceColumn);
+    bold.setBold(true);
+    group->setFont(kResourceColumn, bold);
+    if (missing > 0) {
+        group->setForeground(kResourceColumn, QBrush(QColor(ui::theme::colors::WARNING)));
+        group->setExpanded(true);
+    }
+    return group;
+}
+
+void CompletenessView::setReport(const resource::MapCompletenessReport& report, const QString& mapName) {
+    _tree->clear();
+    _refreshButton->setEnabled(true);
+    _copyButton->setEnabled(true);
+
+    if (report.complete()) {
+        _status->setText(tr("%1 — every referenced resource resolves").arg(mapName));
+        _status->setStyleSheet(QStringLiteral("color: %1;").arg(ui::theme::colors::SUCCESS));
+    } else {
+        _status->setText(tr("%1 — %2 unresolved reference(s)").arg(mapName).arg(report.missingCount()));
+        _status->setStyleSheet(QStringLiteral("color: %1;").arg(ui::theme::colors::WARNING));
+    }
+
+    auto* tiles = addGroup(tr("Tile art"), report.missingTiles.size(),
+        report.missingTiles.empty()
+            ? tr("%1 used tile(s), all resolve").arg(report.usedTileCount)
+            : tr("%1 of %2 used tile(s) unresolved").arg(report.missingTiles.size()).arg(report.usedTileCount));
+    for (const auto& tile : report.missingTiles) {
+        auto* item = new QTreeWidgetItem(tiles);
+        item->setText(kResourceColumn, tr("tile %1").arg(tile.id));
+        item->setText(kNameColumn, QString::fromStdString(tile.art));
+        item->setText(kStatusColumn, QString::fromStdString(tile.reason));
+        paintWarning(item);
+    }
+
+    auto* sprites = addGroup(tr("Object sprites"), report.missingObjectArt.size(),
+        report.missingObjectArt.empty()
+            ? tr("%1 distinct sprite(s), all resolve").arg(report.objectArtCount)
+            : tr("%1 of %2 distinct sprite(s) unresolved").arg(report.missingObjectArt.size()).arg(report.objectArtCount));
+    for (const auto& art : report.missingObjectArt) {
+        auto* item = new QTreeWidgetItem(sprites);
+        item->setText(kResourceColumn, tr("FID %1").arg(art.fid));
+        item->setText(kNameColumn, QString::fromStdString(art.art));
+        item->setText(kStatusColumn, QString::fromStdString(art.reason));
+        paintWarning(item);
+    }
+
+    auto* scripts = addGroup(tr("Scripts"), report.unresolvedScripts.size(),
+        report.unresolvedScripts.empty()
+            ? tr("%1 referenced script(s), all resolve").arg(report.scriptCount)
+            : tr("%1 of %2 referenced script(s) unresolved").arg(report.unresolvedScripts.size()).arg(report.scriptCount));
+    for (const auto& script : report.unresolvedScripts) {
+        auto* item = new QTreeWidgetItem(scripts);
+        item->setText(kResourceColumn, tr("index %1").arg(script.programIndex));
+        item->setText(kNameColumn, QString::fromStdString(script.name));
+        item->setText(kStatusColumn, QString::fromStdString(script.reason));
+        paintWarning(item);
+    }
+
+    // Data-path sanity: the mounts every lookup above walked, plus whether the two index files
+    // the checks key off were themselves found. An unmounted index makes whole sections
+    // unresolvable, so it is the first thing to look at when the counts above are large.
+    const std::size_t indexProblems = (report.tilesLstMounted ? 0 : 1) + (report.scriptsLstMounted ? 0 : 1);
+    auto* mounts = addGroup(tr("Data paths"), indexProblems, tr("%1 mounted").arg(report.mounts.size()));
+    for (const auto& mount : report.mounts) {
+        auto* item = new QTreeWidgetItem(mounts);
+        item->setText(kResourceColumn, mount.kind == resource::MountedSourceInfo::Kind::Dat ? tr("DAT") : tr("folder"));
+        item->setText(kNameColumn, QString::fromStdString(mount.sourcePath.generic_string()));
+        item->setText(kStatusColumn, tr("mounted"));
+    }
+    const auto addIndexRow = [&](const QString& name, bool mounted) {
+        auto* item = new QTreeWidgetItem(mounts);
+        item->setText(kResourceColumn, tr("index"));
+        item->setText(kNameColumn, name);
+        item->setText(kStatusColumn, mounted ? tr("OK") : tr("not mounted"));
+        if (!mounted) {
+            paintWarning(item);
+        }
+    };
+    addIndexRow(QStringLiteral("art/tiles/tiles.lst"), report.tilesLstMounted);
+    addIndexRow(QStringLiteral("scripts/scripts.lst"), report.scriptsLstMounted);
+}
+
+void CompletenessView::clearReport() {
+    _tree->clear();
+    _refreshButton->setEnabled(false);
+    _copyButton->setEnabled(false);
+    _status->setText(tr("No map loaded — completeness is computed when a map opens"));
+    _status->setStyleSheet(QStringLiteral("color: %1;").arg(ui::theme::colors::TEXT_MUTED));
+}
+
+void CompletenessView::onCopy() {
+    QStringList lines;
+    lines.append(_status->text());
+    for (int groupIndex = 0; groupIndex < _tree->topLevelItemCount(); ++groupIndex) {
+        const QTreeWidgetItem* group = _tree->topLevelItem(groupIndex);
+        lines.append(QStringLiteral("%1: %2").arg(group->text(kResourceColumn), group->text(kNameColumn)));
+        for (int childIndex = 0; childIndex < group->childCount(); ++childIndex) {
+            const QTreeWidgetItem* child = group->child(childIndex);
+            lines.append(QStringLiteral("  %1\t%2\t%3")
+                    .arg(child->text(kResourceColumn), child->text(kNameColumn), child->text(kStatusColumn)));
+        }
+    }
+    QApplication::clipboard()->setText(lines.join(QLatin1Char('\n')));
+}
+
+} // namespace geck

--- a/src/ui/panels/CompletenessView.h
+++ b/src/ui/panels/CompletenessView.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QPushButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+namespace geck {
+
+namespace resource {
+    struct MapCompletenessReport;
+}
+
+/// The "Map" tab of the Log dock: a structured per-map completeness summary computed by
+/// resource::scanMapCompleteness — every tile, object sprite, and script the open map references
+/// but the mounted data cannot supply, grouped by kind, plus the data-path mounts the lookups
+/// walk. The structured counterpart of the loader's prose warnings in the Log tab.
+class CompletenessView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit CompletenessView(QWidget* parent = nullptr);
+
+    /// Populate the tree from a scan of the open map. `mapName` labels the status line.
+    void setReport(const resource::MapCompletenessReport& report, const QString& mapName);
+
+    /// No-map state: empty tree, muted status line, Refresh disabled.
+    void clearReport();
+
+Q_SIGNALS:
+    /// The user asked to re-scan (the report reflects load time, not later edits).
+    void refreshRequested();
+
+private:
+    void onCopy();
+
+    /// Top-level section row; `missing` of `total` colours and expands it when non-zero.
+    QTreeWidgetItem* addGroup(const QString& title, std::size_t missing, const QString& detail);
+
+    QLabel* _status;
+    QPushButton* _refreshButton;
+    QPushButton* _copyButton;
+    QTreeWidget* _tree;
+};
+
+} // namespace geck

--- a/src/ui/panels/FileBrowserPanel.cpp
+++ b/src/ui/panels/FileBrowserPanel.cpp
@@ -825,12 +825,13 @@ void FileBrowserPanel::processNextChunk() {
     FileTreeItem* rootItem = static_cast<FileTreeItem*>(_treeModel->invisibleRootItem());
     const auto nativeDirectories = _nativeDirectoriesForSources.empty() ? getNativeDirectoryPaths() : _nativeDirectoriesForSources;
 
+    // No nested processEvents here: a chunk is small (CHUNK_SIZE rows) and the queued
+    // re-invoke below already yields to the real event loop between chunks. Re-entrant
+    // event pumping from inside the chunk let other timers (notably the SFML render
+    // loop) run long work re-entrantly, starving modal progress dialogs — a map load's
+    // progress bar sat frozen until the load finished.
     size_t endIndex = std::min(_currentChunkIndex + CHUNK_SIZE, _pendingFiles.size());
     for (size_t i = _currentChunkIndex; i < endIndex; ++i) {
-        if ((i - _currentChunkIndex) % 10 == 0) {
-            QApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 1);
-        }
-
         insertFileRow(rootItem, _pendingFiles[i], nativeDirectories);
     }
 

--- a/src/ui/widgets/LoadingWidget.cpp
+++ b/src/ui/widgets/LoadingWidget.cpp
@@ -101,7 +101,6 @@ void LoadingWidget::updateProgress() {
     if (!_isLoading) {
         return;
     }
-
     bool allDone = true;
     int totalProgress = 0;
     int activeLoaders = 0;
@@ -132,6 +131,17 @@ void LoadingWidget::updateProgress() {
         } else {
             // Run the completion callback exactly once per loader
             if (!_loadersCompleted[i]) {
+                // onDone() runs the consumer's callback synchronously — for a map load that
+                // is the whole editor build (sprites, GL uploads), which can take seconds and
+                // processes no paint or timer events. Show and PAINT the completion state
+                // first, or the dialog freezes on its last-painted value (often the initial
+                // 0%, since a fast loader finishes before the first timer tick) for the
+                // entire build and then jumps to 100%.
+                if (_loaders.size() == 1) {
+                    _progressBar->setValue(100);
+                }
+                _statusLabel->setText(tr("Finalizing..."));
+                repaint();
                 spdlog::debug("LoadingWidget: Calling onDone() for completed loader {}", i);
                 loader->onDone();
                 _loadersCompleted[i] = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(general_tests
     general/test_pattern_builder.cpp
     general/test_fill_plan.cpp
     general/test_map_script_api.cpp
+    general/test_map_completeness.cpp
     general/test_resource_repository.cpp
     general/test_script_names.cpp
     general/test_object_visibility.cpp
@@ -109,6 +110,8 @@ add_executable(qt_tests
     qt/test_editor_hints.cpp
     # Log panel plumbing: the LogModel store (cap, threading), the spdlog sink, the filter proxy.
     qt/test_log_panel.cpp
+    # The Log dock's "Map" tab: report -> grouped tree, empty states, refresh signal.
+    qt/test_completeness_view.cpp
 )
 
 # Round-trip the headless pattern writer (gecko_cli) through the editor's Qt PatternSerializer.

--- a/tests/general/test_map_completeness.cpp
+++ b/tests/general/test_map_completeness.cpp
@@ -1,0 +1,108 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include "format/map/Map.h"
+#include "format/map/MapObject.h"
+#include "format/map/MapScript.h"
+#include "resource/GameResources.h"
+#include "resource/MapCompleteness.h"
+#include "support/Fixtures.h"
+
+using namespace geck;
+
+namespace {
+
+// f2_res.dat is the committed DAT fixture. It carries interface art but no tiles.lst,
+// scripts.lst, or tile art, so every index-backed check degrades to its "not mounted" reason —
+// exactly the state the scan must report rather than throw on.
+void mountFixtureDat(resource::GameResources& resources) {
+    resources.files().addDataPath(geck::test::dataPath("f2_res.dat"));
+}
+
+std::unique_ptr<Map> emptyMap() {
+    auto map = std::make_unique<Map>("test.map");
+    map->setMapFile(std::make_unique<Map::MapFile>(Map::createEmptyMapFile()));
+    return map;
+}
+
+} // namespace
+
+TEST_CASE("scanMapCompleteness reports an empty map as complete", "[completeness]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    auto map = emptyMap();
+
+    const auto report = resource::scanMapCompleteness(resources, *map);
+
+    CHECK(report.complete());
+    CHECK(report.missingCount() == 0);
+    CHECK(report.usedTileCount == 0);
+    CHECK(report.objectArtCount == 0);
+    CHECK(report.scriptCount == 0);
+    // The fixture DAT ships neither index file; that is mount context, not a missing reference.
+    CHECK_FALSE(report.tilesLstMounted);
+    CHECK_FALSE(report.scriptsLstMounted);
+    REQUIRE(report.mounts.size() == 1);
+    CHECK(report.mounts.front().kind == resource::MountedSourceInfo::Kind::Dat);
+}
+
+TEST_CASE("scanMapCompleteness reports used tiles that no index can resolve", "[completeness]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    auto map = emptyMap();
+    map->getMapFile().tiles.at(0)[100].setFloor(50);
+    map->getMapFile().tiles.at(0)[200].setRoof(60);
+    map->getMapFile().tiles.at(1)[300].setFloor(50); // same id on another elevation: still one entry
+
+    const auto report = resource::scanMapCompleteness(resources, *map);
+
+    CHECK(report.usedTileCount == 2); // distinct ids 50 and 60
+    REQUIRE(report.missingTiles.size() == 2);
+    CHECK(report.missingTiles[0].id == 50);
+    CHECK(report.missingTiles[0].art.empty());
+    CHECK(report.missingTiles[0].reason == "tiles.lst not mounted");
+    CHECK_FALSE(report.complete());
+}
+
+TEST_CASE("scanMapCompleteness reports unresolvable object sprites, skipping inventory children", "[completeness]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    auto map = emptyMap();
+
+    auto placed = std::make_shared<MapObject>();
+    placed->position = 100;
+    placed->frm_pid = 0x0F000001u; // FID type 15 does not exist -> resolve() throws
+    auto duplicate = std::make_shared<MapObject>();
+    duplicate->position = 200;
+    duplicate->frm_pid = 0x0F000001u; // same FID: deduplicated
+    auto inventoryChild = std::make_shared<MapObject>();
+    inventoryChild->position = -1; // inside a container, never rendered
+    inventoryChild->frm_pid = 0x0F000002u;
+    map->getMapFile().map_objects[0] = { placed, duplicate, inventoryChild };
+
+    const auto report = resource::scanMapCompleteness(resources, *map);
+
+    CHECK(report.objectArtCount == 1);
+    REQUIRE(report.missingObjectArt.size() == 1);
+    CHECK(report.missingObjectArt[0].fid == 0x0F000001u);
+    CHECK(report.missingObjectArt[0].reason == "FID does not resolve");
+}
+
+TEST_CASE("scanMapCompleteness reports script references from the header and the script sections", "[completeness]") {
+    resource::GameResources resources;
+    mountFixtureDat(resources);
+    auto map = emptyMap();
+    map->getMapFile().header.script_id = 42; // 1-based -> program index 41
+    map->getMapFile().map_scripts[static_cast<int>(MapScript::ScriptType::CRITTER)].push_back(
+        MapScript::makeObjectScript(MapScript::ScriptType::CRITTER, 0, 7, 1));
+
+    const auto report = resource::scanMapCompleteness(resources, *map);
+
+    CHECK(report.scriptCount == 2);
+    REQUIRE(report.unresolvedScripts.size() == 2);
+    CHECK(report.unresolvedScripts[0].programIndex == 7);
+    CHECK(report.unresolvedScripts[1].programIndex == 41);
+    CHECK(report.unresolvedScripts[0].reason == "scripts.lst not mounted");
+    CHECK(report.unresolvedScripts[0].name.empty());
+}

--- a/tests/qt/test_completeness_view.cpp
+++ b/tests/qt/test_completeness_view.cpp
@@ -1,0 +1,131 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QTreeWidget>
+
+#include "resource/MapCompleteness.h"
+#include "ui/panels/CompletenessView.h"
+
+using namespace geck;
+
+namespace {
+
+QPushButton* findButtonByText(QWidget& root, const QString& text) {
+    for (auto* button : root.findChildren<QPushButton*>()) {
+        if (button->text() == text) {
+            return button;
+        }
+    }
+    return nullptr;
+}
+
+resource::MapCompletenessReport reportWithGaps() {
+    resource::MapCompletenessReport report;
+    report.usedTileCount = 166;
+    report.objectArtCount = 33;
+    report.scriptCount = 3;
+    report.missingTiles.push_back({ 271, "art/tiles/edg5000.frm", "art not in mounted data" });
+    report.missingObjectArt.push_back({ 16793664u, {}, "FID does not resolve" });
+    report.mounts.push_back({ resource::MountedSourceInfo::Kind::Dat, "master.dat", "DAT (master.dat)" });
+    report.tilesLstMounted = true;
+    report.scriptsLstMounted = false;
+    return report;
+}
+
+} // namespace
+
+TEST_CASE("CompletenessView starts in the no-map state", "[qt][completeness]") {
+    CompletenessView view;
+
+    auto* tree = view.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+    CHECK(tree->topLevelItemCount() == 0);
+    REQUIRE(findButtonByText(view, "Refresh") != nullptr);
+    CHECK_FALSE(findButtonByText(view, "Refresh")->isEnabled());
+}
+
+TEST_CASE("CompletenessView renders a report as four grouped sections", "[qt][completeness]") {
+    CompletenessView view;
+    view.setReport(reportWithGaps(), "artemple.map");
+
+    auto* tree = view.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+    REQUIRE(tree->topLevelItemCount() == 4); // tiles, sprites, scripts, data paths
+
+    const QTreeWidgetItem* tiles = tree->topLevelItem(0);
+    REQUIRE(tiles->childCount() == 1);
+    CHECK(tiles->isExpanded()); // sections with problems come pre-expanded
+    CHECK(tiles->child(0)->text(0) == "tile 271");
+    CHECK(tiles->child(0)->text(1) == "art/tiles/edg5000.frm");
+
+    const QTreeWidgetItem* sprites = tree->topLevelItem(1);
+    REQUIRE(sprites->childCount() == 1);
+    CHECK(sprites->child(0)->text(0) == "FID 16793664");
+    CHECK(sprites->child(0)->text(2) == "FID does not resolve");
+
+    const QTreeWidgetItem* scripts = tree->topLevelItem(2);
+    CHECK(scripts->childCount() == 0); // no unresolved scripts -> count-only summary row
+
+    // Data paths: one mount row plus the two index rows; the unmounted scripts.lst is flagged.
+    const QTreeWidgetItem* mounts = tree->topLevelItem(3);
+    REQUIRE(mounts->childCount() == 3);
+    CHECK(mounts->child(0)->text(2) == "mounted");
+    CHECK(mounts->child(1)->text(1) == "art/tiles/tiles.lst");
+    CHECK(mounts->child(1)->text(2) == "OK");
+    CHECK(mounts->child(2)->text(1) == "scripts/scripts.lst");
+    CHECK(mounts->child(2)->text(2) == "not mounted");
+
+    // The status line carries the map name and the total.
+    bool statusFound = false;
+    for (const auto* label : view.findChildren<QLabel*>()) {
+        if (label->text().contains("artemple.map") && label->text().contains("2")) {
+            statusFound = true;
+        }
+    }
+    CHECK(statusFound);
+}
+
+TEST_CASE("CompletenessView reports a clean map without warning rows", "[qt][completeness]") {
+    CompletenessView view;
+    resource::MapCompletenessReport report;
+    report.usedTileCount = 10;
+    report.tilesLstMounted = true;
+    report.scriptsLstMounted = true;
+    view.setReport(report, "clean.map");
+
+    auto* tree = view.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+    REQUIRE(tree->topLevelItemCount() == 4);
+    CHECK(tree->topLevelItem(0)->childCount() == 0);
+    CHECK_FALSE(tree->topLevelItem(0)->isExpanded());
+
+    bool statusFound = false;
+    for (const auto* label : view.findChildren<QLabel*>()) {
+        if (label->text().contains("every referenced resource resolves")) {
+            statusFound = true;
+        }
+    }
+    CHECK(statusFound);
+}
+
+TEST_CASE("CompletenessView clearReport returns to the no-map state", "[qt][completeness]") {
+    CompletenessView view;
+    view.setReport(reportWithGaps(), "artemple.map");
+    view.clearReport();
+
+    auto* tree = view.findChild<QTreeWidget*>();
+    REQUIRE(tree != nullptr);
+    CHECK(tree->topLevelItemCount() == 0);
+    CHECK_FALSE(findButtonByText(view, "Refresh")->isEnabled());
+}
+
+TEST_CASE("CompletenessView refresh button emits refreshRequested", "[qt][completeness]") {
+    CompletenessView view;
+    view.setReport(reportWithGaps(), "artemple.map");
+
+    QSignalSpy spy(&view, &CompletenessView::refreshRequested);
+    findButtonByText(view, "Refresh")->click();
+    CHECK(spy.count() == 1);
+}


### PR DESCRIPTION
Closes the remaining half of the in-app log/diagnostics item (PLAN.md known limitation #10a): the load-time resource warnings now have a structured, per-map counterpart in the UI.

## What changed

**Shared scan (`src/resource/MapCompleteness.*`, gecko_resource).** The per-map missing-resource logic moved out of `cli::resourceMissing` into a Qt-free `resource::scanMapCompleteness(GameResources&, const Map&)` used by the editor panel, `gecko-cli resource missing`, and the MCP `resource_missing` tool, so the three can't drift. On top of the existing tile-art and object-sprite checks it adds:

- **Script references** — the map header's 1-based script id plus every `MapScript` program index, bounds-checked against `scripts.lst` and probed for the compiled `.int` in the mounted data.
- **Mount / data-path sanity** — every initialized mount in priority order (new `DataFileSystem::mounts()`, factored from `sourceInfo`'s classification), plus whether `tiles.lst` / `scripts.lst` themselves resolve.

**UI (`src/ui/panels/CompletenessView.*`).** The Log dock becomes a two-tab dock: **Log** (unchanged) and **Map** — a grouped tree (Tile art / Object sprites / Scripts / Data paths) with per-entry reasons, warning colouring, counts in the group headers (problem groups pre-expanded), copy, a Refresh re-scan, and explicit no-map / all-resolved states. It refreshes on map load, close, new map, and script/fill mutation (`mapModifiedByScript`), and a one-line totals `spdlog::warn` lands in the Log tab so gaps are noticed even with the Map tab hidden.

**CLI/MCP.** `resource missing` JSON gains `scriptCount`, `missingScripts:[{programIndex,name,reason}]`, `mounts:[{kind,path,label}]`, `tilesLstMounted`, `scriptsLstMounted`, and missing entries now always carry a `reason`.

## Verification

- New unit tests for the scan (synthetic maps against the fixture DAT: tiles, sprites incl. inventory-child skip + FID dedupe, header + section script indices, mount reporting) and qt tests for the view (grouping, expansion, empty states, refresh signal). Full `general_tests` + `qt_tests` pass.
- End-to-end: `resource missing` on `artemple.map` with only `master.dat` mounted correctly reports the one critter FID that needs `critter.dat`; a generated map doctored to `script_id=5000` shows up in the GUI's Map tab as "index 4999 — program index out of scripts.lst range", with the totals warning line in the Log tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: fix the map-load progress dialog freezing at 0% → 100%

Diagnosed with tick instrumentation + window filming + `sample` stack captures. Two UI-thread stalls:

1. **`LoadingWidget` ran `onDone()` — the whole editor build (sprites, GL uploads, seconds of work) — inside a timer tick without painting first.** A fast loader finishes before the first 33 ms tick, so the bar's only ever-painted value was the initial 0%, flipping to 100% when everything unwound. The dialog now paints its completion state (100% / "Finalizing…") before invoking the callback.
2. **`FileBrowserPanel::processNextChunk` pumped `QApplication::processEvents` re-entrantly from inside each chunk**, letting the SFML render timer run long work mid-chunk and starving concurrent modal dialogs. The queued re-invoke between chunks already yields, so the nested pump is removed.

A third contributor is out of scope here and noted for the data-path work: tree population calls `files().exists()` / `repository().load<Pro>()` per `.pro` row on the UI thread, contending with the map loader's tight `DataFileSystem` lock loop.
