### PR TITLE
Cap fill-plan recording and give the Script Console a time budget

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1002,14 +1002,17 @@ Fills live in `fills/` under the existing `PatternLibrary::rootDir()`; one brows
 > then **removed by design** — the Luau fills replaced them, so the `autotile_floor` gap is closed by
 > scripting rather than a set primitive. Don't rebuild them.
 
-### 3.10 Sandbox dependency
+### 3.10 Sandbox dependency — CLOSED
 
 `LuaScriptRuntime::run` takes a `timeBudgetMs`, and `LuaSandboxHost` arms a safepoint interrupt +
-deadline whenever it is non-zero — the fill preview passes `FILL_SCRIPT_BUDGET_MS`, and a script can
-no longer `pcall` its way past the deadline. Two gaps remain before untrusted resident plugins may
-hold map-writing callbacks: the **Script Console still runs untimed** (`EditorWidget::runScript`
-passes no budget) and synchronously on the UI thread, and there is still no **placement cap**
-(`FillPlan::dropped` counts only off-grid targets). The freehand brush itself is native and bounded.
+deadline whenever it is non-zero — the fill preview passes `FILL_SCRIPT_BUDGET_MS`, the **Script
+Console now passes `CONSOLE_SCRIPT_BUDGET_MS` (30 s)**, and a script cannot `pcall` its way past
+the deadline. The **plan-sink placement cap** is in: while a sink AND an area are bound, each list
+(objects, tiles) refuses entries past `kSinkCapFactor (8) × the area's footprint` — refused
+placements return false like off-grid ones, `placeStamp`'s bulk append is trimmed, and the surplus
+lands in `FillPlan::dropped`, surfaced by the fill UI as "skipped". A sink with no bound area
+(programmatic use) stays uncapped. gecko-cli batch generation stays untimed by design. What B2
+still owes on top: wiring this cap into the per-dispatch budget for resident `map.write` plugins.
 
 ---
 
@@ -1148,7 +1151,7 @@ Remaining phases, ordered by dependency and value. "Always compiled" phases work
 |---|---|---|---|---|
 | 1 | ~~**B1** `ITool`+`ToolRegistry`+`PluginTool`+generic input+overlay field+MainWindow `addPlugin*`~~ **DONE** | — | L | The seam, validated by porting object placement |
 | 2 | ~~**A5** freehand Fill Brush as native `ITool`~~ **DONE** | B1 | S | Drag-to-paint; proves `ITool` for real |
-| 3 | **Plugin sandbox limits** placement cap + a default budget for the Script Console (the interrupt+deadline watchdog itself shipped with `LuaSandboxHost`) | — | S | Prereq for resident plugin callbacks |
+| 3 | ~~**Plugin sandbox limits** placement cap + a default budget for the Script Console~~ **DONE** (see §3.10) | — | S | Prereq for resident plugin callbacks |
 | 4 | **B2** persistent VM + manifest + lifecycle + **`MapScriptApi::retarget`** + read-only `api` | #3 | L | Plugin MVP (read-only, isolated) |
 | 5 | **B3** `editor:` register + `map.write` + permission prompt + `storage` | B2 | L | Plugins add menus/buttons + undoable mutation |
 | 6 | **B4/B5** `Gui.*` panels; `LuaTool` tools + events | B3 | L | Plugins add panels/tools |

--- a/src/pattern/FillPlan.h
+++ b/src/pattern/FillPlan.h
@@ -31,7 +31,7 @@ struct FillPlan {
 
     std::vector<Entry> objects;
     std::vector<TileChange> tiles;
-    int dropped = 0; ///< objects/tiles whose target fell off the grid (later: clipped/capped too)
+    int dropped = 0; ///< objects/tiles refused at record time: off-grid targets, or surplus past the per-run sink cap
 };
 
 } // namespace geck::pattern

--- a/src/scripting/MapScriptApi.cpp
+++ b/src/scripting/MapScriptApi.cpp
@@ -497,12 +497,26 @@ void MapScriptApi::endBatch() {
     _controller.endBatch();
 }
 
