### PR TITLE
Let users pick an explicit save location among the data paths

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -67,15 +67,16 @@ live with their library (`src/resource/`, `src/ui/`).
     drive it from the same command/action table proposed in #7 (stable action id → icon/label/handler),
     with a context-menu / Preferences UI to add, remove, and reorder buttons, persisted via `Settings`.
     Editor UX only; no map/format change.
-9. **The writable save target is positional, not chosen.** Saving a map (and map-name edits) writes
-    into the *last folder* in Data Paths — `findWritableDataPath` walks the list from the end and takes
-    the first real directory (archives skipped). That's implicit and order-dependent: reordering Data
-    Paths silently changes where saves land, and nothing in the UI shows which location is the writable
-    one. Map saves now default to that folder's `maps/` (Save / Save As), so the choice matters.
-    **Add an explicit default-writable marker:** a button in Settings → Data Paths to designate the
-    selected folder as the default writable location, shown with a badge in the list and persisted in
-    `Settings`; saves then target that folder regardless of list order. If none is marked, keep the
-    current last-folder fallback and hint the user to pick one. DAT archives can't be marked (read-only).
+9. **The writable save target — DONE (explicit save-location marker).** Settings → Data Paths now has
+    a **"Set as Save Location"** toggle button: the chosen folder is persisted (`Settings`
+    `writableDataPath`, cleared automatically if the folder leaves the list) and wins over the
+    positional rule in `resource::findWritableDataPath(paths, preferred)` — with a warning log when a
+    configured marker can't be honoured, never silently. The list badges the *effective* target (save
+    icon; bold = explicit marker, italic = positional default) with explanatory tooltips, DAT archives
+    and the built-in resources folder can't be marked, and marking alone doesn't trigger a data-path
+    remount. With no marker, the previous highest-priority-folder fallback and hint behaviour is
+    unchanged. All consumers (Save/Save As default dir, maps.txt name edits, `.gam` edits) route
+    through `Settings::resolveWritableDataPath()`.
 10. **In-app log panel — SHIPPED, including the completeness summary.** The dockable **Log** panel
     (View › Log, hidden by default like the Script Console) surfaces every `spdlog` record in
     the UI: `LogModelSink` (installed on the default logger at startup) feeds a bounded, thread-safe

--- a/src/resource/WritableDataRoot.cpp
+++ b/src/resource/WritableDataRoot.cpp
@@ -10,19 +10,12 @@
 
 namespace geck::resource {
 
-namespace {
-
-    // Marker membership is a plain path comparison (fs::equivalent for on-disk variance, lexical
-    // fallback) — NOT util::pathsEquivalent, whose resolve-to-game-data-root step would conflate a
-    // folder with its data/ subfolder and honour the marker against the wrong entry.
-    bool sameDataPathEntry(const std::filesystem::path& a, const std::filesystem::path& b) {
-        std::error_code ec;
-        if (std::filesystem::equivalent(a, b, ec)) {
-            return true;
-        }
-        return a.lexically_normal() == b.lexically_normal();
+bool sameDataPathEntry(const std::filesystem::path& a, const std::filesystem::path& b) {
+    std::error_code ec;
+    if (std::filesystem::equivalent(a, b, ec)) {
+        return true;
     }
-
+    return a.lexically_normal() == b.lexically_normal();
 }
 
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths) {

--- a/src/resource/WritableDataRoot.cpp
+++ b/src/resource/WritableDataRoot.cpp
@@ -2,10 +2,28 @@
 
 #include "resource/DataFileSystem.h"
 
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
 #include <fstream>
 #include <stdexcept>
 
 namespace geck::resource {
+
+namespace {
+
+    // Marker membership is a plain path comparison (fs::equivalent for on-disk variance, lexical
+    // fallback) — NOT util::pathsEquivalent, whose resolve-to-game-data-root step would conflate a
+    // folder with its data/ subfolder and honour the marker against the wrong entry.
+    bool sameDataPathEntry(const std::filesystem::path& a, const std::filesystem::path& b) {
+        std::error_code ec;
+        if (std::filesystem::equivalent(a, b, ec)) {
+            return true;
+        }
+        return a.lexically_normal() == b.lexically_normal();
+    }
+
+}
 
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths) {
     for (auto it = dataPaths.rbegin(); it != dataPaths.rend(); ++it) {
@@ -15,6 +33,21 @@ std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std:
         }
     }
     return std::nullopt;
+}
+
+std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths,
+    const std::filesystem::path& preferred) {
+    if (!preferred.empty()) {
+        const bool listed = std::any_of(dataPaths.begin(), dataPaths.end(),
+            [&preferred](const std::filesystem::path& entry) { return sameDataPathEntry(entry, preferred); });
+        std::error_code ec;
+        if (listed && std::filesystem::is_directory(preferred, ec)) {
+            return preferred;
+        }
+        spdlog::warn("Configured save location '{}' is {} — falling back to the highest-priority folder",
+            preferred.string(), listed ? "not an existing directory" : "no longer among the data paths");
+    }
+    return findWritableDataPath(dataPaths);
 }
 
 std::filesystem::path ensureWritableCopy(const DataFileSystem& files,

--- a/src/resource/WritableDataRoot.h
+++ b/src/resource/WritableDataRoot.h
@@ -15,6 +15,13 @@ class DataFileSystem;
 /// location. Being last means its copies shadow the archives mounted before it.
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths);
 
+/// Same, but honouring an explicit user choice first: when `preferred` is non-empty, is one of
+/// `dataPaths`, and is an existing directory, it is the writable root regardless of list order.
+/// Otherwise (unset, removed from the list, missing on disk, or an archive) this falls back to the
+/// positional rule above — with a warning log, so a configured-but-unusable choice is never silent.
+std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths,
+    const std::filesystem::path& preferred);
+
 /// Ensure a loose, writable copy of a VFS file exists under `writableRoot`, and return its native path.
 ///
 /// Editing game data that lives inside a read-only DAT requires copying it out first. If a copy is

