### PR TITLE
Highlight unreachable map areas (editor overlay + headless render)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -532,8 +532,9 @@ The direction instead:
 
 # Map semantics & intelligence (analysis MCP roadmap)
 
-> Status: Remaining: the Phase-3 semantic render overlay (capability 5). The goal is to let an agent reason about a map's **purpose**, its
-> **critters' AI**, and its **scripts**.
+> Status: Phase 3 done — the semantic render overlay (capability 5) shipped as the editor's
+> **Highlight Unreachable Areas** overlay. The goal is to let an agent reason about a map's
+> **purpose**, its **critters' AI**, and its **scripts**.
 
 **Guiding principle.** Don't hardcode classification heuristics ("N critters ⇒ a fight"). Surface
 the engine's own semantic sources faithfully and **cross-referenced**, and let the model infer
@@ -567,10 +568,23 @@ from. Keep all new readers Qt-free (vault/cli) so the server stays headless.
      case; with real `.ssl` we read the source directly. `int2ssl` decompilation stays out of scope.
    Plus a critter/object → `{programIndex, name}` bridge in `analyze`, so the agent reads the roster,
    spots a scripted NPC, and calls `describe_script` for the full who→does→says picture.
-5. **Semantic render overlay** (extends the schematic). **Still open:** *shading the
-   unreachable regions* `reachability`/`describe_map` identify, which needs a per-hex reachable mask
-   exposed from `MapReachability` and a hex→world tint in the renderer (the object-marker path here is
-   sprite-bounds-based and doesn't map arbitrary hexes). **Phase 3.**
+5. **Semantic render overlay** — **DONE (editor overlay).** *Shading the unreachable regions* that
+   `reachability`/`describe_map` identify shipped as **View › Highlight Unreachable Areas**: a
+   translucent red wash over the walkable hexes on the current elevation that are cut off from every
+   entry point (player start + exit grids). The flood-fill was extracted from `cli::MapReachability`
+   into a Qt-free **`geck::reachability`** core (`src/editor/Reachability.{h,cpp}`, gecko_core) so the
+   overlay and the `reachability` CLI/MCP tool compute from **one** implementation and can't drift;
+   the CLI serializer was rewritten on top of it. The renderer tints the hex set via the existing
+   `HexRenderer::renderHexOverlay` (which already maps arbitrary hexes and view-culls — the
+   "sprite-bounds-based" limitation the earlier note assumed was removed by the light-overlay work),
+   in `RenderingEngine::renderReachabilityOverlay`, gated by `VisibilitySettings::showUnreachable` +
+   the View-menu toggle. The editor caches the mask, recomputing only on a map/elevation/object-count
+   signature change (the flood-fill is too heavy per frame). Verified headlessly: the shaded set
+   equals the CLI's unreachable set (cave1 elev 1 → the whole outer solid-rock region, ~37k hexes;
+   the central cavern stays clear). The **same core is also exposed headlessly** for agents: `map
+   render --show-unreachable` (CLI) / `render_map` `showUnreachable:true` (MCP) bakes the shading into
+   the natural-render PNG, so an agent can *see* walled-off regions, not just read the counts from the
+   `reachability` tool.
 
 **Corpus angle (multiplier):** index `analyze` + these semantic facts across all shipped maps so
 the agent can query *examples* ("how do shipped towns place and wire shopkeepers?") — improving

--- a/resources/icons.qrc
+++ b/resources/icons.qrc
@@ -34,6 +34,7 @@
         <file alias="actions/view-light.svg">icons/tabler/actions/brightness.svg</file>
         <file alias="actions/view-exits.svg">icons/door-exit.svg</file>
         <file alias="actions/map-edges.svg">icons/tabler/actions/border-all.svg</file>
+        <file alias="actions/view-unreachable.svg">icons/tabler/actions/ban.svg</file>
         
         <!-- File Types -->
         <file alias="filetypes/map.svg">icons/tabler/filetypes/map-2.svg</file>

--- a/resources/icons/tabler/actions/ban.svg
+++ b/resources/icons/tabler/actions/ban.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-ban">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+  <path d="M5.7 5.7l12.6 12.6" />
+</svg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -523,6 +523,8 @@ add_library(gecko_core STATIC
     editor/HexagonGrid.h
     editor/HexagonGrid.cpp
     editor/HexGeometry.h
+    editor/Reachability.h
+    editor/Reachability.cpp
     editor/Hex.h
     editor/Hex.cpp
     editor/helper/ObjectQueries.h

--- a/src/cli/MapReachability.cpp
+++ b/src/cli/MapReachability.cpp
@@ -2,6 +2,7 @@
 
 #include "cli/MapLoad.h"
 #include "editor/HexGeometry.h"
+#include "editor/Reachability.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "format/msg/Msg.h"
@@ -12,10 +13,8 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
-#include <array>
 #include <cstdint>
 #include <ostream>
-#include <queue>
 #include <string>
 #include <vector>
 
@@ -47,111 +46,11 @@ namespace {
         return {};
     }
 
-    // A door blocks only until opened; for reachability the player can open it, so doors are passable.
-    bool isDoor(resource::GameResources& resources, const MapObject& object) {
-        try {
-            if (const Pro* pro = resources.loadPro(object.pro_pid); pro != nullptr) {
-                return pro->type() == Pro::OBJECT_TYPE::SCENERY
-                    && static_cast<Pro::SCENERY_TYPE>(pro->objectSubtypeId()) == Pro::SCENERY_TYPE::DOOR;
-            }
-        } catch (const std::exception&) {
-        }
-        return false;
-    }
-
     // Only critters and items are gameplay content worth flagging as "orphaned" if cut off.
     bool isGameplayObject(const MapObject& object) {
         const auto type = object.objectType();
         return type == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER)
             || type == static_cast<uint32_t>(Pro::OBJECT_TYPE::ITEM);
-    }
-
-    // Impassable-hex mask for one elevation, using the engine's instance-flag rule, then treating
-    // (openable) doors as passable. Multihex blockers also seal their neighbours.
-    std::vector<char> blockedMask(resource::GameResources& resources, const std::vector<std::shared_ptr<MapObject>>& objects) {
-        std::vector<char> blocked(kHexCount, 0);
-        for (const auto& object : objects) {
-            if (!object || object->position < 0 || object->position >= kHexCount) {
-                continue;
-            }
-            if (!blocksMovementByInstance(object->objectType(), object->flags) || isDoor(resources, *object)) {
-                continue;
-            }
-            blocked[object->position] = 1;
-            if (Pro::hasFlag(object->flags, Pro::ObjectFlags::OBJECT_MULTIHEX)) {
-                for (const int neighbour : hexNeighbors(object->position)) {
-                    blocked[neighbour] = 1;
-                }
-            }
-        }
-        return blocked;
-    }
-
-    // Where the player can enter this elevation: the player start (if they spawn here) plus every exit
-    // grid (you arrive at an exit's position when entering from the adjacent map).
-    std::vector<int> entryHexes(const Map::MapHeader& header, int elevation, const std::vector<std::shared_ptr<MapObject>>& objects) {
-        std::vector<int> seeds;
-        if (static_cast<int>(header.player_default_elevation) == elevation) {
-            seeds.push_back(static_cast<int>(header.player_default_position));
-        }
-        for (const auto& object : objects) {
-            if (object && object->isExitGridMarker() && object->position >= 0 && object->position < kHexCount) {
-                seeds.push_back(object->position);
-            }
-        }
-        return seeds;
-    }
-
-    // Which walkable components the given seeds land in (a seed on a blocked hex still enters via a
-    // walkable neighbour). seedFlags is indexed by component id.
-    std::vector<char> seedComponentFlags(const std::vector<int>& seeds, const std::vector<char>& blocked,
-        const std::vector<int>& component, std::size_t componentCount) {
-        std::vector<char> seedFlags(componentCount, 0);
-        for (const int seed : seeds) {
-            if (seed >= 0 && seed < kHexCount && !blocked[seed]) {
-                seedFlags[component[seed]] = 1;
-            } else {
-                for (const int neighbour : hexNeighbors(seed)) {
-                    if (!blocked[neighbour]) {
-                        seedFlags[component[neighbour]] = 1;
-                    }
-                }
-            }
-        }
-        return seedFlags;
-    }
-
-    // The walkable component a marker hex sits in (or, if on a blocked hex, its first walkable
-    // neighbour's). -1 if it touches no walkable hex.
-    int componentOf(int hex, const std::vector<char>& blocked, const std::vector<int>& component) {
-        if (hex < 0 || hex >= kHexCount) {
-            return -1;
-        }
-        if (!blocked[hex]) {
-            return component[hex];
-        }
-        for (const int neighbour : hexNeighbors(hex)) {
-            if (!blocked[neighbour]) {
-                return component[neighbour];
-            }
-        }
-        return -1;
-    }
-
-    // Whether a hex is in (or borders) a seed-reachable component.
-    bool reaches(int hex, const std::vector<char>& blocked, const std::vector<int>& component, const std::vector<char>& seedFlags) {
-        if (hex < 0 || hex >= kHexCount) {
-            return false;
-        }
-        if (!blocked[hex] && seedFlags[component[hex]]) {
-            return true;
-        }
-        for (const int neighbour : hexNeighbors(hex)) {
-            if (!blocked[neighbour] && seedFlags[component[neighbour]]) {
-                return true;
-            }
-        }
-        return false;
     }
 
     // Per exit grid, whether the player can walk to it *from the start specifically* (same component as
