### PR TITLE
Write to the game root a macOS app bundle actually uses

### DIFF
--- a/src/state/GameLauncher.cpp
+++ b/src/state/GameLauncher.cpp
@@ -15,8 +15,10 @@
 #include <string_view>
 #include <system_error>
 
+#include <QFile>
 #include <QProcess>
 #include <QStringList>
+#include <QXmlStreamReader>
 #include <spdlog/spdlog.h>
 
 namespace geck {
@@ -265,6 +267,32 @@ namespace {
         return {};
     }
 
+    /**
+     * The value of @p key in an XML Info.plist, where keys and values are sibling elements
+     * (<key>NAME</key><string>VALUE</string>). Empty when the file is unreadable, is a binary
+     * plist, or has no such key - all of which the caller treats as "unknown", never as a default.
+     */
+    std::string plistStringValue(const std::filesystem::path& plistPath, QLatin1StringView key) {
+        QFile file(QString::fromStdString(plistPath.string()));
+        if (!file.open(QIODevice::ReadOnly)) {
+            return {};
+        }
+
+        QXmlStreamReader xml(&file);
+        bool atValue = false;
+        while (!xml.atEnd()) {
+            if (xml.readNext() != QXmlStreamReader::StartElement) {
+                continue;
+            }
+            if (xml.name() == QLatin1StringView("key")) {
+                atValue = xml.readElementText() == key;
+            } else if (atValue && xml.name() == QLatin1StringView("string")) {
+                return xml.readElementText().trimmed().toStdString();
+            }
+        }
+        return {};
+    }
+
     /** Whether @p name is one of the patchXXX.dat archives the engine walks until the first gap. */
     bool isPatchArchiveName(std::string_view name) {
         constexpr std::string_view prefix = "patch";
@@ -363,6 +391,18 @@ void GameLauncher::playGame(const Map::MapFile* mapFile, const std::string& mapF
         return;
     }
 
+    // A bundled macOS build chdir's to its own base path on startup, so the configured directory is
+    // not the one it reads: writing the map, the configs and the mods there would leave the game
+    // playing whatever it already had. Follow the bundle instead - it is not a preference.
+    bool rootFixedByBundle = false;
+    if (const auto bundleRoot = macOsBundleDataRoot(executableLocation);
+        bundleRoot.has_value() && normalizedForCompare(*bundleRoot) != normalizedForCompare(gameDataDir)) {
+        spdlog::info("Using {} as the game root: {} fixes it via SDL_FILESYSTEM_BASE_DIR_TYPE, overriding the configured {}",
+            bundleRoot->string(), executableLocation.filename().string(), gameDataDir.string());
+        gameDataDir = *bundleRoot;
+        rootFixedByBundle = true;
+    }
+
     const EditorDataMountPlan mountPlan
         = planEditorDataMounts(gameDataDir, settings.getDataPaths(), engineArchivesInGameFolder(gameDataDir));
     for (const std::filesystem::path& archive : mountPlan.alreadyLoadedByGame) {
@@ -375,7 +415,12 @@ void GameLauncher::playGame(const Map::MapFile* mapFile, const std::string& mapF
     std::filesystem::path mapsDir = gameDataDir / "data" / "maps";
     std::filesystem::path mapDestination = mapsDir / mapFilename;
 
-    _showStatus(QString("Playing map: %1").arg(QString::fromStdString(mapFilename)));
+    // Name the directory when it is not the configured one, so a map that appears not to reach the
+    // game can be traced without having to know what the bundle does to the working directory.
+    _showStatus(rootFixedByBundle
+            ? QString("Playing map: %1 (in %2, the root the app bundle uses)")
+                  .arg(QString::fromStdString(mapFilename), QString::fromStdString(gameDataDir.string()))
+            : QString("Playing map: %1").arg(QString::fromStdString(mapFilename)));
 
     try {
         // 1. Save the current map to the game directory
@@ -528,6 +573,30 @@ std::string applyManagedModsOrderBlock(const std::string& existingContent, const
     }
     content += std::string(kManagedBlockEnd) + lineEnding;
     return content;
+}
+
+std::optional<std::filesystem::path> macOsBundleDataRoot(const std::filesystem::path& executablePath) {
+    if (executablePath.extension() != ".app") {
+        return std::nullopt;
+    }
+
+    const std::filesystem::path plist = executablePath / "Contents" / "Info.plist";
+    std::error_code ec;
+    if (!std::filesystem::exists(plist, ec)) {
+        return std::nullopt;
+    }
+
+    // Absent means SDL's default, "resource" - a real answer, not a failure to read one.
+    const std::string baseDirType
+        = plistStringValue(plist, QLatin1StringView("SDL_FILESYSTEM_BASE_DIR_TYPE"));
+
+    if (baseDirType == "parent") {
+        return executablePath.parent_path();
+    }
+    if (baseDirType == "bundle") {
+        return executablePath;
+    }
+    return executablePath / "Contents" / "Resources";
 }
 
 std::vector<std::string> collectLaunchConfigurationWarnings(

--- a/src/state/GameLauncher.cpp
+++ b/src/state/GameLauncher.cpp
@@ -269,13 +269,18 @@ namespace {
 
     /**
      * The value of @p key in an XML Info.plist, where keys and values are sibling elements
-     * (<key>NAME</key><string>VALUE</string>). Empty when the file is unreadable, is a binary
-     * plist, or has no such key - all of which the caller treats as "unknown", never as a default.
+     * (<key>NAME</key><string>VALUE</string>).
+     *
+     * "Read the file but found no such key" and "could not read the file at all" must not look
+     * alike: the first is an answer (the reader's own default applies), the second is not, and a
+     * caller that conflates them acts on a default it never actually read. So an unreadable file,
+     * malformed XML, or a *binary* plist - which Xcode emits routinely and this parser cannot read
+     * - gives nullopt, while a parsed file missing the key gives an empty string.
      */
-    std::string plistStringValue(const std::filesystem::path& plistPath, QLatin1StringView key) {
+    std::optional<std::string> plistStringValue(const std::filesystem::path& plistPath, QLatin1StringView key) {
         QFile file(QString::fromStdString(plistPath.string()));
         if (!file.open(QIODevice::ReadOnly)) {
-            return {};
+            return std::nullopt;
         }
 
         QXmlStreamReader xml(&file);
@@ -290,7 +295,11 @@ namespace {
                 return xml.readElementText().trimmed().toStdString();
             }
         }
-        return {};
+
+        if (xml.hasError()) {
+            return std::nullopt;
+        }
+        return std::string{}; // parsed, no such key
     }
 
     /** Whether @p name is one of the patchXXX.dat archives the engine walks until the first gap. */
@@ -586,16 +595,20 @@ std::optional<std::filesystem::path> macOsBundleDataRoot(const std::filesystem::
         return std::nullopt;
     }
 
-    // Absent means SDL's default, "resource" - a real answer, not a failure to read one.
-    const std::string baseDirType
+    const std::optional<std::string> baseDirType
         = plistStringValue(plist, QLatin1StringView("SDL_FILESYSTEM_BASE_DIR_TYPE"));
+    if (!baseDirType.has_value()) {
+        spdlog::warn("Could not read {}: leaving the configured game directory in place", plist.string());
+        return std::nullopt;
+    }
 
-    if (baseDirType == "parent") {
+    if (*baseDirType == "parent") {
         return executablePath.parent_path();
     }
-    if (baseDirType == "bundle") {
+    if (*baseDirType == "bundle") {
         return executablePath;
     }
+    // Absent, or a value SDL does not recognise, both mean its default: the Resources directory.
     return executablePath / "Contents" / "Resources";
 }
 

--- a/src/state/GameLauncher.h
+++ b/src/state/GameLauncher.h
@@ -90,6 +90,21 @@ EditorDataMountPlan planEditorDataMounts(const std::filesystem::path& gameDataDi
 std::string applyManagedModsOrderBlock(const std::string& existingContent, const std::vector<std::string>& entries);
 
 /**
+ * @brief The directory a macOS .app bundle will actually treat as the game root, or nullopt.
+ *
+ * SDL calls chdir(SDL_GetBasePath()) at startup on macOS, and fallout2-ce resolves master_patches
+ * ("data") against the working directory - so for a bundled build the engine's root is fixed by the
+ * bundle, and the working directory a launcher sets is discarded. Which directory that is comes
+ * from the bundle's own Info.plist: SDL_FILESYSTEM_BASE_DIR_TYPE is "parent" (the folder holding
+ * the .app - what fallout2-ce ships), "bundle" (the .app itself), or absent/anything else, SDL's
+ * default being Contents/Resources.
+ *
+ * @return the resolved root, or nullopt when @p executablePath is not a bundle or the key cannot be
+ *         read - callers then keep the configured directory rather than act on a guess.
+ */
+std::optional<std::filesystem::path> macOsBundleDataRoot(const std::filesystem::path& executablePath);
+
+/**
  * @brief Reports configuration problems that would make the game load data the editor is not
  * editing (pure).
  *

--- a/tests/qt/test_game_launcher.cpp
+++ b/tests/qt/test_game_launcher.cpp
@@ -3,6 +3,7 @@
 #include "state/GameLauncher.h"
 
 #include <filesystem>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -302,4 +303,106 @@ TEST_CASE("collectLaunchConfigurationWarnings reports incoherent launch setups",
         REQUIRE(warnings[0].find("/elsewhere/data") != std::string::npos);
         REQUIRE(warnings[0].find("/other#path/data") != std::string::npos);
     }
+}
+
+namespace {
+
+// A minimal .app: only Contents/Info.plist matters to macOsBundleDataRoot.
+std::filesystem::path makeBundle(const std::filesystem::path& root, const std::string& plistBody) {
+    const std::filesystem::path bundle = root / "Fallout II Community Edition.app";
+    std::filesystem::create_directories(bundle / "Contents");
+    if (!plistBody.empty()) {
+        std::ofstream(bundle / "Contents" / "Info.plist") << plistBody;
+    }
+    return bundle;
+}
+
+std::string plistWith(const std::string& baseDirType) {
+    return R"(<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>fallout2-ce</string>
+    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+    <string>)"
+        + baseDirType + R"(</string>
+    <key>CFBundleName</key>
+    <string>Fallout II Community Edition</string>
+</dict>
+</plist>
+)";
+}
+
+} // namespace
+
+TEST_CASE("macOsBundleDataRoot follows the bundle's own SDL base-dir type", "[game_launcher]") {
+    // On macOS the engine chdir's to SDL_GetBasePath() at startup and resolves master_patches
+    // ("data") against it, so a bundle decides the game root and the launcher's working directory
+    // is discarded. Reading the key rather than assuming it keeps a differently packaged build
+    // working; fallout2-ce itself ships "parent".
+    const std::filesystem::path root
+        = std::filesystem::temp_directory_path() / "geck_bundle_root_test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+
+    SECTION("\"parent\" resolves to the folder holding the .app") {
+        const auto bundle = makeBundle(root, plistWith("parent"));
+        const auto resolved = macOsBundleDataRoot(bundle);
+
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == root);
+    }
+
+    SECTION("\"bundle\" resolves to the .app itself") {
+        const auto bundle = makeBundle(root, plistWith("bundle"));
+        const auto resolved = macOsBundleDataRoot(bundle);
+
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == bundle);
+    }
+
+    SECTION("A missing key means SDL's default, Contents/Resources") {
+        const auto bundle = makeBundle(root, R"(<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>fallout2-ce</string>
+</dict>
+</plist>
+)");
+        const auto resolved = macOsBundleDataRoot(bundle);
+
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == bundle / "Contents" / "Resources");
+    }
+
+    SECTION("A plain executable is not a bundle") {
+        CHECK_FALSE(macOsBundleDataRoot(root / "fallout2-ce").has_value());
+        CHECK_FALSE(macOsBundleDataRoot("/games/fallout2/fallout2.exe").has_value());
+    }
+
+    SECTION("A .app without an Info.plist yields nothing rather than a guess") {
+        const auto bundle = makeBundle(root, "");
+        CHECK_FALSE(macOsBundleDataRoot(bundle).has_value());
+    }
+
+    SECTION("The key is not confused with a neighbouring one of the same value") {
+        // <string> elements follow every <key>; only the one after OUR key counts.
+        const auto bundle = makeBundle(root, R"(<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>parent</string>
+    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+    <string>bundle</string>
+</dict>
+</plist>
+)");
+        const auto resolved = macOsBundleDataRoot(bundle);
+
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == bundle); // "bundle", not the earlier "parent"
+    }
+
+    std::filesystem::remove_all(root);
 }

--- a/tests/qt/test_game_launcher.cpp
+++ b/tests/qt/test_game_launcher.cpp
@@ -389,6 +389,30 @@ TEST_CASE("macOsBundleDataRoot follows the bundle's own SDL base-dir type", "[ga
         CHECK_FALSE(macOsBundleDataRoot(bundle).has_value());
     }
 
+    SECTION("An unreadable plist yields nothing, never SDL's default") {
+        // "No such key" and "could not read the file" must not both resolve to Contents/Resources:
+        // that would redirect the map into a directory nobody read a setting from. A binary plist
+        // is the realistic case - Xcode emits them routinely and this parser only reads XML.
+        SECTION("binary plist") {
+            const auto bundle = makeBundle(root, std::string("bplist00\xd4\x01\x02\x03\x04", 13));
+            CHECK_FALSE(macOsBundleDataRoot(bundle).has_value());
+        }
+
+        SECTION("truncated XML") {
+            const auto bundle = makeBundle(root, R"(<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+)");
+            CHECK_FALSE(macOsBundleDataRoot(bundle).has_value());
+        }
+
+        SECTION("not XML at all") {
+            const auto bundle = makeBundle(root, "this is not a plist");
+            CHECK_FALSE(macOsBundleDataRoot(bundle).has_value());
+        }
+    }
+
     SECTION("The key is not confused with a neighbouring one of the same value") {
         // <string> elements follow every <key>; only the one after OUR key counts.
         const auto bundle = makeBundle(root, R"(<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/qt/test_game_launcher.cpp
+++ b/tests/qt/test_game_launcher.cpp
@@ -2,6 +2,8 @@
 
 #include "state/GameLauncher.h"
 
+#include <QTemporaryDir>
+
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -340,10 +342,11 @@ TEST_CASE("macOsBundleDataRoot follows the bundle's own SDL base-dir type", "[ga
     // ("data") against it, so a bundle decides the game root and the launcher's working directory
     // is discarded. Reading the key rather than assuming it keeps a differently packaged build
     // working; fallout2-ce itself ships "parent".
-    const std::filesystem::path root
-        = std::filesystem::temp_directory_path() / "geck_bundle_root_test";
-    std::filesystem::remove_all(root);
-    std::filesystem::create_directories(root);
+    // QTemporaryDir, not a fixed name under the shared temp directory: Catch2 re-enters the case
+    // once per SECTION, so each gets its own tree and cannot inherit the last one's bundle.
+    QTemporaryDir tempDir;
+    REQUIRE(tempDir.isValid());
+    const std::filesystem::path root = tempDir.path().toStdString();
 
     SECTION("\"parent\" resolves to the folder holding the .app") {
         const auto bundle = makeBundle(root, plistWith("parent"));
@@ -403,6 +406,4 @@ TEST_CASE("macOsBundleDataRoot follows the bundle's own SDL base-dir type", "[ga
         REQUIRE(resolved.has_value());
         CHECK(*resolved == bundle); // "bundle", not the earlier "parent"
     }
-
-    std::filesystem::remove_all(root);
 }


### PR DESCRIPTION
## Problem

On macOS the engine `chdir`s to `SDL_GetBasePath()` at startup (`win32.cc`, `__APPLE__ && TARGET_OS_OSX`) and resolves `master_patches` — `data`, per `fallout2.cfg` — against the working directory. For a bundled build the root is therefore fixed by the bundle, and the working directory a launcher sets is discarded.

Play went on writing the map, `ddraw.ini`, `data/config/game#patch.cfg` and `mods/mods_order.txt` into the configured game directory, which for an `.app` is usually not the directory the game reads. Every write succeeded, so nothing reported a problem — the map simply never reached the running game.

This is what made "the items are not visible" so hard to pin down: the map was being written somewhere the engine never opens.

## Fix

`macOsBundleDataRoot()` resolves the root from the bundle's own `Info.plist` rather than assuming fallout2-ce's packaging:

| `SDL_FILESYSTEM_BASE_DIR_TYPE` | root |
|---|---|
| `parent` (what fallout2-ce ships) | the folder holding the `.app` |
| `bundle` | the `.app` itself |
| absent / anything else | `Contents/Resources` (SDL's default) |

`playGame` uses it when it differs from the configured directory. A path that is not a bundle, or a bundle whose plist cannot be read, resolves to `nullopt` and the configured directory stands — an unreadable plist can never silently redirect the write.

Since we now target the directory the engine uses, the launcher's working directory and the "executable sits in its own installation" warning both line up instead of firing spuriously.

The status line names the directory whenever it is not the configured one, so a map that appears not to reach the game can be traced without knowing what a bundle does to the working directory.

## Tests

Six sections in `test_game_launcher.cpp` over real `.app` fixtures: each `SDL_FILESYSTEM_BASE_DIR_TYPE` value, a missing key, a non-bundle path, a bundle with no `Info.plist`, and a plist where an earlier unrelated key has a value that would match — only the `<string>` following *our* key counts.

Verified against the installed fallout2-ce bundle's actual `Info.plist`, which resolves to the `.app`'s parent — the directory empirically proven to be the one the running game reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)