+std::size_t MapScriptApi::sinkCap() const {
+    if (_area == nullptr) {
+        return 0;
+    }
+    const std::size_t footprint = _area->hexes.size() + _area->floorTiles.size() + _area->roofTiles.size();
+    return kSinkCapFactor * std::max<std::size_t>(footprint, 1);
+}
+
 bool MapScriptApi::registerObject(const std::shared_ptr<MapObject>& mapObject, int hex, uint32_t frmPid, uint32_t direction) {
     // Plan-sink active (preview / area fill): build the object exactly as the commit paths do
     // (GUI needs a resolvable sprite — a fid that won't load is "not placed", same as below;
     // headless records data with a null visual) but RECORD it into the plan instead of committing.
     // PlacementBatch::replay applies the plan later, so the result matches a direct run.
     if (_planSink != nullptr) {
+        // Refuse past the per-run cap (before any sprite is built): surplus counts as
+        // dropped, and the script sees "not placed" — the same contract as off-grid.
+        if (const std::size_t cap = sinkCap(); cap != 0 && _planSink->objects.size() >= cap) {
+            ++_planSink->dropped;
+            return false;
+        }
         std::shared_ptr<Object> object;
         if (_buildSprites) {
             object = pattern::buildSpriteObject(_resources, _hexgrid, frmPid, hex, direction);
@@ -596,6 +610,12 @@ bool MapScriptApi::paintTile(int tileIndex, uint16_t tileId, bool isRoof) {
     // Plan-sink active: record the tile change (before captured from the committed map) instead of
     // applying it; PlacementBatch::replay applies it later as part of the one-entry batch.
     if (_planSink != nullptr) {
+        // Every paint is a plan entry (repaints included), so a runaway loop grows the plan
+        // without bound — the same cap as objects turns the surplus into dropped instead.
+        if (const std::size_t cap = sinkCap(); cap != 0 && _planSink->tiles.size() >= cap) {
+            ++_planSink->dropped;
+            return false;
+        }
         _planSink->tiles.push_back({ _elevation, tileIndex, isRoof, before, tileId });
         ++_paintedTiles;
         return true;
@@ -847,6 +867,18 @@ int MapScriptApi::placeStamp(const std::string& name, int anchorHex, int variant
         const std::size_t objBefore = _planSink->objects.size();
         const std::size_t tileBefore = _planSink->tiles.size();
         stamper.planInto(*_planSink, pattern.variants[variant], anchorHex, _elevation);
+        // planInto appends in bulk, so the per-run cap is enforced by trimming the surplus
+        // (a truncated stamp is the documented over-cap degradation, not normal operation).
+        if (const std::size_t cap = sinkCap(); cap != 0) {
+            if (_planSink->objects.size() > cap) {
+                _planSink->dropped += static_cast<int>(_planSink->objects.size() - cap);
+                _planSink->objects.resize(cap);
+            }
+            if (_planSink->tiles.size() > cap) {
+                _planSink->dropped += static_cast<int>(_planSink->tiles.size() - cap);
+                _planSink->tiles.resize(cap);
+            }
+        }
         const auto placed = static_cast<int>(_planSink->objects.size() - objBefore);
         _placedObjects += placed;
         _paintedTiles += static_cast<int>(_planSink->tiles.size() - tileBefore);

--- a/src/scripting/MapScriptApi.h
+++ b/src/scripting/MapScriptApi.h
@@ -339,6 +339,16 @@ private:
     // so mutated() reports them even though the placed/painted counters stay at 0.
     bool _mutatedDirectly = false;
     std::unordered_map<std::string, pattern::Pattern> _stamps;
+
+    /// Hard ceiling on entries a plan sink accepts per run, kSinkCapFactor x the bound
+    /// area's total footprint (hexes + floor tiles + roof tiles, floored at 1): a runaway
+    /// or hostile script must not exhaust host memory through the sink — the C++-side
+    /// MapObject/Object/TileChange results are invisible to any Lua-heap allocator cap.
+    /// 0 = uncapped (no area bound: programmatic sink use, not the fill path). Surplus is
+    /// counted in FillPlan::dropped and surfaced by the fill UI.
+    [[nodiscard]] std::size_t sinkCap() const;
+    static constexpr std::size_t kSinkCapFactor = 8;
+
     // When non-null, mutators record into this plan instead of committing (see setPlanSink). Borrowed.
     pattern::FillPlan* _planSink = nullptr;
     // The selection area the area-queries report (see setArea). Borrowed; null when none is bound.

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -826,8 +826,14 @@ ScriptResult EditorWidget::runScript(const std::string& source) {
     // so api:placeStamp(name, ...) finds the user's saved patterns; any unloadable file is reported.
     const std::string stampNotes = registerLibraryStamps(api);
     LuaScriptRuntime runtime;
+    // The console runs synchronously on the UI thread, so a runaway script would hang the
+    // editor with no recourse — arm the same safepoint watchdog the fill preview uses, just
+    // with a far more generous budget (real generation scripts finish in well under a
+    // second; trusted long batches belong on gecko-cli, which stays untimed).
+    constexpr unsigned CONSOLE_SCRIPT_BUDGET_MS = 30000;
     // The continuous SFML render loop shows the script's edits on the next frame.
-    ScriptResult result = runtime.run(source, api, _controller.commandController(), "Run script");
+    ScriptResult result = runtime.run(source, api, _controller.commandController(), "Run script",
+        {}, CONSOLE_SCRIPT_BUDGET_MS);
     if (!stampNotes.empty()) {
         result.output = result.output.empty() ? stampNotes : stampNotes + "\n" + result.output;
     }
@@ -2058,7 +2064,7 @@ void EditorWidget::stampPatternAt(sf::Vector2f worldPos) {
         message += QString(" (%1 missing art)").arg(result.objectsFailed);
     }
     if (result.dropped > 0) {
-        message += QString(" (%1 off-grid)").arg(result.dropped);
+        message += QString(" (%1 skipped: off-grid or over cap)").arg(result.dropped);
     }
     Q_EMIT statusMessageRequested(message);
 }
@@ -2305,7 +2311,7 @@ void EditorWidget::applyFillPreview(const QString& description) {
         message += QString(" (%1 missing art)").arg(result.objectsFailed);
     }
     if (_fillPlan.dropped > 0) {
-        message += QString(" (%1 off-grid)").arg(_fillPlan.dropped);
+        message += QString(" (%1 skipped: off-grid or over cap)").arg(_fillPlan.dropped);
     }
     Q_EMIT statusMessageRequested(message);
 

--- a/src/ui/core/EditorWidget.cpp
+++ b/src/ui/core/EditorWidget.cpp
@@ -2064,7 +2064,8 @@ void EditorWidget::stampPatternAt(sf::Vector2f worldPos) {
         message += QString(" (%1 missing art)").arg(result.objectsFailed);
     }
     if (result.dropped > 0) {
-        message += QString(" (%1 skipped: off-grid or over cap)").arg(result.dropped);
+        // Direct stamping bypasses the plan sink, so dropped here can only mean off-grid.
+        message += QString(" (%1 off-grid)").arg(result.dropped);
     }
     Q_EMIT statusMessageRequested(message);
 }

--- a/src/ui/dialogs/FillDialog.cpp
+++ b/src/ui/dialogs/FillDialog.cpp
@@ -210,7 +210,7 @@ void FillDialog::runPreview() {
                           .arg(plan.tiles.size())
                           .arg(plan.objects.size());
     if (plan.dropped > 0) {
-        summary += QStringLiteral(" (%1 off-grid)").arg(plan.dropped);
+        summary += QStringLiteral(" (%1 skipped: off-grid or over cap)").arg(plan.dropped);
     }
     _summary->setText(summary);
 #endif

--- a/tests/general/test_map_script_api.cpp
+++ b/tests/general/test_map_script_api.cpp
@@ -9,6 +9,9 @@
 #include "format/map/Map.h"
 #include "format/map/MapObject.h"
 #include "format/pro/Pro.h"
+#include "pattern/FillPlan.h"
+#include "pattern/Pattern.h"
+#include "scripting/EditArea.h"
 #include "scripting/MapScriptApi.h"
 #include "util/Constants.h"
 #include "writer/map/MapWriter.h"
@@ -648,4 +651,92 @@ TEST_CASE("MapScriptApi reports genuine failures by throwing, not silently", "[s
         }
         CHECK(api.noise2d(1.5, 2.5) != api.noise2d(40.5, 80.5)); // varies across the field
     }
+}
+
+TEST_CASE("The plan sink caps a run at a multiple of the bound area's footprint", "[scripting][cap]") {
+    ControllerFixture fx;
+    // Headless (buildSprites=false): the sink records objects with a null visual, no art needed.
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+
+    // Footprint = 2 hexes + 1 floor tile = 3 -> cap = 8 * 3 = 24 entries per list.
+    EditArea area;
+    area.hexes = { 20100, 20101 };
+    area.floorTiles = { 0 };
+    pattern::FillPlan plan;
+    api.setArea(&area);
+    api.setPlanSink(&plan);
+
+    constexpr uint32_t PRO = 0x02000066;
+    constexpr uint32_t FRM = 0x02000000;
+
+    // Objects: the 25th and later placements are refused, reported like off-grid ones.
+    int placed = 0;
+    for (int i = 0; i < 40; ++i) {
+        if (api.placeObject(PRO, FRM, 20100, 0)) {
+            ++placed;
+        }
+    }
+    CHECK(placed == 24);
+    CHECK(plan.objects.size() == 24);
+    CHECK(plan.dropped == 16);
+    CHECK(api.placedObjects() == 24); // refused placements are not counted as placed
+
+    // Tiles have the same independent cap: repaints are entries too, so a runaway loop
+    // repainting one tile stops growing the plan at the cap.
+    int painted = 0;
+    for (int i = 0; i < 40; ++i) {
+        if (api.paintFloor(0, SOME_TILE)) {
+            ++painted;
+        }
+    }
+    CHECK(painted == 24);
+    CHECK(plan.tiles.size() == 24);
+    CHECK(plan.dropped == 16 + 16);
+}
+
+TEST_CASE("The plan sink cap trims a stamp's bulk append", "[scripting][cap]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+
+    // Footprint = 1 hex -> cap = 8 entries per list.
+    EditArea area;
+    area.hexes = { 20100 };
+    pattern::FillPlan plan;
+    api.setArea(&area);
+    api.setPlanSink(&plan);
+
+    // A stamp with 12 objects in one variant: planInto appends all of them, then the cap
+    // trims the surplus (a truncated stamp is the documented over-cap degradation).
+    pattern::Pattern big;
+    big.name = "big";
+    pattern::PatternVariant variant;
+    for (int i = 0; i < 12; ++i) {
+        pattern::PatternObject object;
+        object.dxHex = i; // spread along a row so every target lands on the grid
+        object.proPid = 0x02000066;
+        object.frmPid = 0x02000000;
+        variant.objects.push_back(object);
+    }
+    big.variants.push_back(variant);
+    api.addStamp("big", big);
+
+    const int placed = api.placeStamp("big", 20100, 0);
+    CHECK(placed == 8);
+    CHECK(plan.objects.size() == 8);
+    CHECK(plan.dropped == 4);
+}
+
+TEST_CASE("A sink with no bound area stays uncapped", "[scripting][cap]") {
+    ControllerFixture fx;
+    MapScriptApi api(fx.resources, fx.hexgrid, fx.controller, *fx.map, ELEV, false);
+
+    // Programmatic sink use (no fill area): the cap does not apply.
+    pattern::FillPlan plan;
+    api.setPlanSink(&plan);
+
+    for (int i = 0; i < 50; ++i) {
+        REQUIRE(api.placeObject(0x02000066u, 0x02000000u, 20100 + i, 0));
+    }
+    CHECK(plan.objects.size() == 50);
+    CHECK(plan.dropped == 0);
 }


### PR DESCRIPTION
## What

Closes the two sandbox gaps that gate exposing map-writing callbacks to resident plugin scripts (PLAN §3.10), following the watchdog hardening and the tool seam.

**Plan-sink placement cap.** The sink had no size limit — every `paint*` call is a plan entry (repaints included), and scattered objects are C++-side `MapObject`/`Object` allocations invisible to any Lua-heap cap — so a runaway or hostile fill script could exhaust host memory while staying under the interpreter's own limits. While a sink **and** a selection area are bound, each list (objects, tiles) now refuses entries past **8× the area's footprint** (hexes + floor tiles + roof tiles, floored at 1):

- refused placements return `false` to the script, exactly the off-grid contract;
- `placeStamp`'s bulk append is trimmed to the cap (a truncated stamp is the documented over-cap degradation);
- surplus lands in `FillPlan::dropped`, which the fill UI already surfaces — its label generalised from "(N off-grid)" to "(N skipped: off-grid or over cap)";
- a sink with **no bound area** (programmatic use, not the fill path) stays uncapped, pinned by a test.

**Script Console time budget.** The console was the one Luau entry point still running untimed, synchronously on the UI thread — `while true do end` hung the editor with no recourse. It now arms the same safepoint watchdog as the fill preview with a **30 s budget**: generous for real generation scripts (which finish in well under a second), while trusted long batches belong on `gecko-cli`, which stays untimed by design.

## Testing

Three new cases in `test_map_script_api.cpp` (`[cap]`): the per-list cap with refusal accounting (`placed == cap`, `dropped == surplus`, `placedObjects()` counts only kept), the stamp bulk-append trim, and the uncapped no-area sink. Suites: general_tests 423 cases / 210,608 assertions, qt_tests 692 assertions, all green.

The cap composes with the existing fill tests untouched: real fills paint within their selection footprint, far under 8×.

## What B2 still owes on top

Wiring this cap into the per-dispatch budget for resident `map.write` plugins, per the plan's threat model (allocator cap bounds only the Lua heap; this cap bounds the host-side results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRhHnNR8gFUAY5oqM9ha8M