@@ -168,7 +67,7 @@ namespace {
             if (!playerHere) {
                 exit["reachableFromPlayerStart"] = nullptr;
             } else {
-                const int comp = componentOf(object->position, blocked, component);
+                const int comp = reachability::componentOf(object->position, blocked, component);
                 exit["reachableFromPlayerStart"] = comp >= 0 && playerStartFlags[comp] != 0;
             }
             array.push_back(exit);
@@ -185,7 +84,7 @@ namespace {
             if (!object || !isGameplayObject(*object) || object->position < 0 || object->position >= kHexCount) {
                 continue;
             }
-            if (reaches(object->position, blocked, component, entryFlags)) {
+            if (reachability::reaches(object->position, blocked, component, entryFlags)) {
                 continue;
             }
             ++total;
@@ -200,13 +99,12 @@ namespace {
 
     ordered_json elevationToJson(resource::GameResources& resources, const Map::MapHeader& header, int elevation,
         const std::vector<std::shared_ptr<MapObject>>& objects, const std::string& mapName) {
-        const std::vector<char> blocked = blockedMask(resources, objects);
-        std::vector<int> sizes;
-        std::vector<int> samples;
-        const std::vector<int> component = hexComponents(blocked, sizes, samples);
+        const reachability::ElevationResult r = reachability::analyzeElevation(resources,
+            static_cast<int>(header.player_default_elevation), static_cast<int>(header.player_default_position),
+            elevation, objects);
 
         int walkable = 0;
-        for (const int size : sizes) {
+        for (const int size : r.componentSizes) {
             walkable += size;
         }
 
@@ -215,12 +113,10 @@ namespace {
         entry["walkableHexes"] = walkable;
         entry["blockedHexes"] = kHexCount - walkable;
 
-        const bool playerHere = static_cast<int>(header.player_default_elevation) == elevation;
-        entry["playerStartHex"] = playerHere ? ordered_json(static_cast<int>(header.player_default_position)) : ordered_json(nullptr);
+        entry["playerStartHex"] = r.playerHere ? ordered_json(static_cast<int>(header.player_default_position)) : ordered_json(nullptr);
 
-        const std::vector<int> entrySeeds = entryHexes(header, elevation, objects);
-        entry["entryPointHexes"] = static_cast<int>(entrySeeds.size());
-        if (entrySeeds.empty()) {
+        entry["entryPointHexes"] = static_cast<int>(r.entrySeeds.size());
+        if (!r.hasEntryPoints()) {
             // No player start and no exit grid here — entered via stairs/elevators, which the hex flood
             // doesn't model, so reachability can't be determined.
             entry["reachableHexes"] = nullptr;
@@ -233,22 +129,18 @@ namespace {
 
         // Reachability/orphans use every entry point (the player can arrive at the start *or* at an
         // exit grid coming from the adjacent map); the per-exit flag below is start-only.
-        const std::vector<char> entryFlags = seedComponentFlags(entrySeeds, blocked, component, sizes.size());
         int reachable = 0;
-        for (std::size_t id = 0; id < sizes.size(); ++id) {
-            if (entryFlags[id]) {
-                reachable += sizes[id];
+        for (std::size_t id = 0; id < r.componentSizes.size(); ++id) {
+            if (r.entryReachable[id]) {
+                reachable += r.componentSizes[id];
             }
         }
         entry["reachableHexes"] = reachable;
 
-        const std::vector<char> playerStartFlags = playerHere
-            ? seedComponentFlags({ static_cast<int>(header.player_default_position) }, blocked, component, sizes.size())
-            : std::vector<char>{};
-        entry["exits"] = exitsJson(objects, blocked, component, playerStartFlags, playerHere);
+        entry["exits"] = exitsJson(objects, r.blocked, r.component, r.playerStartReachable, r.playerHere);
 
         std::size_t orphanTotal = 0;
-        entry["orphanedObjects"] = orphanedObjectsJson(resources, objects, blocked, component, entryFlags, orphanTotal);
+        entry["orphanedObjects"] = orphanedObjectsJson(resources, objects, r.blocked, r.component, r.entryReachable, orphanTotal);
         entry["orphanedObjectCount"] = static_cast<int>(orphanTotal);
         if (orphanTotal > kMaxReported) {
             spdlog::debug("reachability {} elev {}: reporting {} of {} orphaned objects", mapName, elevation, kMaxReported, orphanTotal);
@@ -256,66 +148,6 @@ namespace {
         return entry;
     }
 } // namespace
-
-bool blocksMovementByInstance(uint32_t objectType, uint32_t flags) {
-    const bool blockingType = objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::CRITTER)
-        || objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::SCENERY)
-        || objectType == static_cast<uint32_t>(Pro::OBJECT_TYPE::WALL);
-    if (!blockingType) {
-        return false;
-    }
-    return !Pro::hasFlag(flags, Pro::ObjectFlags::OBJECT_HIDDEN)
-        && !Pro::hasFlag(flags, Pro::ObjectFlags::OBJECT_NO_BLOCK);
-}
-
-std::vector<int> hexNeighbors(int hex) {
-    using namespace hexgrid;
-    static constexpr std::array<Cube, 6> kDirs = {
-        { { 1, -1, 0 }, { 1, 0, -1 }, { 0, 1, -1 }, { -1, 1, 0 }, { -1, 0, 1 }, { 0, -1, 1 } }
-    };
-    std::vector<int> result;
-    if (hex < 0 || hex >= kHexCount) {
-        return result;
-    }
-    const Cube c = cubeOfPosition(hex);
-    for (const Cube& d : kDirs) {
-        const ColRow cr = cubeToOffset(c + d);
-        if (cr.col >= 0 && cr.col < WIDTH && cr.row >= 0 && cr.row < HEIGHT) {
-            result.push_back(cr.row * WIDTH + cr.col);
-        }
-    }
-    return result;
-}
-
-std::vector<int> hexComponents(const std::vector<char>& blocked, std::vector<int>& sizes, std::vector<int>& samples) {
-    std::vector<int> component(blocked.size(), -1);
-    sizes.clear();
-    samples.clear();
-    for (int start = 0; start < static_cast<int>(blocked.size()); ++start) {
-        if (blocked[start] || component[start] != -1) {
-            continue;
-        }
-        const int id = static_cast<int>(sizes.size());
-        int size = 0;
-        std::queue<int> frontier;
-        frontier.push(start);
-        component[start] = id;
-        while (!frontier.empty()) {
-            const int hex = frontier.front();
-            frontier.pop();
-            ++size;
-            for (const int neighbour : hexNeighbors(hex)) {
-                if (!blocked[neighbour] && component[neighbour] == -1) {
-                    component[neighbour] = id;
-                    frontier.push(neighbour);
-                }
-            }
-        }
-        sizes.push_back(size);
-        samples.push_back(start);
-    }
-    return component;
-}
 
 int analyzeReachability(resource::GameResources& resources, const ReachabilityOptions& options, std::ostream& out) {
     const std::unique_ptr<Map> map = loadMap(resources, options.mapPath);

--- a/src/cli/MapReachability.h
+++ b/src/cli/MapReachability.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <cstdint>
 #include <iosfwd>
 #include <string>
-#include <vector>
 
 namespace geck {
 namespace resource {
@@ -32,23 +30,11 @@ namespace cli {
     ///
     /// Emits a JSON object to `out`; returns 0 on success, nonzero with a message on a hard error
     /// (map fails to load).
+    ///
+    /// The flood-fill itself lives in `geck::reachability` (gecko_core) so this serializer and the
+    /// editor's "unreachable areas" overlay share one implementation; this function only shapes that
+    /// result into JSON.
     int analyzeReachability(resource::GameResources& resources, const ReachabilityOptions& options, std::ostream& out);
-
-    // --- Pure helpers, exposed for testing (no game data needed) ---
-
-    /// The engine's instance-flag movement-blocking rule (fallout2-ce `_obj_blocking_at`): a
-    /// CRITTER/SCENERY/WALL object that is neither `OBJECT_HIDDEN` nor `OBJECT_NO_BLOCK` in its
-    /// per-instance `flags`. Items, misc and tiles never block. (Doors, though scenery, are handled
-    /// separately as passable.)
-    bool blocksMovementByInstance(uint32_t objectType, uint32_t flags);
-
-    /// The up-to-6 parity-correct neighbour positions of a hex (empty if `hex` is off-grid).
-    std::vector<int> hexNeighbors(int hex);
-
-    /// Connected components of the WIDTH*HEIGHT hex grid given a `blocked` mask (1 = impassable).
-    /// Returns a component id per hex (-1 for blocked hexes); `sizes[id]` is each component's hex
-    /// count and `samples[id]` is one representative hex in it.
-    std::vector<int> hexComponents(const std::vector<char>& blocked, std::vector<int>& sizes, std::vector<int>& samples);
 
 } // namespace cli
 } // namespace geck

--- a/src/cli/MapRender.cpp
+++ b/src/cli/MapRender.cpp
@@ -48,6 +48,7 @@ int renderMap(resource::GameResources& resources, const RenderOptions& options, 
     renderOptions.showBlockers = options.showBlockers;
     renderOptions.fullExtent = options.fullExtent;
     renderOptions.exitDots = options.exitDots;
+    renderOptions.showUnreachable = options.showUnreachable;
     renderOptions.style = options.semantic ? MapRenderer::Style::Semantic
         : options.objects                  ? MapRenderer::Style::Objects
         : options.schematic                ? MapRenderer::Style::Schematic

--- a/src/cli/MapRender.h
+++ b/src/cli/MapRender.h
@@ -34,6 +34,9 @@ namespace cli {
         bool fullExtent = false;
         /// Natural style only: overlay a dot on each exit-grid marker's trigger hex (verification aid).
         bool exitDots = false;
+        /// Natural style only: shade the walkable hexes cut off from every entry point (unreachable
+        /// areas) — the visual form of the `reachability` tool, for spotting walled-off regions.
+        bool showUnreachable = false;
     };
 
     /// Render a map to an image file (format inferred from the extension, e.g. .png). Returns 0 on

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -71,7 +71,7 @@ void printUsage(const char* program) {
               << "      pattern stamp the script places with api:placeStamp(name, anchorHex, variant).\n"
               << "  " << program << " map render --map <file.map> --out <file.png>\n"
               << "      [--elevation 0|1|2] [--max-dim N] [--roof] [--schematic|--objects|--semantic]\n"
-              << "      [--show-blockers] [--full] --data <dir-or-.dat> [...]\n"
+              << "      [--show-blockers] [--show-unreachable] [--full] --data <dir-or-.dat> [...]\n"
               << "      Renders a map to a PNG (needs an off-screen GL context). --max-dim caps the\n"
               << "      longest side (default 1600); --roof draws the roof layer over the floor; --full\n"
               << "      frames the whole iso grid (the full playable area) instead of cropping to content.\n"
@@ -79,6 +79,8 @@ void printUsage(const char* program) {
               << "      colour legend); --objects mutes the floor to grey so the object markers pop\n"
               << "      (for checking scatter); --semantic greys the floor and colours markers by role\n"
               << "      (exit grids, critters by team, scripted ringed); --show-blockers also marks FLAT.\n"
+              << "      --show-unreachable (natural style) shades hexes cut off from the player start and\n"
+              << "      every exit grid, the visual form of `map reachability`.\n"
               << "  " << program << " map extract-pattern --map <file.map> --out <file.json> --name <name>\n"
               << "      [--pids id,id,...] [--anchor <hex>] [--radius N] [--elevation 0|1|2]\n"
               << "      [--include-floor] [--include-roof] --data <dir-or-.dat> [--data <...>]\n"
@@ -358,6 +360,10 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
     }
     if (out.render && arg == "--exit-dots") {
         out.ren.exitDots = true;
+        return 1;
+    }
+    if (out.render && arg == "--show-unreachable") {
+        out.ren.showUnreachable = true;
         return 1;
     }
     if (out.render) {

--- a/src/editor/Reachability.cpp
+++ b/src/editor/Reachability.cpp
@@ -1,0 +1,198 @@
+#include "editor/Reachability.h"
+
+#include "editor/HexGeometry.h"
+#include "format/map/MapObject.h"
+#include "format/pro/Pro.h"
+#include "resource/GameResources.h"
+
+#include <array>
+#include <exception>
+#include <queue>
+
+namespace geck::reachability {
+
+namespace {
+    constexpr int kHexCount = hexgrid::WIDTH * hexgrid::HEIGHT;
+
+    // A door blocks only until opened; for reachability the player can open it, so doors are passable.
+    bool isDoor(resource::GameResources& resources, const MapObject& object) {
+        try {
+            if (const Pro* pro = resources.loadPro(object.pro_pid); pro != nullptr) {
+                return pro->type() == Pro::OBJECT_TYPE::SCENERY
+                    && static_cast<Pro::SCENERY_TYPE>(pro->objectSubtypeId()) == Pro::SCENERY_TYPE::DOOR;
+            }
+        } catch (const std::exception&) { // a missing/odd proto just isn't treated as a door
+        }
+        return false;
+    }
+} // namespace
+
+bool blocksMovementByInstance(std::uint32_t objectType, std::uint32_t flags) {
+    const bool blockingType = objectType == static_cast<std::uint32_t>(Pro::OBJECT_TYPE::CRITTER)
+        || objectType == static_cast<std::uint32_t>(Pro::OBJECT_TYPE::SCENERY)
+        || objectType == static_cast<std::uint32_t>(Pro::OBJECT_TYPE::WALL);
+    if (!blockingType) {
+        return false;
+    }
+    return !Pro::hasFlag(flags, Pro::ObjectFlags::OBJECT_HIDDEN)
+        && !Pro::hasFlag(flags, Pro::ObjectFlags::OBJECT_NO_BLOCK);
+}
+
+std::vector<int> hexNeighbors(int hex) {
+    using namespace hexgrid;
+    static constexpr std::array<Cube, 6> kDirs = {
+        { { 1, -1, 0 }, { 1, 0, -1 }, { 0, 1, -1 }, { -1, 1, 0 }, { -1, 0, 1 }, { 0, -1, 1 } }
+    };
+    std::vector<int> result;
+    if (hex < 0 || hex >= kHexCount) {
+        return result;
+    }
+    const Cube c = cubeOfPosition(hex);
+    for (const Cube& d : kDirs) {
+        const ColRow cr = cubeToOffset(c + d);
+        if (cr.col >= 0 && cr.col < WIDTH && cr.row >= 0 && cr.row < HEIGHT) {
+            result.push_back(cr.row * WIDTH + cr.col);
+        }
+    }
+    return result;
+}
+
+std::vector<int> hexComponents(const std::vector<char>& blocked, std::vector<int>& sizes, std::vector<int>& samples) {
+    std::vector<int> component(blocked.size(), -1);
+    sizes.clear();
+    samples.clear();
+    for (int start = 0; start < static_cast<int>(blocked.size()); ++start) {
+        if (blocked[start] || component[start] != -1) {
+            continue;
+        }
+        const int id = static_cast<int>(sizes.size());
+        int size = 0;
+        std::queue<int> frontier;
+        frontier.push(start);
+        component[start] = id;
+        while (!frontier.empty()) {
+            const int hex = frontier.front();
+            frontier.pop();
+            ++size;
+            for (const int neighbour : hexNeighbors(hex)) {
+                if (!blocked[neighbour] && component[neighbour] == -1) {
+                    component[neighbour] = id;
+                    frontier.push(neighbour);
+                }
+            }
+        }
+        sizes.push_back(size);
+        samples.push_back(start);
+    }
+    return component;
+}
+
+std::vector<char> blockedMask(resource::GameResources& resources, const std::vector<std::shared_ptr<MapObject>>& objects) {
+    std::vector<char> blocked(kHexCount, 0);
+    for (const auto& object : objects) {
+        if (!object || object->position < 0 || object->position >= kHexCount) {
+            continue;
+        }
+        if (!blocksMovementByInstance(object->objectType(), object->flags) || isDoor(resources, *object)) {
+            continue;
+        }
+        blocked[object->position] = 1;
+        if (Pro::hasFlag(object->flags, Pro::ObjectFlags::OBJECT_MULTIHEX)) {
+            for (const int neighbour : hexNeighbors(object->position)) {
+                blocked[neighbour] = 1;
+            }
+        }
+    }
+    return blocked;
+}
+
+std::vector<int> entryHexes(int playerDefaultElevation, int playerDefaultPosition, int elevation,
+    const std::vector<std::shared_ptr<MapObject>>& objects) {
+    std::vector<int> seeds;
+    if (playerDefaultElevation == elevation) {
+        seeds.push_back(playerDefaultPosition);
+    }
+    for (const auto& object : objects) {
+        if (object && object->isExitGridMarker() && object->position >= 0 && object->position < kHexCount) {
+            seeds.push_back(object->position);
+        }
+    }
+    return seeds;
+}
+
+std::vector<char> seedComponentFlags(const std::vector<int>& seeds, const std::vector<char>& blocked,
+    const std::vector<int>& component, std::size_t componentCount) {
+    std::vector<char> seedFlags(componentCount, 0);
+    for (const int seed : seeds) {
+        if (seed >= 0 && seed < kHexCount && !blocked[seed]) {
+            seedFlags[component[seed]] = 1;
+        } else {
+            for (const int neighbour : hexNeighbors(seed)) {
+                if (!blocked[neighbour]) {
+                    seedFlags[component[neighbour]] = 1;
+                }
+            }
+        }
+    }
+    return seedFlags;
+}
+
+int componentOf(int hex, const std::vector<char>& blocked, const std::vector<int>& component) {
+    if (hex < 0 || hex >= kHexCount) {
+        return -1;
+    }
+    if (!blocked[hex]) {
+        return component[hex];
+    }
+    for (const int neighbour : hexNeighbors(hex)) {
+        if (!blocked[neighbour]) {
+            return component[neighbour];
+        }
+    }
+    return -1;
+}
+
+bool reaches(int hex, const std::vector<char>& blocked, const std::vector<int>& component, const std::vector<char>& seedFlags) {
+    if (hex < 0 || hex >= kHexCount) {
+        return false;
+    }
+    if (!blocked[hex] && seedFlags[component[hex]]) {
+        return true;
+    }
+    for (const int neighbour : hexNeighbors(hex)) {
+        if (!blocked[neighbour] && seedFlags[component[neighbour]]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ElevationResult analyzeElevation(resource::GameResources& resources, int playerDefaultElevation,
+    int playerDefaultPosition, int elevation, const std::vector<std::shared_ptr<MapObject>>& objects) {
+    ElevationResult result;
+    result.blocked = blockedMask(resources, objects);
+    std::vector<int> samples;
+    result.component = hexComponents(result.blocked, result.componentSizes, samples);
+    result.entrySeeds = entryHexes(playerDefaultElevation, playerDefaultPosition, elevation, objects);
+    result.entryReachable = seedComponentFlags(result.entrySeeds, result.blocked, result.component, result.componentSizes.size());
+    result.playerHere = playerDefaultElevation == elevation;
+    if (result.playerHere) {
+        result.playerStartReachable = seedComponentFlags({ playerDefaultPosition }, result.blocked, result.component, result.componentSizes.size());
+    }
+    return result;
+}
+
+std::vector<int> unreachableWalkableHexes(const ElevationResult& result) {
+    std::vector<int> hexes;
+    if (!result.hasEntryPoints()) {
+        return hexes; // undetermined -> shade nothing rather than everything
+    }
+    for (int hex = 0; hex < kHexCount; ++hex) {
+        if (!result.blocked[hex] && !result.entryReachable[result.component[hex]]) {
+            hexes.push_back(hex);
+        }
+    }
+    return hexes;
+}
+
+} // namespace geck::reachability

--- a/src/editor/Reachability.h
+++ b/src/editor/Reachability.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace geck {
+
+namespace resource {
+    class GameResources;
+}
+struct MapObject;
+
+/**
+ * Optimistic movement reachability over the 200x200 hex grid, shared by the headless
+ * `reachability` analysis (gecko-cli / MCP) and the editor's "unreachable areas" overlay so the
+ * two can never disagree.
+ *
+ * A hex is blocked per the engine's per-instance flag rule (`blocksMovementByInstance`, mirroring
+ * fallout2-ce `_obj_blocking_at`); openable doors are treated as passable, so the result
+ * over-estimates reachability rather than crying wolf. Entry points are the player start (when they
+ * spawn on this elevation) plus every exit grid — you arrive at an exit's position when entering
+ * from the adjacent map.
+ */
+namespace reachability {
+
+    /// The engine's instance-flag movement-blocking rule: a CRITTER/SCENERY/WALL that is neither
+    /// `OBJECT_HIDDEN` nor `OBJECT_NO_BLOCK`. Items, misc and tiles never block. (Doors are scenery
+    /// but `blockedMask` treats them as passable.)
+    bool blocksMovementByInstance(std::uint32_t objectType, std::uint32_t flags);
+
+    /// The up-to-6 parity-correct neighbour positions of a hex (empty if `hex` is off-grid).
+    std::vector<int> hexNeighbors(int hex);
+
+    /// Connected components of the WIDTH*HEIGHT hex grid given a `blocked` mask (1 = impassable).
+    /// Returns a component id per hex (-1 for blocked hexes); `sizes[id]` is each component's hex
+    /// count and `samples[id]` one representative hex in it.
+    std::vector<int> hexComponents(const std::vector<char>& blocked, std::vector<int>& sizes, std::vector<int>& samples);
+
+    /// Impassable-hex mask for one elevation's objects, using the instance-flag rule, then treating
+    /// (openable) doors as passable. Multihex blockers also seal their neighbours.
+    std::vector<char> blockedMask(resource::GameResources& resources,
+        const std::vector<std::shared_ptr<MapObject>>& objects);
+
+    /// Entry hexes for one elevation: the player start (when `playerDefaultElevation == elevation`)
+    /// plus every exit-grid marker's position.
+    std::vector<int> entryHexes(int playerDefaultElevation, int playerDefaultPosition, int elevation,
+        const std::vector<std::shared_ptr<MapObject>>& objects);
+
+    /// Which walkable components the given seeds land in (a seed on a blocked hex still enters via a
+    /// walkable neighbour). Indexed by component id.
+    std::vector<char> seedComponentFlags(const std::vector<int>& seeds, const std::vector<char>& blocked,
+        const std::vector<int>& component, std::size_t componentCount);
+
+    /// The walkable component a marker hex sits in (or, if on a blocked hex, its first walkable
+    /// neighbour's). -1 if it touches no walkable hex.
+    int componentOf(int hex, const std::vector<char>& blocked, const std::vector<int>& component);
+
+    /// Whether a hex is in (or borders) a seed-reachable component.
+    bool reaches(int hex, const std::vector<char>& blocked, const std::vector<int>& component,
+        const std::vector<char>& seedFlags);
+
+    /// Everything a consumer needs for one elevation, computed once so the CLI serializer and the
+    /// editor overlay share a single flood-fill.
+    struct ElevationResult {
+        std::vector<char> blocked;              ///< per hex, 1 = impassable
+        std::vector<int> component;             ///< per hex, component id (-1 if blocked)
+        std::vector<int> componentSizes;        ///< hex count per component id
+        std::vector<int> entrySeeds;            ///< player start (when here) + exit-grid hexes
+        std::vector<char> entryReachable;       ///< by component id: reachable from ANY entry point
+        bool playerHere = false;                ///< does the player spawn on this elevation?
+        std::vector<char> playerStartReachable; ///< by component id: reachable from the player start
+                                                ///< only (empty when !playerHere)
+
+        /// No player start and no exit grid here (reached via stairs/elevators) — reachability can't
+        /// be determined, so consumers should shade/report nothing rather than everything.
+        bool hasEntryPoints() const { return !entrySeeds.empty(); }
+    };
+
+    /// Compute reachability for one elevation from its objects and the map's player-start header.
+    ElevationResult analyzeElevation(resource::GameResources& resources, int playerDefaultElevation,
+        int playerDefaultPosition, int elevation, const std::vector<std::shared_ptr<MapObject>>& objects);
+
+    /// Walkable hexes not connected to any entry point — what the editor overlay shades. Empty when
+    /// there are no entry points (reachability undetermined on this elevation).
+    std::vector<int> unreachableWalkableHexes(const ElevationResult& result);
+
+} // namespace reachability
+} // namespace geck

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -389,6 +389,7 @@ namespace {
         opts.objects = optBool(args, "objects", opts.objects);
         opts.semantic = optBool(args, "semantic", opts.semantic);
         opts.showBlockers = optBool(args, "showBlockers", opts.showBlockers);
+        opts.showUnreachable = optBool(args, "showUnreachable", opts.showUnreachable);
         opts.fullExtent = optBool(args, "full", opts.fullExtent);
         std::ostringstream oss;
         const int rc = cli::renderMap(resources, opts, oss);
@@ -745,12 +746,15 @@ namespace {
             "(for checking scatter). semantic=true also greys the floor but colours markers by role — "
             "exit grids highlighted, critters by team, scripted objects ringed (legend keyed by role) — "
             "the purpose layer that pairs with describe_map. FLAT objects (invisible engine blockers) "
-            "are hidden unless showBlockers. full=true frames the whole iso playable grid instead of "
+            "are hidden unless showBlockers. showUnreachable=true (natural render) shades the walkable "
+            "hexes cut off from the player start and every exit grid with a translucent red wash — the "
+            "visual form of the reachability tool, for seeing walled-off regions on the map. full=true "
+            "frames the whole iso playable grid instead of "
             "cropping to drawn content, so a sparse/empty map still shows the entire map extent. "
             "map/out are filesystem paths — out is written there, and "
             "map may be a VFS path or any file on disk (e.g. one generate just wrote). Needs an "
             "off-screen GL context.",
-            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } }, { "full", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } }, { "showUnreachable", { { "type", "boolean" } } }, { "full", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
             [](resource::GameResources& r, const json& a) { return toolRender(r, a); } });
         t.push_back({ "render_frm",
             "Render an FRM sprite to a PNG so the art can be SEEN, not inferred from PID arithmetic. "

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -2,6 +2,7 @@
 
 #include "editor/HexagonGrid.h"
 #include "editor/Object.h"
+#include "editor/Reachability.h"
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "format/map/Tile.h"
@@ -492,6 +493,22 @@ sf::Image MapRenderer::renderNatural(Map& map, const Options& options) {
     visibility.showHexGrid = false;
     visibility.showLightOverlays = false;
     visibility.showExitGrids = false;
+
+    // Unreachable-areas shading (opt-in): the same geck::reachability flood-fill the editor overlay
+    // and the `reachability` tool use, tinted onto the render so walled-off regions are visible.
+    std::vector<int> unreachableHexes;
+    if (options.showUnreachable) {
+        const auto& mf = map.getMapFile();
+        static const std::vector<std::shared_ptr<MapObject>> kNoObjects;
+        const auto it = mf.map_objects.find(options.elevation);
+        const auto& objs = it != mf.map_objects.end() ? it->second : kNoObjects;
+        const auto result = reachability::analyzeElevation(_resources,
+            static_cast<int>(mf.header.player_default_elevation),
+            static_cast<int>(mf.header.player_default_position), options.elevation, objs);
+        unreachableHexes = reachability::unreachableWalkableHexes(result);
+        data.unreachableHexes = &unreachableHexes;
+        visibility.showUnreachable = true;
+    }
 
     engine.render(*target, target->getView(), data, visibility);
     if (options.exitDots) {

--- a/src/rendering/MapRenderer.h
+++ b/src/rendering/MapRenderer.h
@@ -60,6 +60,10 @@ public:
         /// saved hex position, not the slid bar). A verification aid for the diagonal-band widening —
         /// it shows the hex sits on the band's outer edge. Off by default (the clean artwork view).
         bool exitDots = false;
+        /// Natural style only: shade the walkable hexes cut off from every entry point (player start +
+        /// exit grids) with a translucent red wash — the same "unreachable areas" the editor overlay
+        /// and the `reachability` tool report, so a rendered map shows walled-off regions at a glance.
+        bool showUnreachable = false;
         sf::Color background{ 0, 0, 0, 255 };
     };
 

--- a/src/rendering/RenderingEngine.cpp
+++ b/src/rendering/RenderingEngine.cpp
@@ -127,6 +127,12 @@ void RenderingEngine::render(sf::RenderTarget& target,
         renderLightOverlays(target, view, renderData, visibility);
     }
 
+    // Layer 1c: Unreachable-area shading. A ground wash (over floor, under objects, like the light
+    // pass) over walkable hexes stranded from every entry point — a diagnostic, off by default.
+    if (visibility.showUnreachable && renderData.unreachableHexes) {
+        renderReachabilityOverlay(target, view, renderData);
+    }
+
     // Layer 2: Hex grid overlay (if enabled)
     if (visibility.showHexGrid) {
         renderHexGrid(target, view, renderData);
@@ -409,6 +415,18 @@ void RenderingEngine::renderLightOverlays(sf::RenderTarget& target,
             _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, ringHexes, color);
         }
     }
+}
+
+void RenderingEngine::renderReachabilityOverlay(sf::RenderTarget& target,
+    const sf::View& view,
+    const RenderData& renderData) {
+    if (!renderData.unreachableHexes || !renderData.hexGrid) {
+        return;
+    }
+    // Translucent warning-red wash; renderHexOverlay culls to the view, so passing the whole
+    // (possibly large) unreachable set is fine — only on-screen hexes are drawn.
+    const sf::Color unreachableTint(200, 40, 40, 90);
+    _hexRenderer.renderHexOverlay(target, view, *renderData.hexGrid, *renderData.unreachableHexes, unreachableTint);
 }
 
 void RenderingEngine::renderRoofTiles(sf::RenderTarget& target,

--- a/src/rendering/RenderingEngine.h
+++ b/src/rendering/RenderingEngine.h
@@ -43,6 +43,7 @@ public:
         bool showExitGrids = false;
         bool showSpatialScripts = false;
         bool showMapEdges = false;
+        bool showUnreachable = false;
         // Merge touching selected objects of the same category into one union outline (true), or
         // outline every selected object individually so shared edges show too (false).
         bool mergeSelectionOutlines = true;
@@ -102,6 +103,12 @@ public:
         // Map data
         const Map* map = nullptr;
         int currentElevation = 0;
+
+        // Walkable hexes on the current elevation cut off from every entry point (player start + exit
+        // grids), shaded by the reachability overlay when showUnreachable is on. Computed and cached by
+        // the editor (geck::reachability, the same flood-fill the `reachability` CLI/MCP tool uses);
+        // null when the overlay is off.
+        const std::vector<int>* unreachableHexes = nullptr;
 
         // SID (MapScript::pid) of the spatial script to highlight as selected in the
         // spatial-script overlay, or MapScript::NONE for no selection.
@@ -190,6 +197,15 @@ private:
         const sf::View& view,
         const RenderData& renderData,
         const VisibilitySettings& visibility);
+
+    /**
+     * @brief Shade the walkable hexes cut off from every entry point (a translucent wash), so a
+     * designer sees at a glance which floor is stranded by walls/blockers. The hex set is precomputed
+     * by the editor (renderData.unreachableHexes); this only tints it. Drawn as a ground layer.
+     */
+    void renderReachabilityOverlay(sf::RenderTarget& target,
+        const sf::View& view,
+        const RenderData& renderData);
 
     /**
      * @brief Outline every selected object on top of the scene, grouped by category colour.

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -2726,8 +2726,9 @@ void EditorWidget::refreshUnreachableOverlay() {
     const std::size_t objectCount = objects.size();
 
     // Cheap signature: map identity + elevation + object count. It catches load/new, elevation switch,
-    // and object add/remove without hooking every mutation site; the one miss (toggling an existing
-    // object's blocking flag without changing the count) is refreshed by re-toggling the overlay.
+    // and object add/remove without hooking every mutation site. A count-neutral edit (moving a blocker,
+    // flipping a blocking flag) the signature can't see is picked up by toggling the overlay off and on
+    // — setShowUnreachableAreas invalidates the cache on enable, forcing a fresh flood-fill.
     if (_unreachableCacheValid && map == _unreachableCacheMap
         && elevation == _unreachableCacheElevation && objectCount == _unreachableCacheObjectCount) {
         return;

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -48,6 +48,7 @@
 #include "util/Coordinates.h"
 
 #include "editor/Object.h"
+#include "editor/Reachability.h"
 #include "pattern/PatternStamper.h"
 #include "pattern/PatternSprite.h"
 #include "editor/HexagonGrid.h"
@@ -1405,6 +1406,7 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     visibility.showExitGrids = _session.visibility().showExitGrids;
     visibility.showSpatialScripts = _session.visibility().showSpatialScripts;
     visibility.showMapEdges = _session.visibility().showMapEdges;
+    visibility.showUnreachable = _session.visibility().showUnreachable;
     visibility.mergeSelectionOutlines = _session.visibility().mergeSelectionOutlines;
 
     RenderingEngine::RenderData renderData;
@@ -1438,6 +1440,12 @@ void EditorWidget::render(sf::RenderTarget& target, [[maybe_unused]] const float
     renderData.playerPositionHex = _session.map() ? static_cast<int>(_session.map()->getMapFile().header.player_default_position) : -1;
     renderData.map = _session.map();
     renderData.currentElevation = _session.currentElevation();
+    // Unreachable-areas overlay: only compute (and only point RenderData at the cache) while the
+    // toggle is on, so a map with the overlay off pays nothing.
+    if (_session.visibility().showUnreachable) {
+        refreshUnreachableOverlay();
+        renderData.unreachableHexes = &_unreachableHexes;
+    }
     renderData.selectedSpatialScriptSid = _session.selectedSpatialScriptSid();
     renderData.selectedEdgeZone = _selectedEdgeZone;
     renderData.activeEdgeSide = _activeEdgeSide;
@@ -2700,6 +2708,41 @@ void EditorWidget::setShowLightOverlays(bool show) {
     // RenderingEngine::renderLightOverlays reads this flag and computes the illuminated hexes from each
     // light source's MapObject every frame, so there is no per-object overlay state to update here.
     _session.visibility().showLightOverlays = show;
+}
+
+void EditorWidget::refreshUnreachableOverlay() {
+    const Map* map = _session.map();
+    if (!map) {
+        _unreachableHexes.clear();
+        _unreachableCacheValid = false;
+        _unreachableCacheMap = nullptr;
+        return;
+    }
+    const int elevation = _session.currentElevation();
+    const auto& mapFile = map->getMapFile();
+    static const std::vector<std::shared_ptr<MapObject>> kNoObjects;
+    const auto objIt = mapFile.map_objects.find(elevation);
+    const auto& objects = objIt != mapFile.map_objects.end() ? objIt->second : kNoObjects;
+    const std::size_t objectCount = objects.size();
+
+    // Cheap signature: map identity + elevation + object count. It catches load/new, elevation switch,
+    // and object add/remove without hooking every mutation site; the one miss (toggling an existing
+    // object's blocking flag without changing the count) is refreshed by re-toggling the overlay.
+    if (_unreachableCacheValid && map == _unreachableCacheMap
+        && elevation == _unreachableCacheElevation && objectCount == _unreachableCacheObjectCount) {
+        return;
+    }
+
+    const auto& header = mapFile.header;
+    const reachability::ElevationResult result = reachability::analyzeElevation(_resources,
+        static_cast<int>(header.player_default_elevation), static_cast<int>(header.player_default_position),
+        elevation, objects);
+    _unreachableHexes = reachability::unreachableWalkableHexes(result);
+
+    _unreachableCacheMap = map;
+    _unreachableCacheElevation = elevation;
+    _unreachableCacheObjectCount = objectCount;
+    _unreachableCacheValid = true;
 }
 
 void EditorWidget::clearDragSelectionPreview() {

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -113,6 +113,9 @@ public:
             resetEdgeHoverCursor(); // a lingering resize cursor would suggest a still-grabbable side
         }
     }
+    // The unreachable-areas overlay recomputes lazily in render() from a cached signature, so the
+    // setter only flips the flag (like the light overlay).
+    void setShowUnreachableAreas(bool show) { _session.visibility().showUnreachable = show; }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
     // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that
@@ -582,6 +585,18 @@ private:
     // The side whose resize cursor is currently applied to the viewport (-1 = default cursor); see
     // updateEdgeHoverCursor.
     int _edgeHoverCursorSide = -1;
+
+    // Cached "unreachable areas" overlay: the walkable hexes on the current elevation stranded from
+    // every entry point (player start + exit grids). The flood-fill (geck::reachability) is too heavy
+    // to run per frame, so render() recomputes it only when the map pointer, elevation, or object
+    // count changes — a cheap signature that catches load/new, elevation switch, and object add/remove.
+    std::vector<int> _unreachableHexes;
+    const Map* _unreachableCacheMap = nullptr;
+    int _unreachableCacheElevation = -1;
+    std::size_t _unreachableCacheObjectCount = 0;
+    bool _unreachableCacheValid = false;
+    // Recompute _unreachableHexes if the signature changed; a no-op when the cache is still current.
+    void refreshUnreachableOverlay();
 
     // Base positions of the selected floor/roof sprites captured while a region is being dragged, so
     // the live preview can offset them and restore them when the drag ends.

--- a/src/ui/core/EditorWidget.h
+++ b/src/ui/core/EditorWidget.h
@@ -113,9 +113,16 @@ public:
             resetEdgeHoverCursor(); // a lingering resize cursor would suggest a still-grabbable side
         }
     }
-    // The unreachable-areas overlay recomputes lazily in render() from a cached signature, so the
-    // setter only flips the flag (like the light overlay).
-    void setShowUnreachableAreas(bool show) { _session.visibility().showUnreachable = show; }
+    // The unreachable-areas overlay recomputes lazily in render() from a cached signature. Enabling
+    // it invalidates the cache so it always recomputes from the current map — this is the manual
+    // "refresh" for the count-neutral edits the signature can't see (moving a blocker, flipping a
+    // blocking flag): toggle the overlay off and on to force a fresh flood-fill.
+    void setShowUnreachableAreas(bool show) {
+        _session.visibility().showUnreachable = show;
+        if (show) {
+            _unreachableCacheValid = false;
+        }
+    }
     void setMergeSelectionOutlines(bool merge) { _session.visibility().mergeSelectionOutlines = merge; }
 
     // Edge scrolling: when enabled, parking the cursor near a viewport edge auto-pans the view that

--- a/src/ui/core/MainWindow.cpp
+++ b/src/ui/core/MainWindow.cpp
@@ -530,7 +530,7 @@ void MainWindow::setupMenuBar() {
         QKeySequence shortcut;
     };
 
-    const std::array<ViewToggleSpec, 11> viewToggleSpecs = { {
+    const std::array<ViewToggleSpec, 12> viewToggleSpecs = { {
         { &_showObjectsAction, ":/icons/actions/view-objects.svg", "Show &Objects", UI::DEFAULT_SHOW_OBJECTS, &MainWindow::showObjectsToggled, {}, {} },
         { &_showCrittersAction, ":/icons/actions/view-critters.svg", "Show &Critters", UI::DEFAULT_SHOW_CRITTERS, &MainWindow::showCrittersToggled, {}, {} },
         { &_showWallsAction, ":/icons/actions/view-walls.svg", "Show &Walls", UI::DEFAULT_SHOW_WALLS, &MainWindow::showWallsToggled, {}, {} },
@@ -542,6 +542,7 @@ void MainWindow::setupMenuBar() {
         { &_showExitGridsAction, ":/icons/actions/view-exits.svg", "Show &Exit Grids", false, &MainWindow::showExitGridsToggled, "Show exit grid markers", QKeySequence("Ctrl+E") },
         { &_showSpatialScriptsAction, ":/icons/actions/target-arrow.svg", "Show Spatial &Scripts", false, &MainWindow::showSpatialScriptsToggled, "Show spatial-script trigger markers and their radius", {} },
         { &_showMapEdgesAction, ":/icons/actions/map-edges.svg", "Show Map &Edges", false, &MainWindow::showMapEdgesToggled, "Show the .edg scroll-boundary zones and clip rect", {} },
+        { &_showUnreachableAction, ":/icons/actions/view-unreachable.svg", "Highlight &Unreachable Areas", false, &MainWindow::showUnreachableToggled, "Shade walkable hexes cut off from the player start and every exit grid", {} },
     } };
 
     for (const ViewToggleSpec& spec : viewToggleSpecs) {
@@ -1127,6 +1128,10 @@ void MainWindow::setupDockWidgets() {
     connect(this, &MainWindow::showSpatialScriptsToggled, this, [this](bool enabled) {
         if (_currentEditorWidget)
             _currentEditorWidget->setShowSpatialScripts(enabled);
+    });
+    connect(this, &MainWindow::showUnreachableToggled, this, [this](bool enabled) {
+        if (_currentEditorWidget)
+            _currentEditorWidget->setShowUnreachableAreas(enabled);
     });
     connect(this, &MainWindow::showMapEdgesToggled, this, [this](bool enabled) {
         if (_currentEditorWidget) {
@@ -1992,6 +1997,7 @@ void MainWindow::syncMenuStateToEditorWidget() {
     _currentEditorWidget->setShowExitGrids(_showExitGridsAction->isChecked());
     _currentEditorWidget->setShowSpatialScripts(_showSpatialScriptsAction->isChecked());
     _currentEditorWidget->setShowMapEdges(_showMapEdgesAction->isChecked());
+    _currentEditorWidget->setShowUnreachableAreas(_showUnreachableAction->isChecked());
     _currentEditorWidget->setMergeSelectionOutlines(_mergeOutlinesAction->isChecked());
     _currentEditorWidget->setEdgeScrollEnabled(_edgeScrollAction->isChecked());
     updateUndoRedoActions();

--- a/src/ui/core/MainWindow.h
+++ b/src/ui/core/MainWindow.h
@@ -124,6 +124,7 @@ signals:
     void showExitGridsToggled(bool enabled);
     void showSpatialScriptsToggled(bool enabled);
     void showMapEdgesToggled(bool enabled);
+    void showUnreachableToggled(bool enabled);
     void elevationChanged(int elevation);
     void selectionModeRequested();
     void rotateObjectRequested();
@@ -347,6 +348,7 @@ private:
     QAction* _showExitGridsAction;
     QAction* _showSpatialScriptsAction;
     QAction* _showMapEdgesAction;
+    QAction* _showUnreachableAction;
     QAction* _mergeOutlinesAction;
     QAction* _edgeScrollAction;
 

--- a/src/ui/core/VisibilitySettings.h
+++ b/src/ui/core/VisibilitySettings.h
@@ -24,6 +24,7 @@ struct VisibilitySettings {
     bool showExitGrids = false;
     bool showSpatialScripts = false;
     bool showMapEdges = false;
+    bool showUnreachable = false;
     // Merge touching same-category selected objects into one union outline (vs. one per object).
     bool mergeSelectionOutlines = true;
 };

--- a/tests/general/test_map_reachability.cpp
+++ b/tests/general/test_map_reachability.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "cli/MapReachability.h"
 #include "editor/HexGeometry.h"
+#include "editor/Reachability.h"
 #include "format/pro/Pro.h"
 
 using namespace geck;
@@ -25,40 +25,40 @@ TEST_CASE("blocksMovementByInstance mirrors the engine's instance-flag rule", "[
     constexpr uint32_t kNoBlock = static_cast<uint32_t>(geck::Pro::ObjectFlags::OBJECT_NO_BLOCK);
 
     // Walls, scenery and critters block by default.
-    CHECK(cli::blocksMovementByInstance(kWall, 0));
-    CHECK(cli::blocksMovementByInstance(kScenery, 0));
-    CHECK(cli::blocksMovementByInstance(kCritter, 0));
+    CHECK(reachability::blocksMovementByInstance(kWall, 0));
+    CHECK(reachability::blocksMovementByInstance(kScenery, 0));
+    CHECK(reachability::blocksMovementByInstance(kCritter, 0));
 
     // Items, misc and tiles never block (the engine's type filter) — this is the key fix.
-    CHECK_FALSE(cli::blocksMovementByInstance(kItem, 0));
-    CHECK_FALSE(cli::blocksMovementByInstance(kMisc, 0));
+    CHECK_FALSE(reachability::blocksMovementByInstance(kItem, 0));
+    CHECK_FALSE(reachability::blocksMovementByInstance(kMisc, 0));
 
     // Per-instance flags override: hidden or explicitly no-block objects don't block.
-    CHECK_FALSE(cli::blocksMovementByInstance(kWall, kHidden));
-    CHECK_FALSE(cli::blocksMovementByInstance(kScenery, kNoBlock));
+    CHECK_FALSE(reachability::blocksMovementByInstance(kWall, kHidden));
+    CHECK_FALSE(reachability::blocksMovementByInstance(kScenery, kNoBlock));
 }
 
 TEST_CASE("hexNeighbors yields parity-correct, symmetric neighbours", "[reachability]") {
     // An interior hex has all six neighbours.
-    const std::vector<int> around = cli::hexNeighbors(kCenter);
+    const std::vector<int> around = reachability::hexNeighbors(kCenter);
     CHECK(around.size() == 6);
 
     // Neighbour-ness is symmetric: the centre is a neighbour of each of its neighbours.
     for (const int n : around) {
-        const std::vector<int> back = cli::hexNeighbors(n);
+        const std::vector<int> back = reachability::hexNeighbors(n);
         CHECK(std::find(back.begin(), back.end(), kCenter) != back.end());
     }
 
     // Off-grid positions have no neighbours.
-    CHECK(cli::hexNeighbors(-1).empty());
-    CHECK(cli::hexNeighbors(kCount).empty());
+    CHECK(reachability::hexNeighbors(-1).empty());
+    CHECK(reachability::hexNeighbors(kCount).empty());
 }
 
 TEST_CASE("hexComponents: an open grid is a single walkable region", "[reachability]") {
     const std::vector<char> blocked(kCount, 0);
     std::vector<int> sizes;
     std::vector<int> samples;
-    const std::vector<int> component = cli::hexComponents(blocked, sizes, samples);
+    const std::vector<int> component = reachability::hexComponents(blocked, sizes, samples);
 
     REQUIRE(sizes.size() == 1);
     CHECK(sizes[0] == kCount);
@@ -70,13 +70,13 @@ TEST_CASE("hexComponents: sealing all six neighbours isolates a hex", "[reachabi
     // Block the full ring around the centre — in a hex grid the six neighbours fully enclose it, so
     // the centre must become its own one-hex component (this also proves the neighbour ring is correct).
     std::vector<char> blocked(kCount, 0);
-    for (const int n : cli::hexNeighbors(kCenter)) {
+    for (const int n : reachability::hexNeighbors(kCenter)) {
         blocked[n] = 1;
     }
 
     std::vector<int> sizes;
     std::vector<int> samples;
-    const std::vector<int> component = cli::hexComponents(blocked, sizes, samples);
+    const std::vector<int> component = reachability::hexComponents(blocked, sizes, samples);
 
     // Two components: the big surrounding region and the enclosed centre.
     REQUIRE(sizes.size() == 2);
@@ -88,7 +88,7 @@ TEST_CASE("hexComponents: sealing all six neighbours isolates a hex", "[reachabi
     CHECK(samples[centreId] == kCenter);
 
     // The blocked ring hexes belong to no component.
-    for (const int n : cli::hexNeighbors(kCenter)) {
+    for (const int n : reachability::hexNeighbors(kCenter)) {
         CHECK(component[n] == -1);
     }
 }

--- a/tests/general/test_map_reachability.cpp
+++ b/tests/general/test_map_reachability.cpp
@@ -5,7 +5,11 @@
 
 #include "editor/HexGeometry.h"
 #include "editor/Reachability.h"
+#include "format/map/MapObject.h"
 #include "format/pro/Pro.h"
+#include "util/Constants.h"
+
+#include <memory>
 
 using namespace geck;
 
@@ -91,4 +95,71 @@ TEST_CASE("hexComponents: sealing all six neighbours isolates a hex", "[reachabi
     for (const int n : reachability::hexNeighbors(kCenter)) {
         CHECK(component[n] == -1);
     }
+}
+
+TEST_CASE("entryHexes: player start counts only on its own elevation; every exit grid always counts", "[reachability]") {
+    const std::vector<std::shared_ptr<MapObject>> noObjects;
+
+    // The player start seeds the flood only on the elevation the player spawns on.
+    CHECK(reachability::entryHexes(1, 555, 1, noObjects) == std::vector<int>{ 555 });
+    CHECK(reachability::entryHexes(0, 555, 1, noObjects).empty());
+
+    // An exit-grid marker contributes its hex as an entry regardless of the player's elevation (you
+    // arrive there when entering from the adjacent map).
+    auto exitGrid = std::make_shared<MapObject>();
+    exitGrid->position = 777;
+    exitGrid->pro_pid = (static_cast<uint32_t>(Pro::OBJECT_TYPE::MISC) << FileFormat::TYPE_MASK_SHIFT)
+        | MapObject::EXIT_GRID_PID_INDEX_FIRST;
+    REQUIRE(exitGrid->isExitGridMarker());
+    const std::vector<std::shared_ptr<MapObject>> objects{ exitGrid };
+
+    // Player elsewhere: only the exit grid seeds. Player here: both the start and the exit grid.
+    CHECK(reachability::entryHexes(0, 555, 1, objects) == std::vector<int>{ 777 });
+    CHECK(reachability::entryHexes(1, 555, 1, objects) == std::vector<int>{ 555, 777 });
+}
+
+TEST_CASE("unreachableWalkableHexes: shades the walkable hexes cut off from every entry", "[reachability]") {
+    // Seal the ring around the centre so it is a walkable one-hex pocket disconnected from the rest.
+    std::vector<char> blocked(kCount, 0);
+    for (const int n : reachability::hexNeighbors(kCenter)) {
+        blocked[n] = 1;
+    }
+    std::vector<int> sizes;
+    std::vector<int> samples;
+    const std::vector<int> component = reachability::hexComponents(blocked, sizes, samples);
+
+    // Enter from a far corner (in the big region), not the pocket.
+    const std::vector<int> seeds{ 0 };
+    const std::vector<char> entryReachable = reachability::seedComponentFlags(seeds, blocked, component, sizes.size());
+
+    reachability::ElevationResult result;
+    result.blocked = blocked;
+    result.component = component;
+    result.componentSizes = sizes;
+    result.entrySeeds = seeds;
+    result.entryReachable = entryReachable;
+
+    const std::vector<int> unreachable = reachability::unreachableWalkableHexes(result);
+
+    // Exactly the sealed pocket is unreachable-yet-walkable.
+    REQUIRE(unreachable.size() == 1);
+    CHECK(unreachable[0] == kCenter);
+    // The seeded region is reachable, and the blocked ring hexes are impassable (not walkable), so
+    // neither is shaded.
+    CHECK(std::find(unreachable.begin(), unreachable.end(), 0) == unreachable.end());
+    for (const int n : reachability::hexNeighbors(kCenter)) {
+        CHECK(std::find(unreachable.begin(), unreachable.end(), n) == unreachable.end());
+    }
+}
+
+TEST_CASE("unreachableWalkableHexes: shades nothing when the elevation has no entry point", "[reachability]") {
+    // With no player start and no exit grid here, reachability is undetermined — shade nothing rather
+    // than flagging the whole (unreachable-by-this-model) elevation.
+    reachability::ElevationResult result;
+    result.blocked.assign(kCount, 0); // everything walkable, but no entrySeeds
+    result.component.assign(kCount, 0);
+    result.componentSizes = { kCount };
+    result.entryReachable = { 0 };
+    REQUIRE_FALSE(result.hasEntryPoints());
+    CHECK(reachability::unreachableWalkableHexes(result).empty());
 }


### PR DESCRIPTION
## What

Adds a diagnostic that shades the walkable hexes on the current elevation which are **cut off from every entry point** (the player start + every exit grid) — the floor a wall or blocker has stranded.

- **Editor:** *View › Highlight Unreachable Areas* — a translucent red wash, off by default (session-only, like the other overlay toggles).
- **Headless / MCP:** `map render --show-unreachable` (CLI) and the `render_map` MCP tool's `showUnreachable: true` bake the same shading into the natural-render PNG, so an agent can *see* walled-off regions instead of only reading counts from the `reachability` tool.

This closes the last open item of the "Map semantics & intelligence" roadmap (capability 5, "semantic render overlay").

## How

- The reachability flood-fill was **extracted** from the CLI-only `cli::MapReachability` (which the editor/renderer couldn't link) into a Qt-free **`geck::reachability`** core (`src/editor/Reachability.{h,cpp}`, in `gecko_core`). The editor overlay, the headless renderer, and the `reachability` CLI/MCP tool now all compute from **one** implementation, so they can't drift; `cli::MapReachability` was rewritten to serialize that shared result into JSON.
- The renderer tints the hex set via the existing `HexRenderer::renderHexOverlay` (arbitrary-hex, view-culled — the light-overlay primitive), in `RenderingEngine::renderReachabilityOverlay`, gated by `VisibilitySettings::showUnreachable` + a View-menu toggle.
- The editor **caches** the mask, recomputing only when the map, elevation, or object count changes (the flood-fill is too heavy per frame).

## Verification

- Full suite green: general **398 cases / 170k assertions**, qt **86 cases**, `[reachability]` unit tests. App/CLI/MCP build warning-clean (caught + fixed a `struct/class` forward-decl that would fail MSVC `/WX`).
- Rendered the real path: the shaded set **equals the CLI's unreachable set** — cave1 elev 1 shades the whole outer solid-rock region (~37k hexes) and leaves the central cavern clear. Verified via both `--show-unreachable` and the `render_map` MCP call.
- Confirmed the refactored `reachability` tool still emits correct JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)