### PR TITLE
Show light sources as hex-accurate lit hexes with real falloff

### DIFF
--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -69,44 +69,19 @@ inline std::optional<int> translate(int position, int fromAnchor, int toAnchor) 
     return cr.row * WIDTH + cr.col;
 }
 
-// All grid positions within hex-distance `radius` of `centerPosition` — a filled hex disc
-// with the centre included, in ascending position order per the row-major cube sweep. This
-// matches the engine's spatial-script trigger test `tileDistanceBetween(centre, h) <= radius`
-// (fallout2-ce tile.cc/scripts.cc): cube distance equals that hex-step distance because the
-// offset<->cube conversion mirrors the engine's `_dir_tile` parity layout. Off-grid hexes are
-// skipped, so a disc near an edge is clipped; `radius` < 0 yields an empty list.
-inline std::vector<int> hexesWithinRadius(int centerPosition, int radius) {
-    std::vector<int> positions;
-    if (radius < 0) {
-        return positions;
-    }
-    const Cube center = cubeOfPosition(centerPosition);
-    for (int dx = -radius; dx <= radius; ++dx) {
-        const int lo = std::max(-radius, -dx - radius);
-        const int hi = std::min(radius, -dx + radius);
-        for (int dy = lo; dy <= hi; ++dy) {
-            const int dz = -dx - dy;
-            const ColRow cr = cubeToOffset(center + Cube{ dx, dy, dz });
-            if (cr.col < 0 || cr.col >= WIDTH || cr.row < 0 || cr.row >= HEIGHT) {
-                continue;
-            }
-            positions.push_back(cr.row * WIDTH + cr.col);
-        }
-    }
-    return positions;
-}
-
 // A hex within a disc, paired with its hex-step distance from the centre.
 struct HexAtDistance {
     int position = 0;
     int distance = 0;
 };
 
-// Same filled hex disc as hexesWithinRadius, but each hex is paired with its hex-step distance
-// from the centre (0 at the centre, up to `radius`). Cube distance (|dx|+|dy|+|dz|)/2 equals the
-// engine's hex-step distance because the offset<->cube conversion mirrors fallout2-ce's `_dir_tile`
-// parity layout. Used to tint a light source's hexes by the engine's per-ring falloff. Off-grid
-// hexes are skipped; `radius` < 0 yields an empty list.
+// A filled hex disc of hex-distance `radius` around `centerPosition`, each hex paired with its
+// hex-step distance from the centre (0 at the centre, up to `radius`), in ascending position order
+// per the row-major cube sweep. Cube distance (|dx|+|dy|+|dz|)/2 equals the engine's hex-step
+// distance (fallout2-ce `tileDistanceBetween`) because the offset<->cube conversion mirrors the
+// engine's `_dir_tile` parity layout. Off-grid hexes are skipped, so a disc near an edge is clipped;
+// `radius` < 0 yields an empty list. This is the primitive behind hexesWithinRadius (which drops the
+// distance) and the per-ring light-overlay falloff.
 inline std::vector<HexAtDistance> hexDiscByDistance(int centerPosition, int radius) {
     std::vector<HexAtDistance> hexes;
     if (radius < 0) {
@@ -127,6 +102,19 @@ inline std::vector<HexAtDistance> hexDiscByDistance(int centerPosition, int radi
         }
     }
     return hexes;
+}
+
+// All grid positions within hex-distance `radius` of `centerPosition` — the same filled disc as
+// hexDiscByDistance with the per-hex distance dropped. Matches the engine's spatial-script trigger
+// test `tileDistanceBetween(centre, h) <= radius`.
+inline std::vector<int> hexesWithinRadius(int centerPosition, int radius) {
+    const auto disc = hexDiscByDistance(centerPosition, radius);
+    std::vector<int> positions;
+    positions.reserve(disc.size());
+    for (const auto& hex : disc) {
+        positions.push_back(hex.position);
+    }
+    return positions;
 }
 
 } // namespace geck::hexgrid

--- a/src/editor/HexGeometry.h
+++ b/src/editor/HexGeometry.h
@@ -3,6 +3,7 @@
 #include "HexagonGrid.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <optional>
 #include <vector>
 
@@ -93,6 +94,39 @@ inline std::vector<int> hexesWithinRadius(int centerPosition, int radius) {
         }
     }
     return positions;
