### PR TITLE
Add a zoomed region crop to map render (CLI + MCP)

### DIFF
--- a/src/cli/MapRender.cpp
+++ b/src/cli/MapRender.cpp
@@ -1,10 +1,14 @@
 #include "cli/MapRender.h"
 
 #include "cli/MapLoad.h"
+#include "editor/Hex.h"
+#include "editor/HexagonGrid.h"
 #include "format/map/Map.h"
 #include "rendering/MapRenderer.h"
 
 #include <SFML/Graphics/Image.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <algorithm>
 
 #include <exception>
 #include <format>
@@ -49,6 +53,22 @@ int renderMap(resource::GameResources& resources, const RenderOptions& options, 
     renderOptions.fullExtent = options.fullExtent;
     renderOptions.exitDots = options.exitDots;
     renderOptions.showUnreachable = options.showUnreachable;
+    if (options.cropCenterHex >= 0) {
+        // The hex's screen coordinates are the render's world space (sprites are placed there), so
+        // centre a ±cropExtentPx square on it. computeFrame then upscales it to fill maxDimension.
+        const HexagonGrid grid;
+        if (const auto hex = grid.getHexByPosition(static_cast<uint32_t>(options.cropCenterHex))) {
+            const float ext = static_cast<float>(std::max(1, options.cropExtentPx));
+            const Hex& h = hex->get();
+            renderOptions.hasCrop = true;
+            renderOptions.cropRect = sf::FloatRect(
+                { static_cast<float>(h.x()) - ext, static_cast<float>(h.y()) - ext },
+                { 2.0f * ext, 2.0f * ext });
+        } else {
+            out << "render: crop hex " << options.cropCenterHex << " is off the grid\n";
+            return 1;
+        }
+    }
     renderOptions.style = options.semantic ? MapRenderer::Style::Semantic
         : options.objects                  ? MapRenderer::Style::Objects
         : options.schematic                ? MapRenderer::Style::Schematic

--- a/src/cli/MapRender.h
+++ b/src/cli/MapRender.h
@@ -37,6 +37,12 @@ namespace cli {
         /// Natural style only: shade the walkable hexes cut off from every entry point (unreachable
         /// areas) — the visual form of the `reachability` tool, for spotting walled-off regions.
         bool showUnreachable = false;
+        /// Zoomed region crop: centre the render on this hex (0..39999) and frame a square of
+        /// ±cropExtentPx screen pixels around it, upscaled to fill maxDimension. -1 = no crop (whole
+        /// map). Lets an agent read individual pieces — a cave-rim corner, a scatter cluster — that
+        /// are unreadable in a whole-map render.
+        int cropCenterHex = -1;
+        int cropExtentPx = 220;
     };
 
     /// Render a map to an image file (format inferred from the extension, e.g. .png). Returns 0 on

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -76,7 +76,8 @@ void printUsage(const char* program) {
               << "      pattern stamp the script places with api:placeStamp(name, anchorHex, variant).\n"
               << "  " << program << " map render --map <file.map> --out <file.png>\n"
               << "      [--elevation 0|1|2] [--max-dim N] [--roof] [--schematic|--objects|--semantic]\n"
-              << "      [--show-blockers] [--show-unreachable] [--full] --data <dir-or-.dat> [...]\n"
+              << "      [--show-blockers] [--show-unreachable] [--full] [--crop-hex H [--crop-extent PX]]\n"
+              << "      --data <dir-or-.dat> [...]\n"
               << "      Renders a map to a PNG (needs an off-screen GL context). --max-dim caps the\n"
               << "      longest side (default 1600); --roof draws the roof layer over the floor; --full\n"
               << "      frames the whole iso grid (the full playable area) instead of cropping to content.\n"
@@ -86,6 +87,9 @@ void printUsage(const char* program) {
               << "      (exit grids, critters by team, scripted ringed); --show-blockers also marks FLAT.\n"
               << "      --show-unreachable (natural style) shades hexes cut off from the player start and\n"
               << "      every exit grid, the visual form of `map reachability`.\n"
+              << "      --crop-hex H zooms into a square around hex H (0..39999), ±--crop-extent pixels\n"
+              << "      (default 220), upscaled to --max-dim — to read individual pieces (a rim corner,\n"
+              << "      a scatter cluster) that are unreadable in a whole-map render.\n"
               << "  " << program << " map extract-pattern --map <file.map> --out <file.json> --name <name>\n"
               << "      [--pids id,id,...] [--anchor <hex>] [--radius N] [--elevation 0|1|2]\n"
               << "      [--include-floor] [--include-roof] --data <dir-or-.dat> [--data <...>]\n"
@@ -258,7 +262,7 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
     const std::string& arg = args[i];
     const bool valueFlag = arg == "--data"
         || (out.generate && (arg == "--script" || arg == "--out" || arg == "--in" || arg == "--elevation" || arg == "--count" || arg == "--arg" || arg == "--stamp"))
-        || (out.render && (arg == "--map" || arg == "--out" || arg == "--elevation" || arg == "--max-dim"))
+        || (out.render && (arg == "--map" || arg == "--out" || arg == "--elevation" || arg == "--max-dim" || arg == "--crop-hex" || arg == "--crop-extent"))
         || (out.extract && (arg == "--map" || arg == "--out" || arg == "--name" || arg == "--elevation" || arg == "--pids" || arg == "--anchor" || arg == "--radius"))
         || (out.describeScript && (arg == "--index" || arg == "--locale"))
         || (out.reachability && arg == "--map")
@@ -377,6 +381,12 @@ int consumeArg(const std::vector<std::string>& args, std::size_t i, CliArgs& out
     if (out.render && arg == "--show-unreachable") {
         out.ren.showUnreachable = true;
         return 1;
+    }
+    if (out.render && arg == "--crop-hex") {
+        return parseIntFlag(arg, args[i + 1], out.ren.cropCenterHex, program) ? 2 : 0;
+    }
+    if (out.render && arg == "--crop-extent") {
+        return parseIntFlag(arg, args[i + 1], out.ren.cropExtentPx, program) ? 2 : 0;
     }
     if (out.render) {
         std::cerr << "error: unexpected argument: " << arg << "\n";

--- a/src/mcp/McpServer.cpp
+++ b/src/mcp/McpServer.cpp
@@ -393,6 +393,8 @@ namespace {
         opts.showBlockers = optBool(args, "showBlockers", opts.showBlockers);
         opts.showUnreachable = optBool(args, "showUnreachable", opts.showUnreachable);
         opts.fullExtent = optBool(args, "full", opts.fullExtent);
+        opts.cropCenterHex = static_cast<int>(optInt(args, "cropHex", opts.cropCenterHex, -1, 39999));
+        opts.cropExtentPx = static_cast<int>(optInt(args, "cropExtent", opts.cropExtentPx, 1, 100000));
         std::ostringstream oss;
         const int rc = cli::renderMap(resources, opts, oss);
         return toolText(oss.str(), rc != 0); // rc != 0 e.g. unreadable map or no GL context
@@ -760,10 +762,13 @@ namespace {
             "visual form of the reachability tool, for seeing walled-off regions on the map. full=true "
             "frames the whole iso playable grid instead of "
             "cropping to drawn content, so a sparse/empty map still shows the entire map extent. "
+            "cropHex H (0..39999) zooms into a square centred on that hex, ±cropExtent screen pixels "
+            "(default 220), upscaled to maxDimension — so individual pieces (a cave-rim corner, a "
+            "scatter cluster) become readable where a whole-map render is too small. "
             "map/out are filesystem paths — out is written there, and "
             "map may be a VFS path or any file on disk (e.g. one generate just wrote). Needs an "
             "off-screen GL context.",
-            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } }, { "showUnreachable", { { "type", "boolean" } } }, { "full", { { "type", "boolean" } } } } }, { "required", json::array({ "map", "out" }) } }),
+            json({ { "type", "object" }, { "properties", { { "map", { { "type", "string" } } }, { "out", { { "type", "string" } } }, { "elevation", { { "type", "integer" } } }, { "maxDimension", { { "type", "integer" } } }, { "showRoof", { { "type", "boolean" } } }, { "schematic", { { "type", "boolean" } } }, { "objects", { { "type", "boolean" } } }, { "semantic", { { "type", "boolean" } } }, { "showBlockers", { { "type", "boolean" } } }, { "showUnreachable", { { "type", "boolean" } } }, { "full", { { "type", "boolean" } } }, { "cropHex", { { "type", "integer" } } }, { "cropExtent", { { "type", "integer" } } } } }, { "required", json::array({ "map", "out" }) } }),
             [](resource::GameResources& r, const json& a) { return toolRender(r, a); } });
         t.push_back({ "render_frm",
             "Render an FRM sprite to a PNG so the art can be SEEN, not inferred from PID arithmetic. "

--- a/src/rendering/MapRenderer.cpp
+++ b/src/rendering/MapRenderer.cpp
@@ -59,13 +59,15 @@ namespace {
         unsigned int height = 1;
         sf::View view;
     };
-    Frame computeFrame(Bounds bounds, unsigned int maxDimension) {
+    Frame computeFrame(Bounds bounds, unsigned int maxDimension, bool allowUpscale = false) {
         constexpr float pad = 8.0f;
         bounds.add(bounds.minX - pad, bounds.minY - pad, bounds.maxX + pad, bounds.maxY + pad);
         const float bboxWidth = std::max(1.0f, bounds.maxX - bounds.minX);
         const float bboxHeight = std::max(1.0f, bounds.maxY - bounds.minY);
         const float maxDim = static_cast<float>(std::max(1u, maxDimension));
-        const float scale = std::min(1.0f, maxDim / std::max(bboxWidth, bboxHeight));
+        // A crop UPSCALES to fill maxDimension (zoom in); the whole-map view never upscales.
+        const float fit = maxDim / std::max(bboxWidth, bboxHeight);
+        const float scale = allowUpscale ? fit : std::min(1.0f, fit);
         Frame frame;
         frame.width = static_cast<unsigned int>(std::max(1.0f, bboxWidth * scale));
         frame.height = static_cast<unsigned int>(std::max(1.0f, bboxHeight * scale));
@@ -450,28 +452,35 @@ sf::Image MapRenderer::renderNatural(Map& map, const Options& options) {
     // loader made for empty cells — they just fall outside this frame instead of dominating it.)
     // With fullExtent, seed the bounds with the whole floor-tile grid so even an empty map shows it all.
     Bounds bounds;
-    if (options.fullExtent) {
-        addFullGridBounds(bounds);
-    }
-    const auto& allTiles = map.getMapFile().tiles;
-    if (const auto it = allTiles.find(options.elevation); it != allTiles.end()) {
-        addTileContentBounds(bounds, it->second, false);
-        if (options.showRoof) {
-            addTileContentBounds(bounds, it->second, true);
+    if (options.hasCrop) {
+        // Frame exactly the requested rectangle (the whole map is still drawn; the view clips to it).
+        bounds.add(options.cropRect.position.x, options.cropRect.position.y,
+            options.cropRect.position.x + options.cropRect.size.x,
+            options.cropRect.position.y + options.cropRect.size.y);
+    } else {
+        if (options.fullExtent) {
+            addFullGridBounds(bounds);
         }
-    }
-    if (options.showObjects) {
-        for (const auto& object : objects) {
-            if (object) {
-                bounds.add(object->getSprite());
+        const auto& allTiles = map.getMapFile().tiles;
+        if (const auto it = allTiles.find(options.elevation); it != allTiles.end()) {
+            addTileContentBounds(bounds, it->second, false);
+            if (options.showRoof) {
+                addTileContentBounds(bounds, it->second, true);
             }
         }
-    }
-    if (bounds.empty()) {
-        throw std::runtime_error("map has nothing to render at elevation " + std::to_string(options.elevation));
+        if (options.showObjects) {
+            for (const auto& object : objects) {
+                if (object) {
+                    bounds.add(object->getSprite());
+                }
+            }
+        }
+        if (bounds.empty()) {
+            throw std::runtime_error("map has nothing to render at elevation " + std::to_string(options.elevation));
+        }
     }
 
-    const std::unique_ptr<sf::RenderTexture> target = makeTarget(computeFrame(bounds, options.maxDimension));
+    const std::unique_ptr<sf::RenderTexture> target = makeTarget(computeFrame(bounds, options.maxDimension, options.hasCrop));
     target->clear(options.background);
 
     RenderingEngine engine(_resources);

--- a/src/rendering/MapRenderer.h
+++ b/src/rendering/MapRenderer.h
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Image.hpp>
+#include <SFML/Graphics/Rect.hpp>
 
 #include <cstdint>
 #include <string>
@@ -64,6 +65,12 @@ public:
         /// exit grids) with a translucent red wash — the same "unreachable areas" the editor overlay
         /// and the `reachability` tool report, so a rendered map shows walled-off regions at a glance.
         bool showUnreachable = false;
+        /// Region crop (world/screen coords). When set, the render frames exactly this rectangle
+        /// instead of the map's content bounds, and — unlike the content view — UPSCALES it to fill
+        /// maxDimension, so a small rectangle renders zoomed in. For inspecting individual pieces
+        /// (e.g. one stretch of a cave rim) that are unreadable in a whole-map render.
+        bool hasCrop = false;
+        sf::FloatRect cropRect;
         sf::Color background{ 0, 0, 0, 255 };
     };
 


### PR DESCRIPTION
Whole-map renders are too small to read individual pieces — a cave-rim corner, a scatter cluster — so verifying generated art by eye (agent or human) is impossible. This adds a **zoomed region crop**: center the render on a hex and frame a square of ±`cropExtent` screen pixels around it, upscaled to fill `maxDimension`.

- **`MapRenderer::Options`** gains `hasCrop` + `cropRect`; `computeFrame` upscales for a crop (the whole-map view still never upscales).
- **`gecko-cli map render`**: `--crop-hex H [--crop-extent PX]`.
- **MCP `render_map`**: `cropHex` + `cropExtent` params.

The whole map is still drawn — the view just clips to the region — so no extra memory, and any hex (0–39999) can be inspected. Built to unblock verifying the cave-wall generation, but it's general (scatter density, exit grids, any local detail).

All suites pass (MCP dispatch, FRM, render). Example: `map render --map cave.map --crop-hex 11932 --crop-extent 150 --max-dim 900` yields a readable close-up of a single rim stretch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRhHnNR8gFUAY5oqM9ha8M