--- a/src/resource/WritableDataRoot.h
+++ b/src/resource/WritableDataRoot.h
@@ -22,6 +22,12 @@ std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std:
 std::optional<std::filesystem::path> findWritableDataPath(const std::vector<std::filesystem::path>& dataPaths,
     const std::filesystem::path& preferred);
 
+/// True when two data-path entries denote the same location: std::filesystem::equivalent when both
+/// exist (symlinks, case variance), lexical comparison otherwise. Deliberately NOT
+/// util::pathsEquivalent — its resolve-to-game-data-root step would conflate a folder with its
+/// data/ subfolder. Shared by the marker-membership checks here and in Settings so they can't drift.
+bool sameDataPathEntry(const std::filesystem::path& a, const std::filesystem::path& b);
+
 /// Ensure a loose, writable copy of a VFS file exists under `writableRoot`, and return its native path.
 ///
 /// Editing game data that lives inside a read-only DAT requires copying it out first. If a copy is

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -1,4 +1,5 @@
 #include "Settings.h"
+#include "resource/WritableDataRoot.h"
 #include "util/GameDataPathResolver.h"
 
 #include <QStandardPaths>
@@ -100,6 +101,9 @@ QJsonObject Settings::toJson() const {
 
     json["version"] = _version;
     json["dataPaths"] = pathVectorToJsonArray(_dataPaths);
+    if (!_writableDataPath.empty()) {
+        json["writableDataPath"] = QString::fromStdString(_writableDataPath.string());
+    }
 
     QJsonObject ui;
     if (!_windowGeometry.isEmpty()) {
@@ -162,6 +166,13 @@ void Settings::fromJson(const QJsonObject& json) {
     if (_version != SETTINGS_VERSION) {
         setDataPaths(util::expandDataPaths(_dataPaths));
         _version = SETTINGS_VERSION;
+    }
+
+    // Read after the data paths (setDataPaths clears an unlisted marker); tolerate a hand-edited
+    // settings file whose marker points outside the list by dropping it instead of trusting it.
+    if (json.contains("writableDataPath")) {
+        setWritableDataPath(std::filesystem::path(json["writableDataPath"].toString().toStdString()));
+        clearWritableDataPathIfUnlisted();
     }
 
     if (json.contains("ui")) {
@@ -280,6 +291,7 @@ void Settings::removeDataPath(const std::filesystem::path& path) {
         _dataPaths.erase(it, _dataPaths.end());
         spdlog::debug("Removed data path: {}", normalizedPath.string());
     }
+    clearWritableDataPathIfUnlisted();
 }
 
 std::vector<std::filesystem::path> Settings::getDataPaths() const {
@@ -290,6 +302,30 @@ void Settings::setDataPaths(const std::vector<std::filesystem::path>& paths) {
     _dataPaths.clear();
     for (const auto& path : paths) {
         addDataPath(path);
+    }
+    clearWritableDataPathIfUnlisted();
+}
+
+std::filesystem::path Settings::getWritableDataPath() const {
+    return _writableDataPath;
+}
+
+void Settings::setWritableDataPath(const std::filesystem::path& path) {
+    _writableDataPath = path.empty() ? std::filesystem::path{} : normalizeDataPath(path);
+}
+
+std::optional<std::filesystem::path> Settings::resolveWritableDataPath() const {
+    return resource::findWritableDataPath(_dataPaths, _writableDataPath);
+}
+
+void Settings::clearWritableDataPathIfUnlisted() {
+    if (_writableDataPath.empty()) {
+        return;
+    }
+    // Plain equality: both sides went through normalizeDataPath, so the stored forms are comparable.
+    if (std::find(_dataPaths.begin(), _dataPaths.end(), _writableDataPath) == _dataPaths.end()) {
+        spdlog::debug("Save location '{}' left the data paths; marker cleared", _writableDataPath.string());
+        _writableDataPath.clear();
     }
 }
 

--- a/src/ui/Settings.cpp
+++ b/src/ui/Settings.cpp
@@ -170,6 +170,8 @@ void Settings::fromJson(const QJsonObject& json) {
 
     // Read after the data paths (setDataPaths clears an unlisted marker); tolerate a hand-edited
     // settings file whose marker points outside the list by dropping it instead of trusting it.
+    // An absent key means unset — reset first so a reload can't keep a stale in-memory marker.
+    _writableDataPath.clear();
     if (json.contains("writableDataPath")) {
         setWritableDataPath(std::filesystem::path(json["writableDataPath"].toString().toStdString()));
         clearWritableDataPathIfUnlisted();
@@ -322,8 +324,13 @@ void Settings::clearWritableDataPathIfUnlisted() {
     if (_writableDataPath.empty()) {
         return;
     }
-    // Plain equality: both sides went through normalizeDataPath, so the stored forms are comparable.
-    if (std::find(_dataPaths.begin(), _dataPaths.end(), _writableDataPath) == _dataPaths.end()) {
+    // The same equivalence the resolver uses (fs::equivalent / lexical), so a marker spelled
+    // differently from its list entry (symlink, redundant "..") isn't cleared by mistake.
+    const bool listed = std::any_of(_dataPaths.begin(), _dataPaths.end(),
+        [this](const std::filesystem::path& entry) {
+            return resource::sameDataPathEntry(entry, _writableDataPath);
+        });
+    if (!listed) {
         spdlog::debug("Save location '{}' left the data paths; marker cleared", _writableDataPath.string());
         _writableDataPath.clear();
     }

--- a/src/ui/Settings.h
+++ b/src/ui/Settings.h
@@ -9,7 +9,7 @@
 #include <QJsonArray>
 #include <QByteArray>
 #include <filesystem>
-#include <memory>
+#include <optional>
 #include <vector>
 
 namespace geck {
@@ -41,6 +41,17 @@ public:
     void removeDataPath(const std::filesystem::path& path);
     std::vector<std::filesystem::path> getDataPaths() const;
     void setDataPaths(const std::vector<std::filesystem::path>& paths);
+
+    // Explicit default save location (Settings > Data Paths "Set as Save Location"). Empty = unset,
+    // in which case saves fall back to the highest-priority folder in the data paths. The marker is
+    // cleared automatically when its folder leaves the data paths, so it can never dangle.
+    std::filesystem::path getWritableDataPath() const;
+    void setWritableDataPath(const std::filesystem::path& path);
+
+    // The folder map saves / maps.txt name edits / .gam edits are written to: the marked folder if
+    // it is still a listed, existing directory, otherwise the positional fallback (nullopt if the
+    // data paths hold no directory at all).
+    std::optional<std::filesystem::path> resolveWritableDataPath() const;
 
     // UI state
     QByteArray getWindowGeometry() const;
@@ -113,11 +124,14 @@ private:
 
     // Helper methods
     QString getSettingsFilePath() const;
+    // Keeps the save-location marker consistent with the data paths (a removed folder can't stay marked).
+    void clearWritableDataPathIfUnlisted();
     QJsonArray pathVectorToJsonArray(const std::vector<std::filesystem::path>& paths) const;
     std::vector<std::filesystem::path> jsonArrayToPathVector(const QJsonArray& array) const;
 
     // Settings data
     std::vector<std::filesystem::path> _dataPaths;
+    std::filesystem::path _writableDataPath; // empty = unset (positional fallback applies)
     QByteArray _windowGeometry;
     QByteArray _dockState;
     bool _windowMaximized = true;        // Default to maximized

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -44,7 +44,6 @@
 #include "format/map/Map.h"
 #include "util/Types.h"
 #include "ui/Settings.h"
-#include "resource/WritableDataRoot.h"
 #include "ui/QtDialogs.h"
 #include "ui/ExternalEditorLauncher.h"
 #include "reader/lst/LstReader.h"
@@ -1370,7 +1369,7 @@ std::filesystem::path MainWindow::writableMapsDir() const {
     if (!_settings) {
         return {};
     }
-    const auto root = resource::findWritableDataPath(_settings->getDataPaths());
+    const auto root = _settings->resolveWritableDataPath();
     if (!root) {
         return {}; // no writable Data Path -> the save dialog falls back to its last-used directory
     }

--- a/src/ui/dialogs/SettingsDialog.cpp
+++ b/src/ui/dialogs/SettingsDialog.cpp
@@ -222,6 +222,7 @@ void SettingsDialog::loadSettings() {
     _originalDataPaths = settings.getDataPaths();
 
     _dataPathsWidget->setDataPaths(_originalDataPaths);
+    _dataPathsWidget->setWritableDataPath(settings.getWritableDataPath());
 
     _edgeScrollCheckBox->setChecked(settings.getEdgeScrollEnabled());
 
@@ -253,6 +254,10 @@ void SettingsDialog::saveSettings() {
     auto dataPaths = _dataPathsWidget->getDataPaths();
     bool pathsHaveChanged = dataPaths != _originalDataPaths;
     settings.setDataPaths(dataPaths);
+    // After setDataPaths (which drops an unlisted marker), and deliberately NOT part of
+    // pathsHaveChanged: moving the save target changes where writes land, not what is mounted,
+    // so it must not trigger the data-path reload.
+    settings.setWritableDataPath(_dataPathsWidget->getWritableDataPath());
 
     settings.setEdgeScrollEnabled(_edgeScrollCheckBox->isChecked());
 

--- a/src/ui/panels/MapInfoPanel.cpp
+++ b/src/ui/panels/MapInfoPanel.cpp
@@ -18,7 +18,6 @@
 #include "resource/GameResources.h"
 #include "resource/MapNameResolver.h"
 #include "resource/MapNameEditor.h"
-#include "resource/WritableDataRoot.h"
 #include "ui/Settings.h"
 #include "reader/ReaderFactory.h"
 #include "reader/gam/GamReader.h"
@@ -561,7 +560,7 @@ void MapInfoPanel::updateOverlayHint() {
     // in the Data Paths to save them to (every path is a read-only archive), hint the user to add one —
     // the editor never creates or mounts a hidden writable location.
     const bool editable = !_displayNameEdit->isReadOnly();
-    const bool hasWritablePath = _settings && resource::findWritableDataPath(_settings->getDataPaths()).has_value();
+    const bool hasWritablePath = _settings && _settings->resolveWritableDataPath().has_value();
     const bool needsWritablePath = editable && !hasWritablePath;
     _overlayHintLabel->setVisible(needsWritablePath);
     if (needsWritablePath) {
@@ -1194,7 +1193,7 @@ void MapInfoPanel::persistMapNames() {
 
     // Write into a writable folder from the user's Data Paths (no hidden location). If there's none, the
     // edit can't be saved -> tell the user to add one. updateOverlayHint() already shows the same hint.
-    const auto target = resource::findWritableDataPath(_settings->getDataPaths());
+    const auto target = _settings->resolveWritableDataPath();
     if (!target.has_value()) {
         QMessageBox::warning(this, "Save Map Names",
             "These map name edits can't be saved: add a writable folder to your Data Paths "
@@ -1229,7 +1228,7 @@ void MapInfoPanel::persistMapVars() {
 
     // Write into a writable folder from the user's Data Paths (no hidden location). If there's none, the
     // edit can't be saved -> tell the user to add one (mirrors persistMapNames()).
-    const auto target = resource::findWritableDataPath(_settings->getDataPaths());
+    const auto target = _settings->resolveWritableDataPath();
     if (!target.has_value()) {
         QMessageBox::warning(this, "Save Map Variables",
             "These global variable edits can't be saved: add a writable folder to your Data Paths "

--- a/src/ui/widgets/DataPathsWidget.cpp
+++ b/src/ui/widgets/DataPathsWidget.cpp
@@ -394,6 +394,10 @@ void DataPathsWidget::refreshSaveLocationMarkers() {
         effective = resource::findWritableDataPath(paths);
     }
 
+    // The marker only takes effect while it is usable; when it isn't, the badge (and its claim
+    // about where saves land) must follow the actual fallback, not the configured wish.
+    const bool markerUsable = !_writableDataPath.empty() && effective.has_value() && *effective == _writableDataPath;
+
     for (int row = 0; row < _pathsTable->rowCount(); ++row) {
         QTableWidgetItem* item = _pathsTable->item(row, PathColumn);
         if (!item) {
@@ -409,8 +413,11 @@ void DataPathsWidget::refreshSaveLocationMarkers() {
         item->setFont(font);
 
         QString tooltip = item->data(BaseTooltipRole).toString();
-        if (isExplicit) {
+        if (isExplicit && markerUsable) {
             tooltip += "\nSave location: map saves and name/variable edits are written here.";
+        } else if (isExplicit) {
+            tooltip += "\nMarked as the save location, but currently unusable (missing folder) — "
+                       "the highest-priority folder is used instead.";
         } else if (isEffective) {
             tooltip += "\nCurrent default save location (highest-priority folder). "
                        "Use \"Set as Save Location\" to pin one explicitly.";

--- a/src/ui/widgets/DataPathsWidget.cpp
+++ b/src/ui/widgets/DataPathsWidget.cpp
@@ -1,6 +1,7 @@
 #include "DataPathsWidget.h"
 #include "ui/Settings.h"
 #include "Application.h"
+#include "resource/WritableDataRoot.h"
 #include "ui/UIConstants.h"
 #include "ui/common/ButtonStyle.h"
 #include "util/GameDataPathResolver.h"
@@ -15,11 +16,19 @@
 #include <QTableWidgetItem>
 #include <QAbstractItemView>
 #include <algorithm>
+#include <optional>
+#include <system_error>
 #include <spdlog/spdlog.h>
 
 namespace geck {
 
 using namespace ui::constants;
+
+namespace {
+    // The path item's tooltip as composed at row creation, before the save-location line is
+    // appended — refreshSaveLocationMarkers rebuilds from this so the line never accumulates.
+    constexpr int BaseTooltipRole = Qt::UserRole + 1;
+}
 
 DataPathsWidget::DataPathsWidget(std::shared_ptr<Settings> settings, QWidget* parent)
     : QGroupBox("Fallout 2 Data Paths", parent)
@@ -31,6 +40,7 @@ DataPathsWidget::DataPathsWidget(std::shared_ptr<Settings> settings, QWidget* pa
     , _removeButton(nullptr)
     , _moveUpButton(nullptr)
     , _moveDownButton(nullptr)
+    , _saveLocationButton(nullptr)
     , _autoDetectButton(nullptr)
     , _progressBar(nullptr)
     , _settings(std::move(settings)) {
@@ -47,7 +57,9 @@ void DataPathsWidget::setupUI() {
         "reorder or remove) or a single .dat file. Every source is searched together; when the same "
         "file is present in more than one, the higher-priority source wins.\n"
         "The top entry has the highest priority and overrides the ones below it — use Move Up / Move "
-        "Down to reorder.");
+        "Down to reorder.\n"
+        "Map saves and name/variable edits are written to the folder marked as the Save Location; if "
+        "none is marked, the highest-priority folder is used.");
     _helpLabel->setWordWrap(true);
     _helpLabel->setStyleSheet(ui::theme::styles::helpText());
     _layout->addWidget(_helpLabel);
@@ -96,6 +108,14 @@ void DataPathsWidget::setupUI() {
     _moveDownButton->setEnabled(false);
     _controlLayout->addWidget(_moveDownButton);
 
+    _saveLocationButton = new QPushButton("Set as Save Location");
+    _saveLocationButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogSaveButton));
+    _saveLocationButton->setToolTip(
+        "Write map saves and name/variable edits to the selected folder, regardless of its priority.\n"
+        "Only real folders can be a save location — DAT archives are read-only.");
+    _saveLocationButton->setEnabled(false);
+    _controlLayout->addWidget(_saveLocationButton);
+
     _controlLayout->addStretch();
 
     _autoDetectButton = new QPushButton("Auto-Detect");
@@ -104,7 +124,7 @@ void DataPathsWidget::setupUI() {
     _controlLayout->addWidget(_autoDetectButton);
 
     // Consistent icon size + minimum height so the buttons don't shrink and clip their icons on resize.
-    for (QPushButton* btn : { _addButton, _removeButton, _moveUpButton, _moveDownButton, _autoDetectButton }) {
+    for (QPushButton* btn : { _addButton, _removeButton, _moveUpButton, _moveDownButton, _saveLocationButton, _autoDetectButton }) {
         geck::ui::styleActionButton(btn);
     }
 
@@ -120,6 +140,7 @@ void DataPathsWidget::setupConnections() {
     connect(_removeButton, &QPushButton::clicked, this, &DataPathsWidget::onRemovePath);
     connect(_moveUpButton, &QPushButton::clicked, [this]() { moveSelectedPath(-1); });
     connect(_moveDownButton, &QPushButton::clicked, [this]() { moveSelectedPath(1); });
+    connect(_saveLocationButton, &QPushButton::clicked, this, &DataPathsWidget::onToggleSaveLocation);
     connect(_autoDetectButton, &QPushButton::clicked, this, &DataPathsWidget::onAutoDetect);
     connect(_pathsTable, &QTableWidget::itemSelectionChanged, this, &DataPathsWidget::onSelectionChanged);
     connect(_pathsTable, &QTableWidget::cellDoubleClicked, this, &DataPathsWidget::onCellDoubleClicked);
@@ -154,7 +175,26 @@ void DataPathsWidget::setDataPaths(const std::vector<std::filesystem::path>& pat
     }
 
     renumberPriorities();
+
+    // A save-location marker whose folder is no longer among the rows can't stay marked.
+    if (!_writableDataPath.empty()) {
+        const auto current = getDataPaths();
+        if (std::find(current.begin(), current.end(), _writableDataPath) == current.end()) {
+            _writableDataPath.clear();
+        }
+    }
+
     validatePaths();
+    updateButtonStates();
+}
+
+std::filesystem::path DataPathsWidget::getWritableDataPath() const {
+    return _writableDataPath;
+}
+
+void DataPathsWidget::setWritableDataPath(const std::filesystem::path& path) {
+    _writableDataPath = path.empty() ? std::filesystem::path{} : Settings::normalizeDataPath(path);
+    refreshSaveLocationMarkers();
     updateButtonStates();
 }
 
@@ -202,6 +242,7 @@ bool DataPathsWidget::addPathRow(const std::filesystem::path& path, bool atTop) 
     pathItem->setToolTip(pathStr + "\n" + pathItem->toolTip());
 
     pathItem->setData(Qt::UserRole, isDefaultPath);
+    pathItem->setData(BaseTooltipRole, pathItem->toolTip());
 
     const int row = atTop ? 0 : _pathsTable->rowCount();
     _pathsTable->insertRow(row);
@@ -245,6 +286,8 @@ int DataPathsWidget::selectedRow() const {
 }
 
 void DataPathsWidget::validatePaths() {
+    refreshSaveLocationMarkers(); // rows or the marker changed; either moves the badge
+
     auto& settings = *_settings;
     auto dataPaths = getDataPaths();
 
@@ -287,6 +330,99 @@ void DataPathsWidget::updateButtonStates() {
         _moveUpButton->setEnabled(false);
         _moveDownButton->setEnabled(false);
     }
+
+    // The button doubles as the un-mark action when the selected row is already the save location.
+    const bool markable = isMarkableRow(row);
+    _saveLocationButton->setEnabled(markable);
+    const bool selectedIsMarked = markable && !_writableDataPath.empty() && pathAtRow(row) == _writableDataPath;
+    _saveLocationButton->setText(selectedIsMarked ? "Clear Save Location" : "Set as Save Location");
+}
+
+std::filesystem::path DataPathsWidget::pathAtRow(int row) const {
+    if (row < 0 || row >= _pathsTable->rowCount()) {
+        return {};
+    }
+    QTableWidgetItem* item = _pathsTable->item(row, PathColumn);
+    if (!item) {
+        return {};
+    }
+    return Settings::normalizeDataPath(item->text().toStdString());
+}
+
+bool DataPathsWidget::isMarkableRow(int row) const {
+    if (row < 0 || row >= _pathsTable->rowCount() || isProtectedRow(row)) {
+        return false; // the built-in resources folder must not collect user maps
+    }
+    const std::filesystem::path path = pathAtRow(row);
+    std::error_code ec;
+    return !path.empty() && std::filesystem::is_directory(path, ec);
+}
+
+void DataPathsWidget::onToggleSaveLocation() {
+    const int row = selectedRow();
+    if (!isMarkableRow(row)) {
+        return;
+    }
+
+    const std::filesystem::path path = pathAtRow(row);
+    if (_writableDataPath == path) {
+        _writableDataPath.clear();
+        setStatusMessage("Save location cleared — the highest-priority folder will be used.", "info");
+    } else {
+        _writableDataPath = path;
+        setStatusMessage(QString("Save location: %1").arg(QString::fromStdString(path.string())), "success");
+    }
+
+    Q_EMIT dataPathsChanged(); // marks the dialog dirty so Apply/OK persists the marker
+    refreshSaveLocationMarkers();
+    updateButtonStates();
+}
+
+void DataPathsWidget::refreshSaveLocationMarkers() {
+    const auto paths = getDataPaths();
+
+    // Where saves would land right now. Mirrors resource::findWritableDataPath(paths, marker) but
+    // resolves the fallback locally so a stale marker doesn't warn-log on every table repaint —
+    // the warning belongs to actual save operations.
+    std::optional<std::filesystem::path> effective;
+    std::error_code ec;
+    if (!_writableDataPath.empty()
+        && std::find(paths.begin(), paths.end(), _writableDataPath) != paths.end()
+        && std::filesystem::is_directory(_writableDataPath, ec)) {
+        effective = _writableDataPath;
+    } else {
+        effective = resource::findWritableDataPath(paths);
+    }
+
+    for (int row = 0; row < _pathsTable->rowCount(); ++row) {
+        QTableWidgetItem* item = _pathsTable->item(row, PathColumn);
+        if (!item) {
+            continue;
+        }
+        const std::filesystem::path rowPath = Settings::normalizeDataPath(item->text().toStdString());
+        const bool isExplicit = !_writableDataPath.empty() && rowPath == _writableDataPath;
+        const bool isEffective = effective.has_value() && rowPath == *effective;
+
+        QFont font = _pathsTable->font();
+        font.setBold(isExplicit);
+        font.setItalic(isEffective && !isExplicit);
+        item->setFont(font);
+
+        QString tooltip = item->data(BaseTooltipRole).toString();
+        if (isExplicit) {
+            tooltip += "\nSave location: map saves and name/variable edits are written here.";
+        } else if (isEffective) {
+            tooltip += "\nCurrent default save location (highest-priority folder). "
+                       "Use \"Set as Save Location\" to pin one explicitly.";
+        }
+        item->setToolTip(tooltip);
+
+        // Swap the folder icon for a save badge on the effective row; leave warning/file icons alone.
+        if (std::filesystem::is_directory(rowPath, ec) && _settings->validateDataPath(rowPath)) {
+            item->setIcon(QApplication::style()->standardIcon(
+                isEffective ? QStyle::SP_DialogSaveButton : QStyle::SP_DirIcon));
+        }
+    }
 }
 
 void DataPathsWidget::removeSelectedPath() {
@@ -301,11 +437,20 @@ void DataPathsWidget::removeSelectedPath() {
         return;
     }
 
+    const bool removedMarked = !_writableDataPath.empty() && pathAtRow(row) == _writableDataPath;
+    if (removedMarked) {
+        _writableDataPath.clear();
+    }
+
     _pathsTable->removeRow(row);
     Q_EMIT dataPathsChanged();
     renumberPriorities();
     validatePaths();
     updateButtonStates();
+
+    if (removedMarked) { // after validatePaths so its summary doesn't overwrite this notice
+        setStatusMessage("The removed folder was the save location — the highest-priority folder will be used.", "warning");
+    }
 }
 
 int DataPathsWidget::addFolderExpanded(const std::filesystem::path& folder, bool atTop) {
@@ -458,6 +603,11 @@ void DataPathsWidget::onCellDoubleClicked(int row, int /*column*/) {
         newPath = QFileDialog::getExistingDirectory(this, "Select Fallout 2 Data Directory", currentPath);
     }
     if (!newPath.isEmpty() && newPath != currentPath) {
+        // Re-picking a marked folder keeps it the save location under its new path.
+        const std::filesystem::path oldPath = Settings::normalizeDataPath(currentPath.toStdString());
+        if (!_writableDataPath.empty() && _writableDataPath == oldPath) {
+            _writableDataPath = Settings::normalizeDataPath(newPath.toStdString());
+        }
         item->setText(newPath);
         Q_EMIT dataPathsChanged();
         validatePaths();

--- a/src/ui/widgets/DataPathsWidget.h
+++ b/src/ui/widgets/DataPathsWidget.h
@@ -33,6 +33,11 @@ public:
     std::vector<std::filesystem::path> getDataPaths() const;
     void setDataPaths(const std::vector<std::filesystem::path>& paths);
 
+    // Explicit default save location (empty = unset -> the highest-priority folder is used).
+    // Kept as a path, not a row, so reordering rows never moves the marker.
+    std::filesystem::path getWritableDataPath() const;
+    void setWritableDataPath(const std::filesystem::path& path);
+
     // Validation
     void validatePaths();
 
@@ -50,6 +55,7 @@ private slots:
     void onAutoDetect();
     void onSelectionChanged();
     void onCellDoubleClicked(int row, int column);
+    void onToggleSaveLocation(); // mark the selected folder as the save location (or clear it)
 
 private:
     void setupUI();
@@ -66,6 +72,13 @@ private:
     void renumberPriorities();
     bool isProtectedRow(int row) const;
     int selectedRow() const;
+    std::filesystem::path pathAtRow(int row) const; // normalized, empty if the row has no path item
+    // A row can be marked as the save location only if it's a real folder the editor could write to
+    // (not a .dat, not missing, not the protected built-in resources path).
+    bool isMarkableRow(int row) const;
+    // Re-derive each row's save-location badge (bold + save icon for the explicit marker, italic for
+    // the positional default) from the current rows + marker. Called whenever either changes.
+    void refreshSaveLocationMarkers();
 
     // Highest priority is the top row; the stored order is lowest-priority-first, so the table
     // displays it reversed (see getDataPaths/setDataPaths). Columns:
@@ -82,10 +95,12 @@ private:
     QPushButton* _removeButton;
     QPushButton* _moveUpButton;
     QPushButton* _moveDownButton;
+    QPushButton* _saveLocationButton;
     QPushButton* _autoDetectButton;
     QProgressBar* _progressBar;
 
     std::shared_ptr<Settings> _settings;
+    std::filesystem::path _writableDataPath; // local copy; persisted by SettingsDialog on save
 };
 
 } // namespace geck

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,8 @@ add_executable(qt_tests
     qt/test_completeness_view.cpp
     # File browser population: worker-computed metadata -> chunked tree build.
     qt/test_file_browser_population.cpp
+    # Explicit save-location marker on the data paths: resolution, never-dangles invariant, JSON round-trip.
+    qt/test_settings_writable_path.cpp
     # CI-failing ceilings on operations that have regressed catastrophically before.
     qt/test_performance_guards.cpp
 )

--- a/tests/general/test_writable_data_root.cpp
+++ b/tests/general/test_writable_data_root.cpp
@@ -72,3 +72,48 @@ TEST_CASE("findWritableDataPath returns the last directory, skipping archives", 
     }
     fs::remove_all(base);
 }
+
+TEST_CASE("findWritableDataPath honours an explicit save-location marker", "[writableroot]") {
+    const fs::path base = fs::path{ GECK_TEST_TMP_DIR } / "fwdp_marker";
+    fs::remove_all(base);
+    const fs::path dirA = base / "a";
+    const fs::path dirB = base / "b";
+    fs::create_directories(dirA);
+    fs::create_directories(dirB);
+    const fs::path fakeDat = base / "master.dat";
+    writeFile(fakeDat, "not a real dat"); // a file, not a directory
+
+    SECTION("a marked directory wins regardless of list order") {
+        // The positional rule alone would pick dirB (the last directory).
+        const auto target = resource::findWritableDataPath({ dirA, fakeDat, dirB }, dirA);
+        REQUIRE(target.has_value());
+        CHECK(*target == dirA);
+    }
+    SECTION("an empty marker keeps the positional rule") {
+        const auto target = resource::findWritableDataPath({ dirA, fakeDat, dirB }, {});
+        REQUIRE(target.has_value());
+        CHECK(*target == dirB);
+    }
+    SECTION("a marker that is not a listed data path falls back") {
+        const fs::path outsider = base / "outside";
+        fs::create_directories(outsider);
+        const auto target = resource::findWritableDataPath({ dirA, dirB }, outsider);
+        REQUIRE(target.has_value());
+        CHECK(*target == dirB);
+    }
+    SECTION("a marker pointing at an archive entry falls back") {
+        const auto target = resource::findWritableDataPath({ dirA, fakeDat }, fakeDat);
+        REQUIRE(target.has_value());
+        CHECK(*target == dirA);
+    }
+    SECTION("a marked directory that vanished from disk falls back") {
+        const fs::path gone = base / "gone"; // listed, but never created on disk
+        const auto target = resource::findWritableDataPath({ dirA, gone, dirB }, gone);
+        REQUIRE(target.has_value());
+        CHECK(*target == dirB);
+    }
+    SECTION("marker set but no usable directory at all -> nullopt") {
+        CHECK_FALSE(resource::findWritableDataPath({ fakeDat }, fakeDat).has_value());
+    }
+    fs::remove_all(base);
+}

--- a/tests/qt/test_settings_writable_path.cpp
+++ b/tests/qt/test_settings_writable_path.cpp
@@ -1,0 +1,98 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <filesystem>
+
+#include "ui/Settings.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Settings persists to the (test-mode) ConfigLocation; scrub it so this test neither inherits
+// another test's file nor leaves one behind.
+void removeSettingsFile() {
+    const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QFile::remove(QDir(configPath).filePath("gecko/settings.json"));
+    QFile::remove(QDir(configPath).filePath("settings.json"));
+}
+
+} // namespace
+
+TEST_CASE("Settings save-location marker: resolution, invariant, persistence", "[settings][writableroot]") {
+    QTemporaryDir temp;
+    REQUIRE(temp.isValid());
+    const fs::path dirA = fs::path(temp.path().toStdString()) / "a";
+    const fs::path dirB = fs::path(temp.path().toStdString()) / "b";
+    fs::create_directories(dirA);
+    fs::create_directories(dirB);
+
+    removeSettingsFile();
+
+    SECTION("marker overrides the positional fallback; clearing restores it") {
+        geck::Settings settings;
+        settings.setDataPaths({ dirA, dirB });
+        REQUIRE(settings.resolveWritableDataPath().has_value());
+        CHECK(*settings.resolveWritableDataPath() == dirB); // positional rule: last directory wins
+
+        settings.setWritableDataPath(dirA);
+        CHECK(settings.getWritableDataPath() == dirA);
+        REQUIRE(settings.resolveWritableDataPath().has_value());
+        CHECK(*settings.resolveWritableDataPath() == dirA);
+
+        settings.setWritableDataPath({});
+        REQUIRE(settings.resolveWritableDataPath().has_value());
+        CHECK(*settings.resolveWritableDataPath() == dirB);
+    }
+
+    SECTION("the marker never dangles: it clears when its folder leaves the data paths") {
+        geck::Settings settings;
+        settings.setDataPaths({ dirA, dirB });
+        settings.setWritableDataPath(dirA);
+
+        settings.removeDataPath(dirA);
+        CHECK(settings.getWritableDataPath().empty());
+        REQUIRE(settings.resolveWritableDataPath().has_value());
+        CHECK(*settings.resolveWritableDataPath() == dirB);
+
+        settings.setDataPaths({ dirA, dirB });
+        settings.setWritableDataPath(dirB);
+        settings.setDataPaths({ dirA }); // wholesale replacement drops the marked folder too
+        CHECK(settings.getWritableDataPath().empty());
+    }
+
+    SECTION("marker round-trips through save() and load()") {
+        {
+            geck::Settings settings;
+            settings.setDataPaths({ dirA, dirB });
+            settings.setWritableDataPath(dirA);
+            settings.save();
+        }
+
+        geck::Settings reloaded;
+        reloaded.load();
+        CHECK(reloaded.getWritableDataPath() == dirA);
+        REQUIRE(reloaded.resolveWritableDataPath().has_value());
+        CHECK(*reloaded.resolveWritableDataPath() == dirA);
+    }
+
+    SECTION("an unset marker is not written and loads as unset") {
+        {
+            geck::Settings settings;
+            settings.setDataPaths({ dirA, dirB });
+            settings.save();
+        }
+
+        geck::Settings reloaded;
+        reloaded.load();
+        CHECK(reloaded.getWritableDataPath().empty());
+        REQUIRE(reloaded.resolveWritableDataPath().has_value());
+        CHECK(*reloaded.resolveWritableDataPath() == dirB);
+    }
+
+    removeSettingsFile();
+}

--- a/tests/qt/test_settings_writable_path.cpp
+++ b/tests/qt/test_settings_writable_path.cpp
@@ -80,6 +80,32 @@ TEST_CASE("Settings save-location marker: resolution, invariant, persistence", "
         CHECK(*reloaded.resolveWritableDataPath() == dirA);
     }
 
+    SECTION("a marker spelled differently from its list entry is not cleared by mistake") {
+        geck::Settings settings;
+        settings.setDataPaths({ dirA, dirB });
+        // Same directory, non-canonical spelling: equivalence, not exact equality, must decide.
+        settings.setWritableDataPath(dirA / ".");
+        CHECK_FALSE(settings.getWritableDataPath().empty());
+        REQUIRE(settings.resolveWritableDataPath().has_value());
+
+        settings.setDataPaths({ dirA, dirB }); // re-set must keep the equivalent marker listed
+        CHECK_FALSE(settings.getWritableDataPath().empty());
+    }
+
+    SECTION("loading a file without the key resets an in-memory marker") {
+        {
+            geck::Settings settings;
+            settings.setDataPaths({ dirA, dirB });
+            settings.save(); // no marker in the file
+        }
+
+        geck::Settings stale;
+        stale.setDataPaths({ dirA, dirB });
+        stale.setWritableDataPath(dirA);
+        stale.load(); // absent key means unset — the in-memory marker must not survive
+        CHECK(stale.getWritableDataPath().empty());
+    }
+
     SECTION("an unset marker is not written and loads as unset") {
         {
             geck::Settings settings;


### PR DESCRIPTION
## What

Adds an explicit **"Set as Save Location"** marker to Settings → Data Paths, closing the "writable save target is positional, not chosen" gap tracked in PLAN.md.

Previously, map saves (and maps.txt name / `.gam` edits) landed in whichever folder sat highest in the Data Paths list — reordering the list silently moved the save target, and nothing in the UI showed which folder was the writable one.

## How

- **Resolution** (`src/resource/WritableDataRoot`): new `findWritableDataPath(dataPaths, preferred)` overload. A non-empty marker wins when it is still a listed, existing directory; otherwise it warn-logs and falls back to the existing positional rule — never silently. Membership is a plain path comparison, deliberately not `util::pathsEquivalent`, whose resolve-to-game-data-root step would conflate a folder with its `data/` subfolder.
- **Settings**: optional `writableDataPath` JSON key (no version bump — absent = unset = today's behaviour), plus `resolveWritableDataPath()` used by all consumers. `setDataPaths`/`removeDataPath` clear a marker whose folder leaves the list, so it can never dangle.
- **UI** (`DataPathsWidget`): a toggle button ("Set as Save Location" / "Clear Save Location"), enabled only for real folders — DAT archives and the protected built-in resources folder can't be marked. The table always badges the *effective* save target with a save icon: **bold** = explicit marker, *italic* = positional default, each with an explanatory tooltip. The marker tracks the path, not the row, so reordering never moves it; removing the marked row clears it with a status notice.
- **Dialog wiring**: the marker persists on Apply/OK but is excluded from `pathsHaveChanged`, so changing only the save target doesn't trigger the expensive data-path remount.
- **Call sites**: `MainWindow::writableMapsDir` (Save/Save As default dir) and `MapInfoPanel` (overlay hint, maps.txt name edits, `.gam` writes) now use `Settings::resolveWritableDataPath()`.

## Tests

- `tests/general/test_writable_data_root.cpp`: marker beats list order; empty marker preserves the old rule; unlisted / archive / vanished-from-disk markers fall back; nothing usable → `nullopt`.
- `tests/qt/test_settings_writable_path.cpp` (new): marker overrides and clears correctly, the never-dangles invariant across `removeDataPath`/`setDataPaths`, and the JSON round-trip through `save()`/`load()` including the unset case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)