+}
+
+// A hex within a disc, paired with its hex-step distance from the centre.
+struct HexAtDistance {
+    int position = 0;
+    int distance = 0;
+};
+
+// Same filled hex disc as hexesWithinRadius, but each hex is paired with its hex-step distance
+// from the centre (0 at the centre, up to `radius`). Cube distance (|dx|+|dy|+|dz|)/2 equals the
+// engine's hex-step distance because the offset<->cube conversion mirrors fallout2-ce's `_dir_tile`
+// parity layout. Used to tint a light source's hexes by the engine's per-ring falloff. Off-grid
+// hexes are skipped; `radius` < 0 yields an empty list.
+inline std::vector<HexAtDistance> hexDiscByDistance(int centerPosition, int radius) {
+    std::vector<HexAtDistance> hexes;
+    if (radius < 0) {
+        return hexes;
+    }
+    const Cube center = cubeOfPosition(centerPosition);
+    for (int dx = -radius; dx <= radius; ++dx) {
+        const int lo = std::max(-radius, -dx - radius);
+        const int hi = std::min(radius, -dx + radius);
+        for (int dy = lo; dy <= hi; ++dy) {
+            const int dz = -dx - dy;
+            const ColRow cr = cubeToOffset(center + Cube{ dx, dy, dz });
+            if (cr.col < 0 || cr.col >= WIDTH || cr.row < 0 || cr.row >= HEIGHT) {
+                continue;
+            }
+            const int distance = (std::abs(dx) + std::abs(dy) + std::abs(dz)) / 2;
+            hexes.push_back({ cr.row * WIDTH + cr.col, distance });
+        }
+    }
+    return hexes;
 }
 
 } // namespace geck::hexgrid

--- a/src/editor/Object.cpp
+++ b/src/editor/Object.cpp
@@ -16,8 +16,7 @@ Object::Object(const Frm* frm)
     : _sprite(createBlankTexture())
     , _frm(frm)
     , _direction(0)
-    , _selected(false)
-    , _showLightOverlay(false) {
+    , _selected(false) {
 
     if (!frm) {
         spdlog::error("Object constructor: FRM pointer is null");
@@ -35,8 +34,6 @@ Object::Object(const Frm* frm)
             frm->filename(), frm->directions().at(0).frames().size());
         throw SpriteException("FRM direction has no frames", frm->filename());
     }
-
-    initializeLightOverlay();
 }
 
 sf::Texture& Object::createBlankTexture() {
@@ -118,10 +115,6 @@ void Object::setHexPosition(const Hex& hex) {
     if (_mapObject != nullptr) {
         _mapObject->position = hex.position();
     }
-
-    if (_showLightOverlay && hasLight()) {
-        updateLightOverlay();
-    }
 }
 
 int16_t Object::shiftX() const {
@@ -185,46 +178,6 @@ void Object::unselect() {
 
 bool Object::isSelected() const noexcept {
     return _selected;
-}
-
-void Object::initializeLightOverlay() {
-    _lightOverlay.setFillColor(sf::Color(255, 255, 100, 30));    // Light yellow, semi-transparent
-    _lightOverlay.setOutlineColor(sf::Color(255, 255, 150, 80)); // Brighter yellow outline
-    _lightOverlay.setOutlineThickness(1.0f);
-    _lightOverlay.setPointCount(6); // Hexagonal shape to match the grid
-}
-
-void Object::setShowLightOverlay(bool show) {
-    _showLightOverlay = show;
-    if (show && _mapObject) {
-        updateLightOverlay();
-    }
-}
-
-void Object::updateLightOverlay() {
-    if (!_mapObject || !_mapObject->isLightSource()) {
-        return;
-    }
-
-    // Each hex is approximately 32 pixels wide in standard zoom.
-    float hexWidth = 32.0f;
-    float radius = _mapObject->light_radius * hexWidth / 2.0f;
-
-    _lightOverlay.setRadius(radius);
-    _lightOverlay.setOrigin(sf::Vector2f(radius, radius));
-
-    // Position the overlay at the object's center.
-    auto spritePos = _sprite.getPosition();
-    auto spriteBounds = _sprite.getLocalBounds();
-    _lightOverlay.setPosition(sf::Vector2f(
-        spritePos.x + spriteBounds.size.x / 2.0f,
-        spritePos.y + spriteBounds.size.y / 2.0f));
-
-    auto color = _lightOverlay.getFillColor();
-    // Map light intensity (engine range 0-65535) to alpha (30-100).
-    uint8_t alpha = static_cast<uint8_t>(30 + (_mapObject->light_intensity / 65535.0f) * 70);
-    color.a = alpha;
-    _lightOverlay.setFillColor(color);
 }
 
 bool Object::hasLight() const noexcept {

--- a/src/editor/Object.h
+++ b/src/editor/Object.h
@@ -30,14 +30,12 @@ class Frm;
 class Object {
 private:
     sf::Sprite _sprite;
-    sf::CircleShape _lightOverlay; // Light radius visualization
 
     std::shared_ptr<MapObject> _mapObject;
 
     const Frm* _frm;
     int _direction;
     bool _selected;
-    bool _showLightOverlay;
 
 public:
     Object(const Frm* frm);
@@ -63,11 +61,8 @@ public:
     void unselect();
     [[nodiscard]] bool isSelected() const noexcept;
 
-    // Light overlay methods
-    void setShowLightOverlay(bool show);
-    [[nodiscard]] bool isShowingLightOverlay() const noexcept { return _showLightOverlay; }
-    void updateLightOverlay();
-    [[nodiscard]] const sf::CircleShape& getLightOverlay() const noexcept { return _lightOverlay; }
+    // True when this object is a light source (its MapObject has a non-zero light radius or intensity).
+    // The illuminated hexes themselves are drawn by RenderingEngine::renderLightOverlays.
     [[nodiscard]] bool hasLight() const noexcept;
 
     [[nodiscard]] int16_t shiftX() const;
@@ -78,7 +73,6 @@ public:
 
 private:
     static sf::Texture& createBlankTexture();
-    void initializeLightOverlay();
 };
 
 } // namespace geck

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -16,6 +16,7 @@
 #include "util/Coordinates.h"
 #include "util/TileUtils.h"
 #include "viewport/ViewportController.h"
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <exception>
@@ -54,6 +55,42 @@ void main() {
 
     // Outline thickness in pixels (texels sampled when detecting the silhouette edge).
     constexpr float kOutlineThickness = 1.0f;
+
+    // Fallout 2 CE light model, used to tint the "Show light overlays" cue like the engine lights a
+    // hex (fallout2-ce src/light.cc, src/object.cc `_obj_adjust_light`). The engine stamps light into
+    // a per-hex grid: full intensity on the source hex, then a linear per-ring decrement out to the
+    // light's radius. We reproduce the falloff value per ring; we do NOT reproduce wall shadowing or
+    // the ambient-darkness pass — this is an illustrative overlay, not a lighting simulation.
+    namespace light {
+        constexpr int FLOOR = 655;    // per-hex ambient floor the engine inits every cell to (~1% of full)
+        constexpr int FULL = 65536;   // 0x10000 == 100% brightness (light intensity is clamped to this)
+        constexpr int MAX_RADIUS = 8; // object light radius is clamped to 8 hexes
+
+        // Intensity the engine deposits `ring` steps from a source of the given `intensity`/`radius`:
+        // the source hex (ring 0) gets full intensity, each further ring loses (intensity - FLOOR) /
+        // (radius + 1). Mirrors the `v28[]` distribution built in `_obj_adjust_light`.
+        int depositedIntensity(int intensity, int radius, int ring) {
+            if (ring <= 0) {
+                return intensity;
+            }
+            const int step = (intensity - FLOOR) / (radius + 1);
+            return intensity - ring * step;
+        }
+
+        // Overlay alpha for a deposited intensity: nothing at/below the ambient floor, otherwise a warm
+        // tint whose opacity tracks the fraction of full brightness contributed, so brighter/closer
+        // hexes read stronger and dim or distant ones fade out.
+        constexpr int MIN_ALPHA = 30;
+        constexpr int MAX_ALPHA = 140;
+        int tintAlpha(int deposited) {
+            if (deposited <= FLOOR) {
+                return 0;
+            }
+            const float frac = std::min(1.0f,
+                static_cast<float>(deposited - FLOOR) / static_cast<float>(FULL - FLOOR));
+            return MIN_ALPHA + static_cast<int>(frac * static_cast<float>(MAX_ALPHA - MIN_ALPHA));
+        }
+    } // namespace light
 } // namespace
 
 sf::Color RenderingEngine::objectOutlineColor(const Object& object) const {
@@ -82,6 +119,12 @@ void RenderingEngine::render(sf::RenderTarget& target,
     // Layer 1: Floor tiles (always rendered)
     if (renderData.floorSprites) {
         renderFloorTiles(target, *renderData.floorSprites);
+    }
+
+    // Layer 1b: Light overlays. Drawn as a ground layer (over the floor, under objects) so each light
+    // source's illuminated hexes read like light pooling on the ground with objects standing in it.
+    if (visibility.showLightOverlays) {
+        renderLightOverlays(target, view, renderData);
     }
 
     // Layer 2: Hex grid overlay (if enabled)
@@ -307,16 +350,55 @@ void RenderingEngine::renderObjects(sf::RenderTarget& target,
         }
 
         target.draw(object->getSprite());
-
-        if (visibility.showLightOverlays && object->hasLight()) {
-            target.draw(object->getLightOverlay());
-        }
     }
 
     // Wall blocker overlays render on top of regular objects
     if (visibility.showWallBlockers && renderData.wallBlockerOverlays) {
         for (const auto& overlay : *renderData.wallBlockerOverlays) {
             target.draw(overlay);
+        }
+    }
+}
+
+void RenderingEngine::renderLightOverlays(sf::RenderTarget& target,
+    const sf::View& view,
+    const RenderData& renderData) {
+    if (!renderData.objects || !renderData.hexGrid) {
+        return;
+    }
+
+    // Warm light tint; the per-ring alpha (set below) carries the falloff.
+    const sf::Color lightTint(255, 224, 130);
+
+    for (const auto& object : *renderData.objects) {
+        if (!object->hasLight()) {
+            continue;
+        }
+        const auto mapObject = object->getMapObjectPtr(); // non-null: hasLight() already checked it
+
+        const int radius = std::min<int>(static_cast<int>(mapObject->light_radius), light::MAX_RADIUS);
+        const int intensity = std::min<int>(static_cast<int>(mapObject->light_intensity), light::FULL);
+        const int centerHex = mapObject->position;
+
+        // Group the illuminated hexes by ring so each ring can be tinted by its falloff value; a single
+        // renderHexOverlay call per ring keeps the draw count low (radius is at most 8).
+        std::vector<std::vector<int>> hexesByRing(static_cast<size_t>(radius) + 1);
+        for (const auto& hex : hexgrid::hexDiscByDistance(centerHex, radius)) {
+            hexesByRing[static_cast<size_t>(hex.distance)].push_back(hex.position);
+        }
+
+        for (int ring = 0; ring <= radius; ++ring) {
+            const auto& ringHexes = hexesByRing[static_cast<size_t>(ring)];
+            if (ringHexes.empty()) {
+                continue;
+            }
+            const int alpha = light::tintAlpha(light::depositedIntensity(intensity, radius, ring));
+            if (alpha <= 0) {
+                continue;
+            }
+            sf::Color color = lightTint;
+            color.a = static_cast<std::uint8_t>(alpha);
+            _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, ringHexes, color);
         }
     }
 }

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -124,7 +124,7 @@ void RenderingEngine::render(sf::RenderTarget& target,
     // Layer 1b: Light overlays. Drawn as a ground layer (over the floor, under objects) so each light
     // source's illuminated hexes read like light pooling on the ground with objects standing in it.
     if (visibility.showLightOverlays) {
-        renderLightOverlays(target, view, renderData);
+        renderLightOverlays(target, view, renderData, visibility);
     }
 
     // Layer 2: Hex grid overlay (if enabled)
@@ -362,7 +362,8 @@ void RenderingEngine::renderObjects(sf::RenderTarget& target,
 
 void RenderingEngine::renderLightOverlays(sf::RenderTarget& target,
     const sf::View& view,
-    const RenderData& renderData) {
+    const RenderData& renderData,
+    const VisibilitySettings& visibility) {
     if (!renderData.objects || !renderData.hexGrid) {
         return;
     }
@@ -375,9 +376,16 @@ void RenderingEngine::renderLightOverlays(sf::RenderTarget& target,
             continue;
         }
         const auto mapObject = object->getMapObjectPtr(); // non-null: hasLight() already checked it
+        // A light on a hidden layer (e.g. walls off) shows no overlay, matching the object itself —
+        // the same visibility rule renderObjects uses, so a hidden source never glows.
+        if (!isObjectVisible(*mapObject, visibility)) {
+            continue;
+        }
 
-        const int radius = std::min<int>(static_cast<int>(mapObject->light_radius), light::MAX_RADIUS);
-        const int intensity = std::min<int>(static_cast<int>(mapObject->light_intensity), light::FULL);
+        // light_radius / light_intensity are uint32_t; clamp in unsigned space so a corrupt
+        // out-of-range value can't become a negative int after the cast.
+        const int radius = static_cast<int>(std::min<std::uint32_t>(mapObject->light_radius, light::MAX_RADIUS));
+        const int intensity = static_cast<int>(std::min<std::uint32_t>(mapObject->light_intensity, light::FULL));
         const int centerHex = mapObject->position;
 
         // Group the illuminated hexes by ring so each ring can be tinted by its falloff value; a single

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -180,6 +180,16 @@ private:
         const VisibilitySettings& visibility);
 
     /**
+     * @brief Editor-only "Show light overlays" cue: tint every light-source object's illuminated hexes
+     * using Fallout 2 CE's per-ring linear falloff (fallout2-ce `_obj_adjust_light`) — brightest on the
+     * source hex, fading out to the light's radius. Illustrative only: no wall shadowing and no ambient
+     * darkness simulation, it just shows which hexes each light reaches and how strongly.
+     */
+    void renderLightOverlays(sf::RenderTarget& target,
+        const sf::View& view,
+        const RenderData& renderData);
+
+    /**
      * @brief Outline every selected object on top of the scene, grouped by category colour.
      *
      * Renders each colour group's selected sprites into an offscreen mask, then edge-detects the

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -180,14 +180,16 @@ private:
         const VisibilitySettings& visibility);
 
     /**
-     * @brief Editor-only "Show light overlays" cue: tint every light-source object's illuminated hexes
-     * using Fallout 2 CE's per-ring linear falloff (fallout2-ce `_obj_adjust_light`) — brightest on the
-     * source hex, fading out to the light's radius. Illustrative only: no wall shadowing and no ambient
-     * darkness simulation, it just shows which hexes each light reaches and how strongly.
+     * @brief Editor-only "Show light overlays" cue: tint every visible light-source object's illuminated
+     * hexes using Fallout 2 CE's per-ring linear falloff (fallout2-ce `_obj_adjust_light`) — brightest on
+     * the source hex, fading out to the light's radius. Honours the same per-layer visibility rule as
+     * renderObjects, so a light on a hidden layer shows no overlay. Illustrative only: no wall shadowing
+     * and no ambient darkness simulation, it just shows which hexes each light reaches and how strongly.
      */
     void renderLightOverlays(sf::RenderTarget& target,
         const sf::View& view,
-        const RenderData& renderData);
+        const RenderData& renderData,
+        const VisibilitySettings& visibility);
 
     /**
      * @brief Outline every selected object on top of the scene, grouped by category colour.

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -2697,19 +2697,9 @@ void EditorWidget::setSelectionColors(const RenderingEngine::SelectionPalette& c
 }
 
 void EditorWidget::setShowLightOverlays(bool show) {
+    // RenderingEngine::renderLightOverlays reads this flag and computes the illuminated hexes from each
+    // light source's MapObject every frame, so there is no per-object overlay state to update here.
     _session.visibility().showLightOverlays = show;
-
-    int lightObjectCount = 0;
-    std::ranges::for_each(_session.objects(), [&lightObjectCount, show](auto& object) {
-        if (object->hasLight()) {
-            lightObjectCount++;
-            spdlog::debug("EditorWidget: Found light source object with light_radius={}, light_intensity={}",
-                object->getMapObject().light_radius, object->getMapObject().light_intensity);
-        }
-        object->setShowLightOverlay(show);
-    });
-
-    spdlog::debug("Light overlay display set to: {} (found {} light objects)", show, lightObjectCount);
 }
 
 void EditorWidget::clearDragSelectionPreview() {

--- a/tests/general/test_hex_geometry.cpp
+++ b/tests/general/test_hex_geometry.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdlib>
 #include <unordered_set>
@@ -154,4 +155,34 @@ TEST_CASE("hexesWithinRadius clips at the grid edge and stays in bounds", "[hex_
 
 TEST_CASE("hexesWithinRadius is empty for a negative radius", "[hex_geometry]") {
     CHECK(hexesWithinRadius(100 * WIDTH + 100, -1).empty());
+}
+
+TEST_CASE("hexDiscByDistance covers the same disc and tags each hex's hex-step distance", "[hex_geometry]") {
+    const int center = 100 * WIDTH + 100; // interior so the disc isn't clipped
+    for (int radius = 0; radius <= 8; ++radius) { // 8 == the engine's max light radius
+        INFO("radius " << radius);
+        const auto disc = hexDiscByDistance(center, radius);
+        const auto plain = hexesWithinRadius(center, radius);
+
+        // Same set of hexes as hexesWithinRadius (order aside).
+        REQUIRE(disc.size() == plain.size());
+        std::unordered_set<int> discPositions;
+        int maxDistance = -1;
+        for (const auto& hex : disc) {
+            discPositions.insert(hex.position);
+            // The tagged distance is exactly the engine's tileDistanceBetween.
+            CHECK(hex.distance == cubeDistance(center, hex.position));
+            maxDistance = std::max(maxDistance, hex.distance);
+        }
+        const std::unordered_set<int> plainPositions(plain.begin(), plain.end());
+        CHECK(discPositions == plainPositions);
+
+        // The centre is present at distance 0, and nothing reaches past the radius.
+        CHECK(discPositions.contains(center));
+        CHECK(maxDistance == radius);
+    }
+}
+
+TEST_CASE("hexDiscByDistance is empty for a negative radius", "[hex_geometry]") {
+    CHECK(hexDiscByDistance(100 * WIDTH + 100, -1).empty());
 }


### PR DESCRIPTION
## What

Replaces the light-source overlay (toggled by **View → Show Light Overlays**) with a hex-accurate one that shows *which hexes each light actually reaches and how strongly*, instead of a rough illustrative circle.

**Before:** each light-source object drew a single semi-transparent pixel-space hexagon (`sf::CircleShape`, radius ≈ `light_radius × 16px`), centred on the sprite — not snapped to the hex grid, no falloff.

**After:** the overlay tints the real hexes a light illuminates, using Fallout 2 CE's per-ring light model — full intensity on the source hex, then a linear decrement out to the light's radius (mirroring the engine's `_obj_adjust_light`). Closer/brighter hexes read stronger; dim or distant ones fade out. It's drawn as a ground layer (over the floor, under objects) so the light reads as pooling on the ground.

## How

- **`RenderingEngine::renderLightOverlays`** (new render *Layer 1b*): for each light source, groups its illuminated hexes by ring and tints each ring by its deposited intensity. Reuses `HexRenderer::renderHexOverlay` (the same primitive as the spatial-script radius disc) — one draw call per ring, radius capped at 8.
- File-local `light::depositedIntensity()` / `light::tintAlpha()` encode the engine falloff (`step = (intensity − 655) / (radius + 1)`) and map it to a warm tint's alpha.
- **`hexgrid::hexDiscByDistance()`** (new, in `HexGeometry.h`): the hex disc plus each hex's hex-step distance from the centre. Covered by new tests in `test_hex_geometry.cpp`.
- Removes the now-unused `sf::CircleShape` light-overlay state from `Object` (`setShowLightOverlay`/`updateLightOverlay`/`getLightOverlay`/`initializeLightOverlay`); `EditorWidget::setShowLightOverlays` now just sets the visibility flag (the renderer recomputes from the `MapObject` fields each frame).

## Scope

Visualization only — deliberately **no wall shadowing** and **no ambient-darkness simulation** (a full illumination/darkness preview would need a per-hex light buffer, per-tile/object colour modulation, and a user-chosen ambient level, since the `.map` doesn't encode one — the engine gets it from map scripts). Those remain possible follow-ups.

## Testing

- Builds clean (gecko + gecko-cli); full suite green — 398 general test cases / 170k assertions + 85 qt cases. Added 2 `hexDiscByDistance` cases.
- Verified headless by rendering shipped cavern/interior maps (`klatoxcv`, `modinn`, `cave1`) with the overlay on: lit-hex pools appear exactly at light sources with the expected centre-bright / edge-fade gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)